### PR TITLE
SearchEnv prompt extensibility + playground_preprocess + rubric api_key/ground_truth forwarding

### DIFF
--- a/src/benchmax/envs/base_env.py
+++ b/src/benchmax/envs/base_env.py
@@ -53,6 +53,22 @@ class BaseEnv(ABC):
 
         Override this for datasets with other column names or to project
         ``task`` down to a subset of fields.
+
+        Classmethod vs. instance method
+            The default is a classmethod so envs with a static
+            ``system_prompt`` (set as a class attribute) can preprocess
+            without paying the cost of constructing an env instance. The
+            trainer detects which form a subclass overrode with and
+            dispatches accordingly (``utils.is_classmethod``).
+
+            If your env interpolates runtime kwargs into
+            ``self.system_prompt`` in ``__init__`` (e.g. a corpus
+            description known only at construction time), override
+            ``dataset_preprocess`` as an **instance method** instead
+            and read ``self.system_prompt`` — ``cls.system_prompt``
+            would still be the unresolved class default. See
+            :class:`benchmax.envs.postgres_search.search_env.SearchEnv`
+            for the reference pattern.
         """
         if "prompt_messages" in row:
             prompt_messages = row["prompt_messages"]

--- a/src/benchmax/envs/base_env.py
+++ b/src/benchmax/envs/base_env.py
@@ -76,26 +76,13 @@ class BaseEnv(ABC):
         )
 
     def playground_preprocess(self, prompt: str, **kwargs: Any) -> Example:
-        """Turn a one-shot playground prompt into an :class:`Example`.
+        """Wrap a one-shot playground prompt into an :class:`Example`.
 
-        The playground counterpart to ``dataset_preprocess``. Unlike
-        ``dataset_preprocess`` (which is a classmethod that runs during
-        dataset loading before any env instance exists), this is an
-        instance method so subclasses that interpolate ``self.system_prompt``
-        in ``__init__`` (e.g. :class:`SearchEnv` formatting in
-        ``corpus_description``) see the resolved value here.
-
-        The default builds ``[system?, user(prompt)]`` via :func:`make_example`,
-        which prepends ``self.system_prompt`` when non-empty. Override for
-        envs that need to wrap playground prompts differently — e.g.
-        structured user messages, env-side context preludes, or a separate
-        playground-only system prompt distinct from the training one.
-
-        ``task`` is ``None`` because playground prompts carry no ground
-        truth, references, or scoring config — the worker skips reward
-        computation for playground examples entirely. Override may set
-        ``task=...`` if the env can score playground prompts in a
-        meaningful way without operator-supplied grading data.
+        Instance method (vs classmethod :meth:`dataset_preprocess`) so
+        subclasses that interpolate ``self.system_prompt`` in ``__init__``
+        see the resolved value. Default prepends ``self.system_prompt`` via
+        :func:`make_example` with ``task=None`` — the rollout worker skips
+        reward computation for playground examples.
         """
         return make_example(
             prompt_messages=[{"role": "user", "content": prompt}],

--- a/src/benchmax/envs/base_env.py
+++ b/src/benchmax/envs/base_env.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-from benchmax.envs.example_id import canonical_example_id
+from benchmax.envs.example_id import canonical_example_id, make_example
 from benchmax.envs.types import Example, Messages, ToolDefinition
 from benchmax.prompts.tools import render_tools_prompt
 
@@ -73,6 +73,34 @@ class BaseEnv(ABC):
             prompt_messages=prompt_messages,
             task=task,
             init_rollout_args=row.get("init_rollout_args"),
+        )
+
+    def playground_preprocess(self, prompt: str, **kwargs: Any) -> Example:
+        """Turn a one-shot playground prompt into an :class:`Example`.
+
+        The playground counterpart to ``dataset_preprocess``. Unlike
+        ``dataset_preprocess`` (which is a classmethod that runs during
+        dataset loading before any env instance exists), this is an
+        instance method so subclasses that interpolate ``self.system_prompt``
+        in ``__init__`` (e.g. :class:`SearchEnv` formatting in
+        ``corpus_description``) see the resolved value here.
+
+        The default builds ``[system?, user(prompt)]`` via :func:`make_example`,
+        which prepends ``self.system_prompt`` when non-empty. Override for
+        envs that need to wrap playground prompts differently — e.g.
+        structured user messages, env-side context preludes, or a separate
+        playground-only system prompt distinct from the training one.
+
+        ``task`` is ``None`` because playground prompts carry no ground
+        truth, references, or scoring config — the worker skips reward
+        computation for playground examples entirely. Override may set
+        ``task=...`` if the env can score playground prompts in a
+        meaningful way without operator-supplied grading data.
+        """
+        return make_example(
+            prompt_messages=[{"role": "user", "content": prompt}],
+            task=None,
+            system_prompt=self.system_prompt,
         )
 
     @classmethod

