### PR TITLE
rename: seed_messages → prompt_messages; bump canonical hash to v:2

### DIFF
--- a/examples/guess/launch_guess.py
+++ b/examples/guess/launch_guess.py
@@ -66,7 +66,7 @@ class GuessEnv(BaseEnv):
     @classmethod
     def dataset_preprocess(cls, example: Any, **kwargs: Any) -> Example:
         return make_example(
-            seed_messages=[
+            prompt_messages=[
                 {"role": "user", "content": "Are you ready to play a guessing game?"},
                 {
                     "role": "assistant",

--- a/examples/telestitch/telestich.py
+++ b/examples/telestitch/telestich.py
@@ -1142,7 +1142,7 @@ User: 写一首关于思念的藏尾诗，尾字拼出"月光"
     def dataset_preprocess(cls, example: Any, **kwargs) -> Example:
         prompt_text = example.get("prompt", "")
         return make_example(
-            seed_messages=[{"role": "user", "content": prompt_text}],
+            prompt_messages=[{"role": "user", "content": prompt_text}],
             task={
                 "prompt": prompt_text,
                 "ground_truth": example.get("ground_truth", ""),

--- a/src/benchmax/envs/base_env.py
+++ b/src/benchmax/envs/base_env.py
@@ -40,10 +40,10 @@ class BaseEnv(ABC):
     def dataset_preprocess(cls, row: Any, **kwargs) -> Example:
         """Turn a dataset row into an :class:`Example`.
 
-        ``seed_messages`` is built from the first column that's present:
+        ``prompt_messages`` is built from the first column that's present:
 
-        - ``seed_messages``: already a chat list — used as-is.
-        - ``messages``: chat list — used as ``seed_messages``.
+        - ``prompt_messages``: already a chat list — used as-is.
+        - ``messages``: chat list — used as ``prompt_messages``.
         - ``prompt``: single string — wrapped as one user message.
 
         ``task`` is the entire row as a dict, so any column
@@ -54,23 +54,23 @@ class BaseEnv(ABC):
         Override this for datasets with other column names or to project
         ``task`` down to a subset of fields.
         """
-        if "seed_messages" in row:
-            seed_messages = row["seed_messages"]
+        if "prompt_messages" in row:
+            prompt_messages = row["prompt_messages"]
         elif "messages" in row:
-            seed_messages = row["messages"]
+            prompt_messages = row["messages"]
         elif "prompt" in row:
-            seed_messages = [{"role": "user", "content": row["prompt"]}]
+            prompt_messages = [{"role": "user", "content": row["prompt"]}]
         else:
             raise ValueError(
                 f"{cls.__name__}.dataset_preprocess: row has none of "
-                "'seed_messages', 'messages', 'prompt'. Override "
-                "dataset_preprocess to build seed_messages from your "
+                "'prompt_messages', 'messages', 'prompt'. Override "
+                "dataset_preprocess to build prompt_messages from your "
                 "dataset's columns."
             )
         task = dict(row)
         return Example(
-            id=canonical_example_id(seed_messages, task),
-            seed_messages=seed_messages,
+            id=canonical_example_id(prompt_messages, task),
+            prompt_messages=prompt_messages,
             task=task,
             init_rollout_args=row.get("init_rollout_args"),
         )

--- a/src/benchmax/envs/crm/crm_env.py
+++ b/src/benchmax/envs/crm/crm_env.py
@@ -62,7 +62,7 @@ class CRMEnv(ParallelMcpEnv):
             prompt = f"{persona}\n{instruction}\n{required_metadata}\n{query}"
 
         return make_example(
-            seed_messages=[{"role": "user", "content": prompt}],
+            prompt_messages=[{"role": "user", "content": prompt}],
             task={"ground_truth": answer, "reward_metric": reward_metric},
             system_prompt=cls.system_prompt,
         )

--- a/src/benchmax/envs/example_id.py
+++ b/src/benchmax/envs/example_id.py
@@ -1,6 +1,6 @@
 """Canonical example identity.
 
-``canonical_example_id(seed_messages, task)`` returns a SHA-256 hex digest
+``canonical_example_id(prompt_messages, task)`` returns a SHA-256 hex digest
 that is stable across processes and languages: a TypeScript port lives in
 ``platform-service/src/lib/canonical-example-id.ts`` and is exercised by a
 parity test.
@@ -15,8 +15,9 @@ Determinism is achieved by:
 - emitting canonical JSON with sorted keys, no whitespace, and no ASCII
   escaping (modern JSON.stringify also preserves non-ASCII).
 
-The hash is computed over ``{"v": 1, "seed_messages": ..., "task": ...}`` —
-the version tag lets us bump the algorithm later without ambiguity.
+The hash is computed over ``{"v": 2, "prompt_messages": ..., "task": ...}``.
+v:2 bump went together with the ``seed_messages`` → ``prompt_messages``
+field rename in 2026-05; v:1 hashes are obsolete.
 """
 from __future__ import annotations
 
@@ -86,10 +87,10 @@ def _normalize(v: Any) -> Any:
 
 
 def canonical_example_id(
-    seed_messages: Messages,
+    prompt_messages: Messages,
     task: dict[str, Any] | None,
 ) -> str:
-    payload = {"v": 1, "seed_messages": seed_messages, "task": task}
+    payload = {"v": 2, "prompt_messages": prompt_messages, "task": task}
     serialized = json.dumps(
         _normalize(payload),
         sort_keys=True,
@@ -100,14 +101,14 @@ def canonical_example_id(
 
 
 def make_example(
-    seed_messages: Messages,
+    prompt_messages: Messages,
     task: dict[str, Any] | None = None,
     init_rollout_args: dict[str, Any] | None = None,
     system_prompt: str | None = None,
 ) -> Example:
     """Build an :class:`Example` with the canonical id pre-computed.
 
-    If ``system_prompt`` is non-empty, it is prepended to ``seed_messages``
+    If ``system_prompt`` is non-empty, it is prepended to ``prompt_messages``
     as ``{"role": "system", "content": system_prompt}`` so the env's system
     prompt is part of the example's identity. Two envs with the same user
     prompt but different system prompts (e.g. "be concise" vs "be verbose")
@@ -120,7 +121,7 @@ def make_example(
     requires an async ``list_tools()`` call, which doesn't fit
     ``dataset_preprocess``'s classmethod contract. The trainer renders
     tools into the first system message at LLM-call time without mutating
-    ``seed_messages``. Envs that need tool-set sensitivity in their group
+    ``prompt_messages``. Envs that need tool-set sensitivity in their group
     identity should bake a tool-signature string into ``task``.
 
     Convenience for env authors overriding ``dataset_preprocess``::
@@ -128,19 +129,19 @@ def make_example(
         @classmethod
         def dataset_preprocess(cls, row, **_):
             return make_example(
-                seed_messages=[{"role": "user", "content": row["question"]}],
+                prompt_messages=[{"role": "user", "content": row["question"]}],
                 task={"answer": row["answer"]},
                 system_prompt=cls.system_prompt,
             )
     """
     if system_prompt:
-        seed_messages = [
+        prompt_messages = [
             {"role": "system", "content": system_prompt},
-            *seed_messages,
+            *prompt_messages,
         ]
     return Example(
-        id=canonical_example_id(seed_messages, task),
-        seed_messages=seed_messages,
+        id=canonical_example_id(prompt_messages, task),
+        prompt_messages=prompt_messages,
         task=task,
         init_rollout_args=init_rollout_args,
     )

--- a/src/benchmax/envs/excel/excel_env.py
+++ b/src/benchmax/envs/excel/excel_env.py
@@ -132,7 +132,7 @@ Answer Position: {answer_position}
 Output Path: {output_filename}"""
 
         return make_example(
-            seed_messages=[{"role": "user", "content": prompt.strip()}],
+            prompt_messages=[{"role": "user", "content": prompt.strip()}],
             task={
                 "dataset_row_id": row_id,
                 "answer_position": answer_position,

--- a/src/benchmax/envs/math/math_env.py
+++ b/src/benchmax/envs/math/math_env.py
@@ -27,7 +27,7 @@ class MathEnv(ParallelMcpEnv):
     @classmethod
     def dataset_preprocess(cls, example: Any, **kwargs) -> Example:
         return make_example(
-            seed_messages=[{"role": "user", "content": example.get("task", "")}],
+            prompt_messages=[{"role": "user", "content": example.get("task", "")}],
             task={"ground_truth": example.get("answer", "")},
             system_prompt=cls.system_prompt,
         )

--- a/src/benchmax/envs/postgres_search/linker_env.py
+++ b/src/benchmax/envs/postgres_search/linker_env.py
@@ -169,7 +169,7 @@ class LinkerEnv(BaseEnv):
             f"Primary chunk:\n{example.get('prompt', '')}"
         )
         return make_example(
-            seed_messages=[{"role": "user", "content": prompt}],
+            prompt_messages=[{"role": "user", "content": prompt}],
             task={"target_n": target_n, "reasoning_mode": reasoning_mode},
             system_prompt=cls.system_prompt,
         )

--- a/src/benchmax/envs/postgres_search/search_env.py
+++ b/src/benchmax/envs/postgres_search/search_env.py
@@ -213,7 +213,7 @@ class SearchEnv(BaseEnv):
     def dataset_preprocess(cls, example: Any, **kwargs) -> Example:
         question = example.get("question", "")
         return make_example(
-            seed_messages=[{"role": "user", "content": question}],
+            prompt_messages=[{"role": "user", "content": question}],
             task={
                 "question": question,
                 "ground_truth": example.get("answer"),

--- a/src/benchmax/envs/types.py
+++ b/src/benchmax/envs/types.py
@@ -7,11 +7,11 @@ Messages = List[Dict[str, Any]]
 class Example(TypedDict):
     """A dataset example after preprocessing.
 
-    ``id`` is a SHA-256 hash over ``(seed_messages, task)`` computed by
+    ``id`` is a SHA-256 hash over ``(prompt_messages, task)`` computed by
     :func:`benchmax.envs.example_id.canonical_example_id`. Equal seeds + tasks
     across calls (and across Python/TypeScript) produce equal ids.
 
-    ``seed_messages`` is the full prompt as a chat-message list. Includes the
+    ``prompt_messages`` is the full prompt as a chat-message list. Includes the
     system message if the env has one (rendered with tool definitions when
     tools are present).
 
@@ -25,7 +25,7 @@ class Example(TypedDict):
     """
 
     id: str
-    seed_messages: Messages
+    prompt_messages: Messages
     task: NotRequired[Optional[Dict[str, Any]]]
     init_rollout_args: NotRequired[Optional[Dict[str, Any]]]
 

--- a/src/benchmax/envs/wikipedia/wiki_env.py
+++ b/src/benchmax/envs/wikipedia/wiki_env.py
@@ -218,7 +218,7 @@ class WikipediaEnv(BaseEnv):
     @classmethod
     def dataset_preprocess(cls, example: Any, **kwargs) -> Example:
         return make_example(
-            seed_messages=[{"role": "user", "content": example.get("Question", "")}],
+            prompt_messages=[{"role": "user", "content": example.get("Question", "")}],
             task={"ground_truth": example.get("Answer")},
             system_prompt=cls.system_prompt,
         )

--- a/src/benchmax/platform/validation.py
+++ b/src/benchmax/platform/validation.py
@@ -111,7 +111,7 @@ def validate_env(
     preprocessed = None
     try:
         preprocessed = env_class.dataset_preprocess(examples[0])
-        required = {"id", "seed_messages"}
+        required = {"id", "prompt_messages"}
         if not isinstance(preprocessed, dict) or not required.issubset(preprocessed):
             missing = (
                 required - set(preprocessed)
@@ -124,32 +124,32 @@ def validate_env(
             )
             print(
                 "    Fix: return benchmax.envs.example_id.make_example("
-                "seed_messages=[...], task=...)."
+                "prompt_messages=[...], task=...)."
             )
             failed += 1
         else:
-            print("  \u2713 dataset_preprocess returns Example with id + seed_messages")
+            print("  \u2713 dataset_preprocess returns Example with id + prompt_messages")
             passed += 1
     except Exception as exc:
         print(f"  \u2717 dataset_preprocess raised {type(exc).__name__}: {exc}")
         failed += 1
 
-    # ── 2. seed_messages shape ───────────────────────────────────
-    if preprocessed and isinstance(preprocessed, dict) and "seed_messages" in preprocessed:
-        seed = preprocessed["seed_messages"]
+    # ── 2. prompt_messages shape ───────────────────────────────────
+    if preprocessed and isinstance(preprocessed, dict) and "prompt_messages" in preprocessed:
+        seed = preprocessed["prompt_messages"]
         if not isinstance(seed, list) or not all(
             isinstance(mm, dict) and "role" in mm and "content" in mm for mm in seed
         ):
-            print("  \u2717 seed_messages is not a list of {role,content} dicts")
+            print("  \u2717 prompt_messages is not a list of {role,content} dicts")
             failed += 1
         elif not seed:
-            print("  \u2717 seed_messages is empty")
+            print("  \u2717 prompt_messages is empty")
             failed += 1
         else:
-            print(f"  \u2713 seed_messages is a {len(seed)}-message chat list")
+            print(f"  \u2713 prompt_messages is a {len(seed)}-message chat list")
             passed += 1
     else:
-        print("  - seed_messages shape check: skipped (no preprocessed result)")
+        print("  - prompt_messages shape check: skipped (no preprocessed result)")
 
     # ── 3. load_dataset ──────────────────────────────────────────
     try:
@@ -227,7 +227,7 @@ def validate_env(
             failed += 1
 
     # ── 5. compute_reward with trainer-style args ────────────────
-    if env is not None and isinstance(preprocessed, dict) and "seed_messages" in preprocessed:
+    if env is not None and isinstance(preprocessed, dict) and "prompt_messages" in preprocessed:
         try:
             task = preprocessed.get("task")
             init_args = preprocessed.get("init_rollout_args") or {}
@@ -235,7 +235,7 @@ def validate_env(
             # Simulate the trainer's call: a fake one-turn transcript echoing
             # the seed plus a stub assistant turn. compute_reward receives
             # task verbatim and runtime kwargs (init_rollout_args fields).
-            messages = list(preprocessed["seed_messages"]) + [
+            messages = list(preprocessed["prompt_messages"]) + [
                 {"role": "assistant", "content": "I found the answer based on the search results."}
             ]
 
@@ -282,9 +282,9 @@ def validate_env(
             failed += 1
 
     # ── 5b. Simulated rollout (E2E) ──────────────────────────────
-    if env is not None and isinstance(preprocessed, dict) and "seed_messages" in preprocessed:
+    if env is not None and isinstance(preprocessed, dict) and "prompt_messages" in preprocessed:
         try:
-            seed_messages = preprocessed["seed_messages"]
+            prompt_messages = preprocessed["prompt_messages"]
             task = preprocessed.get("task")
             init_args = preprocessed.get("init_rollout_args") or {}
 
@@ -292,13 +292,13 @@ def validate_env(
 
             # Seed text used for dummy tool-arg generation.
             first_user = next(
-                (m["content"] for m in seed_messages if m.get("role") == "user"),
+                (m["content"] for m in prompt_messages if m.get("role") == "user"),
                 "",
             )
             query_text = first_user[:200] if isinstance(first_user, str) else "test"
 
             # ── Call each tool twice (catch stateful bugs) ──────
-            transcript: list[dict[str, Any]] = list(seed_messages)
+            transcript: list[dict[str, Any]] = list(prompt_messages)
             tool_call_count = 0
             for tool in tools:
                 tool_args = _build_dummy_args(tool.input_schema, query_text)

--- a/tests/unit/envs/excel/test_excel_env.py
+++ b/tests/unit/envs/excel/test_excel_env.py
@@ -86,9 +86,9 @@ class TestDatasetPreprocess:
         ):
             result = ExcelEnv.dataset_preprocess(example, dataset_path=mock_dataset)
 
-        # Result is an Example TypedDict: id, seed_messages, task, init_rollout_args.
+        # Result is an Example TypedDict: id, prompt_messages, task, init_rollout_args.
         assert result is not None
-        prompt_blob = "\n".join(m["content"] for m in result["seed_messages"])
+        prompt_blob = "\n".join(m["content"] for m in result["prompt_messages"])
         assert "Fill cell A1 with 10" in prompt_blob
         assert "1_42_input.xlsx" in prompt_blob
         assert result["init_rollout_args"] is not None

--- a/tests/unit/envs/math/test_math_env.py
+++ b/tests/unit/envs/math/test_math_env.py
@@ -46,7 +46,7 @@ class TestDatasetPreprocess:
     """Test dataset preprocessing logic."""
 
     def _user_msg(self, ex):
-        for m in ex["seed_messages"]:
+        for m in ex["prompt_messages"]:
             if m["role"] == "user":
                 return m["content"]
         return ""

--- a/tests/unit/envs/postgres_search/test_search_env.py
+++ b/tests/unit/envs/postgres_search/test_search_env.py
@@ -378,7 +378,7 @@ class TestDatasetPreprocess:
     def test_extracts_question_answer(self):
         result = SearchEnv.dataset_preprocess({"question": "What is X?", "answer": "Y"})
         # User message carries the question text (system msg is prepended by make_example).
-        user_msgs = [m for m in result["seed_messages"] if m["role"] == "user"]
+        user_msgs = [m for m in result["prompt_messages"] if m["role"] == "user"]
         assert user_msgs and user_msgs[0]["content"] == "What is X?"
         assert result["task"]["question"] == "What is X?"
         assert result["task"]["ground_truth"] == "Y"

--- a/tests/unit/envs/test_dataset_preprocess.py
+++ b/tests/unit/envs/test_dataset_preprocess.py
@@ -1,6 +1,6 @@
 """Tests for ``BaseEnv.dataset_preprocess``.
 
-The default builds ``seed_messages`` from whichever of ``seed_messages`` /
+The default builds ``prompt_messages`` from whichever of ``prompt_messages`` /
 ``messages`` / ``prompt`` is present in the row, and dumps the whole row
 into ``task`` so ``compute_reward`` can read any column. Envs whose source
 datasets use other column names override.
@@ -35,7 +35,7 @@ class _NoopEnv(BaseEnv):
 
 def test_dataset_preprocess_does_not_mutate_input():
     row = {
-        "seed_messages": [{"role": "user", "content": "hello"}],
+        "prompt_messages": [{"role": "user", "content": "hello"}],
         "ground_truth": "world",
         "init_rollout_args": {"seed": 1},
     }
@@ -48,14 +48,14 @@ def test_dataset_preprocess_does_not_mutate_input():
         assert row[k] == snapshot[k]
 
 
-def test_dataset_preprocess_seed_messages_column():
+def test_dataset_preprocess_prompt_messages_column():
     row = {
-        "seed_messages": [{"role": "user", "content": "q"}],
+        "prompt_messages": [{"role": "user", "content": "q"}],
         "ground_truth": "a",
     }
     ex = _NoopEnv.dataset_preprocess(row)
     assert isinstance(ex["id"], str) and len(ex["id"]) == 64
-    assert ex["seed_messages"] == row["seed_messages"]
+    assert ex["prompt_messages"] == row["prompt_messages"]
     # task carries the whole row, so compute_reward can read any column.
     assert ex["task"] == row
 
@@ -66,38 +66,38 @@ def test_dataset_preprocess_messages_column_used_as_seed():
         "ground_truth": "a",
     }
     ex = _NoopEnv.dataset_preprocess(row)
-    assert ex["seed_messages"] == row["messages"]
+    assert ex["prompt_messages"] == row["messages"]
     assert ex["task"] == row
 
 
 def test_dataset_preprocess_prompt_column_wrapped_as_user_message():
     row = {"prompt": "hello", "ground_truth": "world"}
     ex = _NoopEnv.dataset_preprocess(row)
-    assert ex["seed_messages"] == [{"role": "user", "content": "hello"}]
+    assert ex["prompt_messages"] == [{"role": "user", "content": "hello"}]
     assert ex["task"] == row
 
 
 def test_dataset_preprocess_priority_seed_over_messages_over_prompt():
-    """When multiple seed columns are present, ``seed_messages`` wins, then
+    """When multiple seed columns are present, ``prompt_messages`` wins, then
     ``messages``, then ``prompt`` — order matters because some upstream
     datasets carry redundant copies of the prompt."""
     row = {
-        "seed_messages": [{"role": "user", "content": "from_seed"}],
+        "prompt_messages": [{"role": "user", "content": "from_seed"}],
         "messages": [{"role": "user", "content": "from_messages"}],
         "prompt": "from_prompt",
     }
     ex = _NoopEnv.dataset_preprocess(row)
-    assert ex["seed_messages"][0]["content"] == "from_seed"
+    assert ex["prompt_messages"][0]["content"] == "from_seed"
 
     ex2 = _NoopEnv.dataset_preprocess(
         {"messages": [{"role": "user", "content": "from_messages"}], "prompt": "from_prompt"}
     )
-    assert ex2["seed_messages"][0]["content"] == "from_messages"
+    assert ex2["prompt_messages"][0]["content"] == "from_messages"
 
 
 def test_dataset_preprocess_pulls_init_rollout_args():
     row = {
-        "seed_messages": [{"role": "user", "content": "q"}],
+        "prompt_messages": [{"role": "user", "content": "q"}],
         "init_rollout_args": {"seed": 7},
     }
     ex = _NoopEnv.dataset_preprocess(row)
@@ -106,7 +106,7 @@ def test_dataset_preprocess_pulls_init_rollout_args():
 
 def test_dataset_preprocess_idempotent():
     row = {
-        "seed_messages": [{"role": "user", "content": "q"}],
+        "prompt_messages": [{"role": "user", "content": "q"}],
         "ground_truth": "a",
     }
     a = _NoopEnv.dataset_preprocess(row)
@@ -116,18 +116,18 @@ def test_dataset_preprocess_idempotent():
 
 def test_dataset_preprocess_id_groups_equal_examples():
     a = _NoopEnv.dataset_preprocess(
-        {"seed_messages": [{"role": "user", "content": "q"}], "gt": "x"}
+        {"prompt_messages": [{"role": "user", "content": "q"}], "gt": "x"}
     )
     b = _NoopEnv.dataset_preprocess(
-        {"seed_messages": [{"role": "user", "content": "q"}], "gt": "x"}
+        {"prompt_messages": [{"role": "user", "content": "q"}], "gt": "x"}
     )
     c = _NoopEnv.dataset_preprocess(
-        {"seed_messages": [{"role": "user", "content": "q"}], "gt": "y"}
+        {"prompt_messages": [{"role": "user", "content": "q"}], "gt": "y"}
     )
     assert a["id"] == b["id"]
     assert a["id"] != c["id"]
 
 
 def test_dataset_preprocess_requires_recognized_seed_column():
-    with pytest.raises(ValueError, match="seed_messages"):
+    with pytest.raises(ValueError, match="prompt_messages"):
         _NoopEnv.dataset_preprocess({"ground_truth": "x"})

--- a/tests/unit/envs/test_example_id.py
+++ b/tests/unit/envs/test_example_id.py
@@ -16,13 +16,13 @@ import pytest
 from benchmax.envs.example_id import canonical_example_id
 
 
-# Each case: (name, seed_messages, task, expected_hex)
+# Each case: (name, prompt_messages, task, expected_hex)
 GOLDEN_CASES = [
     (
         "bare_single_user",
         [{"role": "user", "content": "Hello"}],
         None,
-        "0bbb7577dbc0523b59e954d128ef3b112645477ae2d9081b0007189090421b8f",
+        "04d553add09f1f28f35139014176fe64cf3cbbecb0de22e99370c49b3e35088b",
     ),
     (
         "multi_turn",
@@ -33,25 +33,25 @@ GOLDEN_CASES = [
             {"role": "user", "content": "Solve 2+2"},
         ],
         {"ground_truth": "4"},
-        "9bd75cd9d5e39c53f02763adc43062bd80542f5c0b6b851d317f5a59dacefe05",
+        "dcf4e5fcce040c41d527b27c3c6e9c4f1df0745c7f48c3f11b0e21a4500ea5fa",
     ),
     (
         "task_none",
         [{"role": "user", "content": "x"}],
         None,
-        "8b39309c8f43c56551281509f9e8f76973f64f94ef98afd7826a9f6eb161a8ca",
+        "e4d534ac3d401153ec029cd68bae30cdcbe03314cc69296ffc48ce4458dddff8",
     ),
     (
         "task_empty_dict",
         [{"role": "user", "content": "x"}],
         {},
-        "839198565d0c3acd3151efc10c9e65a2dac911b06f8eb199f2e107b567c23e14",
+        "5d6763943667224756336ff9ffc2eff2e9267ac8a815745db54a75373073134a",
     ),
     (
         "unicode",
         [{"role": "user", "content": "你好 émoji 🚀"}],
         {"locale": "zh-CN"},
-        "a50f4c4ad3fd5c6838098fe4b09e6b9a24a875a4c9c4ee717d304a53ebe31873",
+        "d1f6a202e088221a60711f105c02e8cfce9da69c14ef479efcbf7416d63280b9",
     ),
     (
         "nested_task",
@@ -62,14 +62,14 @@ GOLDEN_CASES = [
             "max_steps": 5,
             "scoring": {"weights": {"correctness": 1, "format": 0}},
         },
-        "c1d79889b683b3d5129d07a7b68bce827fbcae50437f164e76769667145b5b1f",
+        "cee4165ba98d0c7b7ac8b12ce2587bdad88e38ef63d2235a071423fb3968915d",
     ),
 ]
 
 
-@pytest.mark.parametrize("name,seed_messages,task,expected", GOLDEN_CASES)
-def test_golden_hash(name: str, seed_messages, task, expected: str) -> None:
-    assert canonical_example_id(seed_messages, task) == expected
+@pytest.mark.parametrize("name,prompt_messages,task,expected", GOLDEN_CASES)
+def test_golden_hash(name: str, prompt_messages, task, expected: str) -> None:
+    assert canonical_example_id(prompt_messages, task) == expected
 
 
 def test_none_task_differs_from_empty_task() -> None:

--- a/tests/unit/envs/test_guess_env_wordle_discrimination.py
+++ b/tests/unit/envs/test_guess_env_wordle_discrimination.py
@@ -4,7 +4,7 @@ The Example-as-first-class redesign exists primarily to fix one pathology:
 envs where every row shares a generic seed prompt template ("guess my
 number", "solve the wordle puzzle") but differs in the per-row ground
 truth would, under the old prompt_text-hash grouping, collapse into a
-single group. The new ``canonical_example_id(seed_messages, task)`` hash
+single group. The new ``canonical_example_id(prompt_messages, task)`` hash
 includes ``task``, so identical seeds with distinct tasks correctly land
 in distinct groups.
 
@@ -51,7 +51,7 @@ class GuessEnv(BaseEnv):
     def dataset_preprocess(cls, example: Any, **kwargs) -> Example:
         # Constant seed across all rows — the wordle pathology.
         return make_example(
-            seed_messages=[
+            prompt_messages=[
                 {"role": "user", "content": "I have a number in mind. What is it?"},
             ],
             task={"target": int(example["target"])},
@@ -95,18 +95,18 @@ def test_distinct_targets_produce_distinct_example_ids():
     # All three ids must differ from each other (3 distinct rows).
     assert len(set(ids)) == 3, f"expected 3 distinct ids, got {ids}"
 
-    # And the seed_messages must in fact be identical across rows —
+    # And the prompt_messages must in fact be identical across rows —
     # that's what makes this a useful test (the property would be trivial
-    # if rows varied in seed_messages too).
-    seed_strings = {tuple((m["role"], m["content"]) for m in ex["seed_messages"]) for ex in examples}
-    assert len(seed_strings) == 1, "seed_messages should be identical across rows"
+    # if rows varied in prompt_messages too).
+    seed_strings = {tuple((m["role"], m["content"]) for m in ex["prompt_messages"]) for ex in examples}
+    assert len(seed_strings) == 1, "prompt_messages should be identical across rows"
 
 
-def test_seed_messages_includes_system_prompt():
-    """make_example bakes the env's static system_prompt into seed_messages
+def test_prompt_messages_includes_system_prompt():
+    """make_example bakes the env's static system_prompt into prompt_messages
     at index 0, so the system prompt is part of the example's identity."""
     ex = GuessEnv.dataset_preprocess({"target": 1})
-    seed = ex["seed_messages"]
+    seed = ex["prompt_messages"]
     assert len(seed) == 2, f"expected [system, user], got {len(seed)} messages"
     assert seed[0] == {"role": "system", "content": SYSTEM_PROMPT}
     assert seed[1]["role"] == "user"
@@ -115,7 +115,7 @@ def test_seed_messages_includes_system_prompt():
 def test_distinct_system_prompts_produce_distinct_example_ids():
     """Same dataset row + different env system prompts → different ids.
 
-    This is the property that would have been broken if seed_messages had
+    This is the property that would have been broken if prompt_messages had
     stayed user-only: two envs with the same dataset rows but different
     system instructions would have collapsed into the same example_id.
     """
@@ -143,10 +143,10 @@ def test_same_target_produces_same_example_id():
 def test_example_id_matches_direct_canonical_hash():
     """The id baked into Example.id matches the hash an external caller
     (e.g. external-eval webhook, or the TS port) would compute from the
-    same (seed_messages, task) pair."""
+    same (prompt_messages, task) pair."""
     row = {"target": 17}
     ex = GuessEnv.dataset_preprocess(row)
-    expected = canonical_example_id(ex["seed_messages"], ex["task"])
+    expected = canonical_example_id(ex["prompt_messages"], ex["task"])
     assert ex["id"] == expected
 
 

--- a/tests/unit/envs/wikipedia/test_wiki_env.py
+++ b/tests/unit/envs/wikipedia/test_wiki_env.py
@@ -30,7 +30,7 @@ class TestDatasetPreprocess:
         result = wiki_env.dataset_preprocess(example)
 
         # Find the user seed message (preprocess injects the system prompt first).
-        user_msg = next(m for m in result["seed_messages"] if m["role"] == "user")
+        user_msg = next(m for m in result["prompt_messages"] if m["role"] == "user")
         assert user_msg["content"] == "Who created Python?"
         assert result["task"] == {"ground_truth": "Guido van Rossum"}
 


### PR DESCRIPTION
The kwarg / attribute / dataset-column convention rename across the env APIs. Paired with a payload version bump in canonical_example_id (v:1 → v:2) so existing example_ids cleanly invalidate — the old field name lived in the hash payload and the rename would have silently diverged from the v:1 wire shape otherwise.

19 files touched, +96/-95. Golden hashes in test_example_id.py regenerated for v:2. TS parity test in platform-service/src/lib/__tests__ already carries the matching v:2 hashes.