### PR TITLE
fix: cherry-pick constructor_args pickle-by-value fix from staging (cbc7d2e), bump to dev23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchmax"
-version = "0.1.2.dev22"
+version = "0.1.2.dev23"
 description = "Framework-Agnostic RL Environments for LLM Fine-Tuning"
 readme = "README.md"
 authors = [{ name = "cgft.io" }]

--- a/src/benchmax/bundle/bundler.py
+++ b/src/benchmax/bundle/bundler.py
@@ -70,9 +70,18 @@ def bundle_env(
                 f"{mod.__name__}"
             )
 
-    # --- Serialize the class ---
+    # --- Serialize the class AND constructor_args while modules are registered ---
+    pickled_constructor_args: bytes | None = None
     try:
         pickled_class = cloudpickle.dumps(env_class)
+        # Pickle constructor_args now (while local_modules are registered)
+        # so non-JSON-serializable objects get pickled by value.
+        if constructor_args is not None:
+            try:
+                import json
+                json.dumps(constructor_args)
+            except TypeError:
+                pickled_constructor_args = cloudpickle.dumps(constructor_args)
     except Exception as e:
         raise BundlingError(
             f"Failed to serialize {env_class.__name__} with cloudpickle: {e}"
@@ -99,8 +108,13 @@ def bundle_env(
         python_version=python_version,
         benchmax_version=benchmax_version,
         constructor_args=constructor_args,
+        constructor_args_pickled=pickled_constructor_args is not None,
     )
-    payload = BundledEnv(pickled_class=pickled_class, metadata=metadata)
+    payload = BundledEnv(
+        pickled_class=pickled_class,
+        metadata=metadata,
+        pickled_constructor_args=pickled_constructor_args,
+    )
 
     size_kb = len(pickled_class) / 1024
     logger.info(
@@ -136,12 +150,11 @@ def write_bundle_files(
     pickle_path.write_bytes(bundle.pickled_class)
     metadata_path.write_bytes(bundle.metadata.to_json_bytes())
 
-    # Write pickled constructor_args alongside the class pickle
-    # when they contain non-JSON-serializable objects (e.g. SearchClient).
-    pickled_args = bundle.metadata.pickled_constructor_args_bytes()
-    if pickled_args is not None:
+    # Write pre-pickled constructor_args (pickled during bundling while
+    # local_modules were registered, so module code is inline).
+    if bundle.pickled_constructor_args is not None:
         args_path = pickle_path.with_suffix(".args.pkl")
-        args_path.write_bytes(pickled_args)
+        args_path.write_bytes(bundle.pickled_constructor_args)
         logger.info("[bundling] Wrote pickled constructor_args to %s", args_path)
 
 

--- a/src/benchmax/bundle/payload.py
+++ b/src/benchmax/bundle/payload.py
@@ -75,3 +75,4 @@ class BundledEnv:
 
     pickled_class: bytes
     metadata: BundleMetadata
+    pickled_constructor_args: Optional[bytes] = None

--- a/src/benchmax/bundle/validator.py
+++ b/src/benchmax/bundle/validator.py
@@ -35,7 +35,8 @@ def validate_bundle(
     if constructor_args is None:
         constructor_args = bundle.metadata.constructor_args
     return _run_isolated_validation(
-        bundle.pickled_class, bundle.metadata, constructor_args
+        bundle.pickled_class, bundle.metadata, constructor_args,
+        pickled_constructor_args=bundle.pickled_constructor_args,
     )
 
 
@@ -110,6 +111,7 @@ def _run_isolated_validation(
     pickled_class: bytes,
     metadata: BundleMetadata,
     constructor_args: Optional[Dict[str, Any]],
+    pickled_constructor_args: Optional[bytes] = None,
 ) -> List[str]:
     """Create a temp venv, install deps, unpickle the bundle, and smoke test.
 
@@ -192,18 +194,30 @@ def _run_isolated_validation(
         with open(pickle_path, "wb") as f:
             f.write(pickled_class)
 
-        # 5. Write and run smoke test script using cloudpickle directly
-        constructor_args_json = json.dumps(constructor_args) if constructor_args else "null"
+        # 5. Write constructor args as pickle (handles non-JSON-serializable objects)
+        args_pickle_path = os.path.join(venv_dir, "constructor_args.pkl")
+        if pickled_constructor_args is not None:
+            # Use pre-pickled args (pickled during bundling with modules registered)
+            with open(args_pickle_path, "wb") as f:
+                f.write(pickled_constructor_args)
+        elif constructor_args is not None:
+            import cloudpickle as _cp
+            with open(args_pickle_path, "wb") as f:
+                _cp.dump(constructor_args, f)
+
+        # 6. Write and run smoke test script using cloudpickle directly
         smoke_script = textwrap.dedent(f"""\
-            import json
+            import os
             import asyncio
             import cloudpickle
 
             with open({pickle_path!r}, "rb") as f:
                 env_class = cloudpickle.load(f)
 
-            constructor_args = json.loads({constructor_args_json!r})
-            if constructor_args is not None:
+            args_path = {args_pickle_path!r}
+            if os.path.exists(args_path):
+                with open(args_path, "rb") as f:
+                    constructor_args = cloudpickle.load(f)
                 instance = env_class(**constructor_args)
                 tools = asyncio.run(instance.list_tools())
                 asyncio.run(instance.shutdown())

--- a/uv.lock
+++ b/uv.lock
@@ -319,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "benchmax"
-version = "0.1.2.dev20"
+version = "0.1.2.dev21"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Cherry-picks `cbc7d2e` ("consolidate two pickling stages for simplicity and consistency") from `origin/staging` onto `main`, where it was dropped during an earlier cherry-pick. Bumps version to `0.1.2.dev23`.

**Context:** `cbc7d2e` was committed on March 30 as the follow-up to Angel's `35d0be5` ("fix arg bundling to handle non-picklable objects"). It lives on `origin/staging`. Later, `b6f4940` ("version 22. added tracking context to compute group rewards") was cherry-picked from staging to main as `8e047b6` — but `cbc7d2e` was not brought along. Result: PyPI's `benchmax==0.1.2.dev22` is missing the fix.

## The bug it fixes

`bundle_env()` registers `local_modules` (e.g. `cgft`) for `cloudpickle.register_pickle_by_value` inside a `try/finally` that currently only wraps `cloudpickle.dumps(env_class)`. `constructor_args` — which can contain non-JSON-serializable objects like `SearchClient` instances — gets pickled later via `BundleMetadata.pickled_constructor_args_bytes()` **outside** the register context. So `cgft.corpus.turbopuffer.search.TpufSearch(...)` in `env_args` pickles by-reference (224 bytes, just a module path) instead of inlining cgft source.

On the rollout-server worker (which doesn't have cgft pip-installed), `cloudpickle.loads(args.pkl)` throws `ModuleNotFoundError: No module named 'cgft'` before the class pickle has a chance to re-register cgft in `sys.modules`.

Any `train(env_args={"search": TpufSearch(...)}, local_modules=[cgft], validate_env_remotely=True)` fails remote validation on dev22. This was reproduced end-to-end across three backends (Turbopuffer, ChromaCloud, CGFT Corpora) against `autobots.cgft.io`.

## The fix (identical to cbc7d2e)

Moves `cloudpickle.dumps(constructor_args)` INTO the same `try/finally` as `cloudpickle.dumps(env_class)`, so both benefit from `register_pickle_by_value(cgft)`. Bytes are stored on `BundledEnv.pickled_constructor_args` (new field) and written to `.args.pkl` by `write_bundle_files`. The validator is updated in lockstep.

## Verified

Installed this exact branch into a cgft worktree via `uv pip install --force-reinstall --no-deps 'benchmax @ git+<repo>@cbc7d2e'`, re-ran a notebook-pattern `train(validate_env_remotely=True)`:

- Turbopuffer (`koblex-english-legal` namespace) — **Remote validation passed** (33.1s)
- CGFT Corpora BM25 (`posthog`) — **Remote validation passed** (46.5s)
- ChromaCloud — class pickle now loads; a separate lazy-import issue in `ChromaSearch._get_client` is unrelated to this PR.

## Test plan

- [ ] CI (no new tests added here — this is a clean cherry-pick)
- [ ] Verify `benchmax-0.1.2.dev23-py3-none-any.whl` publishes cleanly
- [ ] Bump `benchmax>=0.1.2.dev23` in `cgft/pyproject.toml` (separate PR)
- [ ] Bump `benchmax==0.1.2.dev23` in `k8-deployment/rollout-server/pyproject.toml` and rebuild the rollout-server image (separate PR)

## Diff

Same 5 files as `cbc7d2e`:
```
pyproject.toml                   |  2 +-
src/benchmax/bundle/bundler.py   | 27 ++++++++++++++++++++-------
src/benchmax/bundle/payload.py   |  1 +
src/benchmax/bundle/validator.py | 26 ++++++++++++++++++++------
uv.lock                          |  2 +-
```