--- a/src/benchmax/envs/base_env.py
+++ b/src/benchmax/envs/base_env.py
@@ -96,21 +96,11 @@ class BaseEnv(ABC):
     ) -> Tuple[
         "DatasetDict | Dataset | IterableDatasetDict | IterableDataset", str | None
     ]:
-        """
-        Download and prepare a dataset for use with this environment.
+        """Load + prepare a dataset for this env.
 
-        This method should handle retrieving the specified dataset (e.g., from HuggingFace, local files,
-        or a custom source), preprocessing or converting it into a compatible structure, and storing it
-        locally in a reusable format. The processed dataset should be suitable for downstream use with
-        `dataset_preprocess`, which standardizes individual examples into the expected format.
-
-        Args:
-            dataset_name (str): Identifier of the dataset to be loaded.
-            **kwargs: Additional dataset-specific arguments (e.g., split, filtering options, cache directory).
-
-        Returns:
-            Dataset: A dataset object (e.g., HuggingFace Dataset or similar) ready for processing.
-            str: Optional string pointing to where the dataset is stored locally
+        Default thin-wraps ``datasets.load_dataset``. Override to fetch from
+        custom sources or to materialize a local cache; return the dataset
+        and an optional local path.
         """
         from datasets import load_dataset
 
@@ -136,22 +126,12 @@ class BaseEnv(ABC):
         task: Optional[Dict[str, Any]],
         **kwargs: Any,
     ) -> Dict[str, float]:
-        """Compute rewards for a single rollout.
+        """Score a rollout.
 
-        Args:
-            rollout_id: Identifier for the rollout being graded.
-            messages: Full conversation transcript (seed messages + every assistant /
-                tool turn produced during the rollout). Was named ``completion`` in
-                the legacy signature, which was misleading: this is the entire
-                message list, not just the model's final answer.
-            task: Per-example reward-side data from
-                :class:`benchmax.envs.types.Example` (e.g. ``ground_truth``,
-                scoring config). ``None`` for envs that grade without per-row data.
-            **kwargs: Trainer-runtime context (e.g. ``workspace_path``). Example
-                fields should be read from ``task``, not ``kwargs``.
-
-        Returns:
-            Mapping of reward function name to scalar score.
+        ``messages`` is the full transcript (seed + assistant + tool turns).
+        ``task`` carries per-example reward-side data (e.g. ``ground_truth``,
+        scoring config); ``None`` for envs that grade without per-row data.
+        Returns ``{reward_name: score}``.
         """
         pass
 
@@ -162,22 +142,12 @@ class BaseEnv(ABC):
         tasks: List[Optional[Dict[str, Any]]],
         **kwargs: Any,
     ) -> List[Dict[str, float]]:
-        """Compute rewards across a group of rollouts jointly.
+        """Score a rollout group jointly.
 
