### PR TITLE
linker_env: fix system_prompt dropped from training Examples (classmethod read cls.system_prompt)

### DIFF
--- a/src/benchmax/envs/postgres_search/linker_env.py
+++ b/src/benchmax/envs/postgres_search/linker_env.py
@@ -98,6 +98,14 @@ class LinkerEnv(BaseEnv):
         max_search_calls: Maximum number of search calls allowed.
     """
 
+    # Static prompt exposed as a class attribute (not assigned on the
+    # instance) so the ``dataset_preprocess`` classmethod can read it via
+    # ``cls.system_prompt``. Setting it only on ``self`` left
+    # ``cls.system_prompt`` resolving to BaseEnv's "" — dropping the prompt
+    # from training Examples. See BaseEnv.dataset_preprocess for the
+    # classmethod-vs-instance-method rationale.
+    system_prompt: str = _SYSTEM_PROMPT
+
     def __init__(
         self,
         search: SearchClient,
@@ -139,8 +147,6 @@ class LinkerEnv(BaseEnv):
         self._tools: dict[str, tuple[ToolDefinition, Any]] = {
             "search": (search_tool, self._search_tool),
         }
-
-        self.system_prompt = _SYSTEM_PROMPT
 
     # ------------------------------------------------------------------
     # BaseEnv interface
@@ -196,7 +202,9 @@ class LinkerEnv(BaseEnv):
         if not query:
             return "Error: Missing required parameter: 'query'"
         try:
-            results = self._search.search(query=query, mode=self._default_mode, top_k=limit)
+            results = self._search.search(
+                query=query, mode=self._default_mode, top_k=limit
+            )
             return self._format_results(results)
         except Exception:
             return f"Error:\n{traceback.format_exc()}"

--- a/tests/unit/envs/postgres_search/test_linker_env.py
+++ b/tests/unit/envs/postgres_search/test_linker_env.py
@@ -1,0 +1,65 @@
+"""Tests for LinkerEnv — search environment for LLM-driven chunk linking."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from benchmax.envs.postgres_search.linker_env import _SYSTEM_PROMPT, LinkerEnv
+
+
+class StubSearch:
+    """Minimal SearchClient for testing."""
+
+    def __init__(self, modes: list[str] | None = None):
+        self._modes = modes or ["vector"]
+
+    def search(
+        self, query: str, mode: str = "auto", top_k: int = 10
+    ) -> list[dict[str, Any]]:
+        return [{"content": "result", "source": "doc_0", "metadata": {}, "score": 1.0}]
+
+    def embed(self, text: str) -> list[float]:
+        return [0.1, 0.2, 0.3]
+
+    @property
+    def available_modes(self) -> list[str]:
+        return self._modes
+
+    def get_params(self) -> dict[str, str]:
+        return {"backend": "stub"}
+
+
+class TestSystemPrompt:
+    def test_system_prompt_is_a_class_attribute(self):
+        # Must live on the class (not just the instance) so the
+        # dataset_preprocess classmethod can read it via cls.system_prompt.
+        assert LinkerEnv.system_prompt == _SYSTEM_PROMPT
+        assert LinkerEnv.system_prompt
+
+    def test_instance_resolves_system_prompt(self):
+        env = LinkerEnv(search=StubSearch())
+        assert env.system_prompt == _SYSTEM_PROMPT
+
+
+class TestDatasetPreprocess:
+    def test_bakes_system_prompt_into_example_via_classmethod(self):
+        # Regression: dataset_preprocess is a classmethod reading
+        # cls.system_prompt. Before the fix the prompt was only set on the
+        # instance, so cls.system_prompt resolved to BaseEnv's "" and the
+        # system message was silently dropped from training Examples.
+        result = LinkerEnv.dataset_preprocess(
+            {"target_n": 2, "reasoning_mode": "", "prompt": "Primary chunk text."}
+        )
+        system_msgs = [m for m in result["prompt_messages"] if m["role"] == "system"]
+        assert len(system_msgs) == 1
+        assert "evidence chain" in system_msgs[0]["content"]
+
+    def test_templates_user_prompt(self):
+        result = LinkerEnv.dataset_preprocess(
+            {"target_n": 3, "reasoning_mode": "", "prompt": "Primary chunk text."}
+        )
+        user_msgs = [m for m in result["prompt_messages"] if m["role"] == "user"]
+        assert user_msgs
+        assert "Find 3 secondary chunk(s)" in user_msgs[0]["content"]
+        assert "Primary chunk text." in user_msgs[0]["content"]
+        assert result["task"]["target_n"] == 3


### PR DESCRIPTION
## Summary

Fixes the same bug class as #24, in `LinkerEnv` (SearchEnv's sibling in
`postgres_search/`). `LinkerEnv.__init__` set `self.system_prompt = _SYSTEM_PROMPT`
on the **instance**, but `dataset_preprocess` is a `@classmethod` that passes
`system_prompt=cls.system_prompt` to `make_example`. With no class-level
`system_prompt`, `cls.system_prompt` resolved to `BaseEnv.system_prompt = ""` —
so training Examples were built with **no system prompt at all**.

## Fix

`LinkerEnv`'s prompt is **static** (never interpolated from runtime kwargs), so the
right fix is a **class attribute** — `system_prompt: str = _SYSTEM_PROMPT` — matching
`math` / `crm` / `wikipedia` / `excel`. This keeps the classmethod's no-instance
dataset-load path. (#24 needed the *instance-method* route only because SearchEnv
interpolates `corpus_description` / `max_search_calls` into its prompt — LinkerEnv
doesn't.)

## Tests

`tests/unit/envs/postgres_search/test_linker_env.py` (none existed before):
- `system_prompt` is present as a class attribute and equals `_SYSTEM_PROMPT`
- an instance resolves `system_prompt` correctly
- regression: the system message bakes into the Example via the classmethod path

44/44 postgres_search tests pass; `ruff check` + `ruff format --check` clean.

## Audit note

Swept every `dataset_preprocess` in the repo for this pattern. The other envs
(`math`, `crm`, `wikipedia`, `excel`) and the examples (`guess`, `telestitch`)
already declare `system_prompt` as a class attribute, so the classmethod reads it
correctly — `LinkerEnv` was the only remaining instance.