-        Override this when reward computation requires cross-rollout context (e.g.,
-        relative scoring, group normalization, deduplication). Default returns
-        empty dicts so per-rollout ``compute_reward`` runs in isolation.
-
-        Args:
-            rollout_ids: Identifiers for each rollout in the group.
-            messages_list: One message transcript per rollout (see
-                :meth:`compute_reward` for the renaming from ``completions``).
-            tasks: One task dict (or ``None``) per rollout, paired by index.
-            **kwargs: Trainer-runtime context shared across the group.
-
-        Returns:
-            One reward dict per rollout, in input order. An empty dict signals
-            that no group reward was computed for that rollout.
+        Override when reward needs cross-rollout context (relative scoring,
+        group normalization, dedup). Default returns one empty dict per
+        rollout, signalling per-rollout :meth:`compute_reward` runs in
+        isolation. Returns are paired with ``rollout_ids`` by index.
         """
         return [{} for _ in rollout_ids]
 

--- a/src/benchmax/envs/postgres_search/search_env.py
+++ b/src/benchmax/envs/postgres_search/search_env.py
@@ -60,31 +60,6 @@ _CONCISENESS_RUBRIC = Rubric(
     type="positive",
 )
 
-SYSTEM_PROMPT_TEMPLATE = """\
-Answer the given question by searching over {corpus_description}.
-
-First, reason about the question inside <think>...</think>. You may want to rephrase the
-question or break it down into sub-questions.
-
-Call the search tool to retrieve relevant results. After receiving information, reason
-about it inside <think>...</think> before either:
-(1) issuing a new search query
-(2) providing the final answer
-
-Each reasoning step should be grounded in retrieved information.
-
-You can search up to {max_search_calls} times. Break the question down across multiple
-search queries to gather comprehensive information.
-
-Recommended approach:
-1. If initial results do not contain the answer, re-query with broadened or rephrased language.
-2. Reference retrieved chunks to formulate more specific follow-up queries
-(e.g. using keywords in chunk content or using metadata).
-
-When you have gathered enough information, return your final answer inside <answer>...</answer>
-tags. Cite your sources inline using [Source: <source_id>] next to each claim.
-"""
-
 MAX_TOOL_OUTPUT_CHARS = 10000
 TOOL_OUTPUT_TRUNCATION_SUFFIX = "\n...[truncated due to character limit]"
 SEARCH_EFFICIENCY_DECAY_RATE = 0.2
@@ -109,6 +84,31 @@ class SearchEnv(BaseEnv):
         w_search_efficiency: Weight for search efficiency reward component.
         max_search_calls: Hard search call budget (0 reward if exceeded).
     """
+
+    SYSTEM_PROMPT_TEMPLATE = """\
+Answer the given question by searching over {corpus_description}.
+
+First, reason about the question inside <think>...</think>. You may want to rephrase the
+question or break it down into sub-questions.
+
+Call the search tool to retrieve relevant results. After receiving information, reason
+about it inside <think>...</think> before either:
+(1) issuing a new search query
+(2) providing the final answer
+
+Each reasoning step should be grounded in retrieved information.
+
+You can search up to {max_search_calls} times. Break the question down across multiple
+search queries to gather comprehensive information.
+
+Recommended approach:
+1. If initial results do not contain the answer, re-query with broadened or rephrased language.
+2. Reference retrieved chunks to formulate more specific follow-up queries
+(e.g. using keywords in chunk content or using metadata).
+
+When you have gathered enough information, return your final answer inside <answer>...</answer>
+tags. Cite your sources inline using [Source: <source_id>] next to each claim.
+"""
 
     def __init__(
         self,
@@ -190,11 +190,13 @@ class SearchEnv(BaseEnv):
             "search": (search_tool, self._search_tool),
         }
 
-        # Build system prompt.
-        self.system_prompt = SYSTEM_PROMPT_TEMPLATE.format(
-            corpus_description=corpus_description,
-            max_search_calls=max_search_calls,
-        )
+        # Build system prompt — but only if the subclass hasn't overridden
+        # `system_prompt` as a class attribute (BaseEnv-style extension).
+        if not type(self).system_prompt:
+            self.system_prompt = self.SYSTEM_PROMPT_TEMPLATE.format(
+                corpus_description=corpus_description,
+                max_search_calls=max_search_calls,
+            )
 
     # ------------------------------------------------------------------
     # BaseEnv interface
@@ -209,8 +211,11 @@ class SearchEnv(BaseEnv):
         _, tool_function = self._tools[tool_name]
         return await tool_function(**tool_args)
 
-    @classmethod
-    def dataset_preprocess(cls, example: Any, **kwargs) -> Example:
+    def dataset_preprocess(self, example: Any, **kwargs) -> Example:
+        # Instance method (vs. BaseEnv's classmethod default) because the system
+        # prompt is interpolated in __init__ from runtime kwargs — only `self`
+        # has the resolved value; `cls.system_prompt` is still BaseEnv's "".
+        # See BaseEnv.dataset_preprocess docstring for the broader pattern.
         question = example.get("question", "")
         return make_example(
             prompt_messages=[{"role": "user", "content": question}],
@@ -219,7 +224,7 @@ class SearchEnv(BaseEnv):
                 "ground_truth": example.get("answer"),
                 "reference_chunks": example.get("reference_chunks", []),
             },
-            system_prompt=cls.system_prompt,
+            system_prompt=self.system_prompt,
         )
 
     async def compute_reward(

--- a/src/benchmax/envs/postgres_search/search_env.py
+++ b/src/benchmax/envs/postgres_search/search_env.py
@@ -61,28 +61,28 @@ _CONCISENESS_RUBRIC = Rubric(
 )
 
 SYSTEM_PROMPT_TEMPLATE = """\
-Answer the given question by using a search engine over {corpus_description}.
+Answer the given question by searching over {corpus_description}.
 
-You will first reason about the question inside <think> and </think>. For instance you may want
-to rephrase the question or break down the question into multiple sub-questions that you will search for.
+First, reason about the question inside <think>...</think>. You may want to rephrase the
+question or break it down into sub-questions.
 
-You must call the search engine with <tool_call> and it will return the top searched results.
-After receiving the information, you must reason about it inside <think> and </think> before either
-(1) issuing a new query with <tool_call>
-(2) providing the final answer inside <answer> and </answer> tags.
+Call the search tool to retrieve relevant results. After receiving information, reason
+about it inside <think>...</think> before either:
+(1) issuing a new search query
+(2) providing the final answer
 
-Each of your reasoning steps should be grounded in the retrieved information.
+Each reasoning step should be grounded in retrieved information.
 
-You can search up to {max_search_calls} times. Try to break down the question for each search query \
-and gather comprehensive information.
+You can search up to {max_search_calls} times. Break the question down across multiple
+search queries to gather comprehensive information.
 
 Recommended approach:
-1. If initial results do not contain the answer, try to re-query with broadened or rephrased language.
-2. Reference retrieved chunks to formulate more specific follow-up queries \
-(e.g. using keywords in chunk content or using metadata)
+1. If initial results do not contain the answer, re-query with broadened or rephrased language.
+2. Reference retrieved chunks to formulate more specific follow-up queries
+(e.g. using keywords in chunk content or using metadata).
 
-If you have gathered enough information to answer the question,
-return your final answer inside <answer>...</answer> and cite supporting sources as [Source: <source_id>].\
+When you have gathered enough information, return your final answer inside <answer>...</answer>
+tags. Cite your sources inline using [Source: <source_id>] next to each claim.
 """
 
 MAX_TOOL_OUTPUT_CHARS = 10000

--- a/src/benchmax/envs/postgres_search/search_env.py
+++ b/src/benchmax/envs/postgres_search/search_env.py
@@ -37,6 +37,26 @@ from benchmax.rubrics.rubric import Rubric, evaluate_single_rubric
 
 _CITATION_RE = re.compile(r"\[Source:\s*([^\]]+)\]", re.IGNORECASE)
 
+# Match Python-style `{name}` placeholders with word-char names only —
+# leaves JSON-like literals (e.g. `{"answer": "X"}`) and unknown keys
+# untouched, so a user-edited SYSTEM_PROMPT_TEMPLATE that contains JSON
+# examples doesn't blow up at env construction time.
+_TEMPLATE_PLACEHOLDER_RE = re.compile(r"\{(\w+)\}")
+
+
+def _render_template(template: str, **vars: Any) -> str:
+    """Substitute `{name}` placeholders, leaving unknown matches verbatim.
+
+    Safer than ``str.format`` for templates that may legitimately contain
+    raw `{` / `}` characters (JSON examples, escape sequences). Only word-
+    character placeholders are considered; ``{"answer": "X"}`` passes
+    through unchanged.
+    """
+    return _TEMPLATE_PLACEHOLDER_RE.sub(
+        lambda m: str(vars[m.group(1)]) if m.group(1) in vars else m.group(0),
+        template,
+    )
+
 _CORRECTNESS_RUBRIC = Rubric(
     title="Answer correctness",
     description=(
@@ -193,7 +213,8 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         # Build system prompt — but only if the subclass hasn't overridden
         # `system_prompt` as a class attribute (BaseEnv-style extension).
         if not type(self).system_prompt:
-            self.system_prompt = self.SYSTEM_PROMPT_TEMPLATE.format(
+            self.system_prompt = _render_template(
+                self.SYSTEM_PROMPT_TEMPLATE,
                 corpus_description=corpus_description,
                 max_search_calls=max_search_calls,
             )

--- a/src/benchmax/envs/postgres_search/search_env.py
+++ b/src/benchmax/envs/postgres_search/search_env.py
@@ -11,21 +11,15 @@ Provides 5 reward components:
 from __future__ import annotations
 
 import asyncio
+import logging
 import math
 import re
 import traceback
 from collections.abc import Callable
 from typing import Any
 
-import logging
-
 from benchmax.envs.base_env import BaseEnv
 from benchmax.envs.example_id import make_example
-from benchmax.envs.types import Example, Messages, ToolDefinition
-
-logger = logging.getLogger(__name__)
-
-from benchmax.rag.corpus.search_client import SearchClient
 from benchmax.envs.reward_helpers import (
     clip01,
     count_search_calls,
@@ -33,7 +27,11 @@ from benchmax.envs.reward_helpers import (
     extract_completion_text,
     search_within_budget,
 )
+from benchmax.envs.types import Example, Messages, ToolDefinition
+from benchmax.rag.corpus.search_client import SearchClient
 from benchmax.rubrics.rubric import Rubric, evaluate_single_rubric
+
+logger = logging.getLogger(__name__)
 
 _CITATION_RE = re.compile(r"\[Source:\s*([^\]]+)\]", re.IGNORECASE)
 
@@ -56,6 +54,7 @@ def _render_template(template: str, **vars: Any) -> str:
         lambda m: str(vars[m.group(1)]) if m.group(1) in vars else m.group(0),
         template,
     )
+
 
 _CORRECTNESS_RUBRIC = Rubric(
     title="Answer correctness",
@@ -194,7 +193,9 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
             search_props["mode"] = {
                 "type": "string",
                 "enum": modes,
-                "description": (f"Search mode. Available: {modes}. Default: {self._default_mode}."),
+                "description": (
+                    f"Search mode. Available: {modes}. Default: {self._default_mode}."
+                ),
             }
 
         search_tool = ToolDefinition(
@@ -271,7 +272,9 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
 
             logger.info(
                 "[SearchEnv] Q: %s\n  GT: %s\n  A: %s",
-                prompt[:200], gt_str[:200], answer[:200],
+                prompt[:200],
+                gt_str[:200],
+                answer[:200],
             )
 
             # 1. Correctness + Conciseness (concurrent judge calls)
@@ -285,7 +288,9 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
             rewards: dict[str, float] = {
                 "answer_correctness": self._w_correctness * clip01(correctness_raw),
                 "conciseness": (
-                    self._w_conciseness * clip01(conciseness_raw) if correctness_ok else 0.0
+                    self._w_conciseness * clip01(conciseness_raw)
+                    if correctness_ok
+                    else 0.0
                 ),
             }
 
@@ -467,7 +472,9 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         precision = len(overlap) / len(cited_ids) if cited_ids else 0.0
         return recall, precision
 
-    def _extract_reference_ids(self, reference_chunks: list[dict[str, Any]]) -> set[str]:
+    def _extract_reference_ids(
+        self, reference_chunks: list[dict[str, Any]]
+    ) -> set[str]:
         """Extract document-level source IDs from reference chunks.
 
         Default uses the ``file`` metadata key. Override in subclasses

--- a/src/benchmax/rubrics/rubric.py
+++ b/src/benchmax/rubrics/rubric.py
@@ -382,7 +382,12 @@ async def generate_instance_wise_adaptive_rubrics(
 
     prompt = INSTANCE_WISE_RUBRIC_GENERATION_PROMPT + prompt_suffix
 
-    client = AsyncOpenAI(base_url=base_url, api_key=api_key, max_retries=3)
+    # `api_key or None` so an unset/empty value falls through to OPENAI_API_KEY.
+    # The OpenAI SDK only checks the env var when api_key is None or omitted;
+    # passing api_key="" is treated as a real (invalid) credential and skips
+    # the fallback, which is the failure mode when this helper is called from
+    # paths that don't thread an api_key (e.g. single_rubric_based_reward_function).
+    client = AsyncOpenAI(base_url=base_url, api_key=api_key or None, max_retries=3)
 
     try:
         response = await client.chat.completions.create(
@@ -410,10 +415,10 @@ async def generate_instance_wise_adaptive_rubrics(
 async def evaluate_single_rubric(
     rubric: Rubric,
     question: str,
-    ground_truth: Optional[str],
     response: str,
     model_name: str,
     base_url: str,
+    ground_truth: Optional[str] = None,
     api_key: str = "",
     timeout: Optional[float] = None,
 ) -> Dict[str, Any]:
@@ -464,7 +469,12 @@ async def evaluate_single_rubric(
             response=response,
         )
 
-    client = AsyncOpenAI(base_url=base_url, api_key=api_key, max_retries=3)
+    # `api_key or None` so an unset/empty value falls through to OPENAI_API_KEY.
+    # The OpenAI SDK only checks the env var when api_key is None or omitted;
+    # passing api_key="" is treated as a real (invalid) credential and skips
+    # the fallback, which is the failure mode when this helper is called from
+    # paths that don't thread an api_key (e.g. single_rubric_based_reward_function).
+    client = AsyncOpenAI(base_url=base_url, api_key=api_key or None, max_retries=3)
 
     try:
         resp = await client.chat.completions.create(
@@ -793,6 +803,7 @@ async def single_rubric_based_reward_function(
     llm_judge_url: str,
     prompt: str,
     model: str,
+    api_key: str = "",
     timeout: Optional[float] = None,
 ) -> Dict[str, float]:
     """
@@ -816,6 +827,8 @@ async def single_rubric_based_reward_function(
             response=text,
             model_name=model,
             base_url=llm_judge_url,
+            ground_truth=ground_truth,
+            api_key=api_key,
             timeout=timeout,
         )
         for rubric in rubrics

--- a/tests/unit/envs/postgres_search/test_search_env.py
+++ b/tests/unit/envs/postgres_search/test_search_env.py
@@ -129,6 +129,31 @@ class TestInit:
         env = CustomEnv(**defaults, corpus_description="Korean law", max_search_calls=7)
         assert env.system_prompt == "Search over Korean law with 7 budget."
 
+    def test_template_substitution_preserves_json_like_literals(self):
+        # RAG prompts frequently include JSON few-shot examples. The regex
+        # substitution should leave them untouched instead of crashing.
+        class CustomEnv(SearchEnv):
+            SYSTEM_PROMPT_TEMPLATE = (
+                'Example: {"answer": "X"} for {corpus_description}.'
+            )
+
+        defaults = {"search": StubSearch(), **JUDGE_ARGS}
+        env = CustomEnv(**defaults, corpus_description="legal docs")
+        assert env.system_prompt == 'Example: {"answer": "X"} for legal docs.'
+
+    def test_template_substitution_preserves_unknown_placeholders(self):
+        # An unknown {name} placeholder should be passed through verbatim
+        # rather than raising KeyError, so users can author templates
+        # forward-compatibly without crashing on terms we don't yet support.
+        class CustomEnv(SearchEnv):
+            SYSTEM_PROMPT_TEMPLATE = (
+                "Use {corpus_description}. Future hook: {custom_var}."
+            )
+
+        defaults = {"search": StubSearch(), **JUDGE_ARGS}
+        env = CustomEnv(**defaults, corpus_description="legal docs")
+        assert env.system_prompt == "Use legal docs. Future hook: {custom_var}."
+
 
 class TestSearchTool:
     def test_empty_query_returns_error(self):

--- a/tests/unit/envs/postgres_search/test_search_env.py
+++ b/tests/unit/envs/postgres_search/test_search_env.py
@@ -111,6 +111,24 @@ class TestInit:
         env = _make_env()
         assert env._w_search_efficiency == pytest.approx(0.1)
 
+    def test_subclass_can_override_system_prompt_via_class_attribute(self):
+        class CustomEnv(SearchEnv):
+            system_prompt = "Override prompt"
+
+        defaults = {"search": StubSearch(), **JUDGE_ARGS}
+        env = CustomEnv(**defaults, corpus_description="ignored", max_search_calls=99)
+        assert env.system_prompt == "Override prompt"
+
+    def test_subclass_can_override_system_prompt_template(self):
+        class CustomEnv(SearchEnv):
+            SYSTEM_PROMPT_TEMPLATE = (
+                "Search over {corpus_description} with {max_search_calls} budget."
+            )
+
+        defaults = {"search": StubSearch(), **JUDGE_ARGS}
+        env = CustomEnv(**defaults, corpus_description="Korean law", max_search_calls=7)
+        assert env.system_prompt == "Search over Korean law with 7 budget."
+
 
 class TestSearchTool:
     def test_empty_query_returns_error(self):
@@ -376,7 +394,8 @@ class TestCitationScoring:
 
 class TestDatasetPreprocess:
     def test_extracts_question_answer(self):
-        result = SearchEnv.dataset_preprocess({"question": "What is X?", "answer": "Y"})
+        env = _make_env()
+        result = env.dataset_preprocess({"question": "What is X?", "answer": "Y"})
         # User message carries the question text (system msg is prepended by make_example).
         user_msgs = [m for m in result["prompt_messages"] if m["role"] == "user"]
         assert user_msgs and user_msgs[0]["content"] == "What is X?"
@@ -384,10 +403,23 @@ class TestDatasetPreprocess:
         assert result["task"]["ground_truth"] == "Y"
 
     def test_passes_reference_chunks(self):
-        result = SearchEnv.dataset_preprocess(
+        env = _make_env()
+        result = env.dataset_preprocess(
             {"question": "Q", "answer": "A", "reference_chunks": [{"id": "c1"}]}
         )
         assert result["task"]["reference_chunks"] == [{"id": "c1"}]
+
+    def test_bakes_interpolated_system_prompt_into_example(self):
+        # The whole point of making this an instance method: the system prompt
+        # is interpolated in __init__ from runtime kwargs, so only `self` has
+        # the resolved value. Verifies the bug from
+        # project_searchenv_classmethod_system_prompt_drop is fixed.
+        env = _make_env(corpus_description="Korean legal statutes", max_search_calls=4)
+        result = env.dataset_preprocess({"question": "Q", "answer": "A"})
+        system_msgs = [m for m in result["prompt_messages"] if m["role"] == "system"]
+        assert len(system_msgs) == 1
+        assert "Korean legal statutes" in system_msgs[0]["content"]
+        assert "4 times" in system_msgs[0]["content"]
 
 
 class TestListTools:

--- a/uv.lock
+++ b/uv.lock
@@ -1294,7 +1294,11 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.408" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "ruff", specifier = ">=0.15.0" },
+]
 
 [[package]]
 name = "joblib"


### PR DESCRIPTION
## Summary

Bundles benchmax env + rubric improvements from `rubrics-api-key-forwarding`.
Two are correctness fixes (system prompt silently dropped from training
Examples; tool-call directives breaking native tool calls); the rest are
extensibility and hygiene. `main` (`e2bb11f`) is already merged in, so this
fast-forwards cleanly. Net diff: `base_env.py`, `search_env.py`,
`rubric.py`, `test_search_env.py`.

## Changes

### Rubrics (`rubric.py`)
- `single_rubric_based_reward_function` now forwards `ground_truth` to
  `evaluate_single_rubric` — it took the arg but dropped it, so judge prompts
  were built without ground-truth context.
- Adds an `api_key` param so callers (incl. wizard-generated env code) can
  thread an explicit key.
- `evaluate_single_rubric` coerces empty `api_key` → `None` so the OpenAI
  SDK's `OPENAI_API_KEY` fallback fires (passing `""` was treated as a real,
  invalid credential).
- ⚠️ **Reviewer note:** `evaluate_single_rubric.ground_truth` moved to a
  keyword-defaulted position (`Optional[str] = None`). All internal call
  sites use kwargs, but an external caller passing 3+ positional args would
  silently get wrong arg mapping.

### SearchEnv (`search_env.py`)
- **Fix:** `dataset_preprocess` was a `@classmethod` reading
  `cls.system_prompt` → resolved to BaseEnv's `""`, silently dropping the
  interpolated system prompt from training Examples. Now an instance method
  reading `self.system_prompt`; the trainer already dispatches classmethod
  vs. instance via `is_classmethod`.
- Two-slot subclass override: a static `system_prompt` class attr (Slot 1)
  wins outright; a `SYSTEM_PROMPT_TEMPLATE` class attr (Slot 2) is
  interpolated. Template moved from module-level to a class attribute.
- Template rendering uses a regex helper (`re.sub(r"\{(\w+)\}", ...)`)
  instead of `str.format`, so user-authored prompts containing JSON few-shot
  examples (`{"answer": "X"}`) don't crash at env construction.
- **Fix:** dropped Hermes `<tool_call>` XML directives from the system
  prompt — they caused gpt-5.x to emit `<tool_call>{...}` in `content`
  instead of native `tool_calls`, which workers then dropped. Kept the
  `<think>` / `<answer>` conventions.

### BaseEnv (`base_env.py`)
- Adds `playground_preprocess` — an instance-method counterpart to
  `dataset_preprocess` that wraps bare `{prompt}` playground requests into an
  Example with the env's system prompt; `task=None` so rollout-service skips
  reward computation (no ground truth).
- Documents the classmethod-vs-instance-method tradeoff for envs that
  interpolate runtime kwargs into their prompt.
- Docstring trims on `load_dataset` / `compute_reward` /
  `compute_group_reward` / `playground_preprocess` (comments only).

## Testing
- `tests/unit/envs/postgres_search/test_search_env.py`: 40/40 pass. New
  regression tests cover interpolated-prompt bake-in, Slot 1 / Slot 2
  overrides, JSON-literal preservation, and unknown-placeholder pass-through.
- `ruff check` + `ruff format --check` clean on `search_env.py`.
