### PR TITLE
drop unused job-telemetry dependency + legacy telemetry remnants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "cloudpickle>=3.0.0",
     "datasets>=4.0.0",
     "httpx>=0.27.0",
-    "job-telemetry>=0.1.0",
     "json-repair>=0.59.10",
     "openai>=2.15.0",
     "pydantic>=2.0.0",
@@ -75,6 +74,3 @@ skypilot = [
 excel = ["openpyxl>=3.1.5"]
 excel-mac-windows = ["openpyxl>=3.1.5", "xlwings>=0.33.16"]
 crm = ["python-dateutil>=2.9.0.post0"]
-
-[tool.uv.sources]
-job-telemetry = { path = "../job-telemetry", editable = true }

--- a/src/benchmax/envs/mcp/provisioners/utils.py
+++ b/src/benchmax/envs/mcp/provisioners/utils.py
@@ -91,7 +91,7 @@ def get_setup_command() -> str:
 # Install uv
 curl -LsSf https://astral.sh/uv/install.sh | sh
 UV_VENV_CLEAR=1 uv venv ~/venv && source ~/venv/bin/activate
-uv pip install fastmcp~=2.12.0 pyyaml psutil job-telemetry
+uv pip install fastmcp~=2.12.0 pyyaml psutil
 bash setup.sh
 """
 

--- a/src/benchmax/envs/mcp/proxy_server.py
+++ b/src/benchmax/envs/mcp/proxy_server.py
@@ -360,10 +360,6 @@ class ProxyServer:
         payload_kwargs: Dict[str, Any] = {
             k: v for k, v in data.items() if k not in ("completion", "ground_truth")
         }
-        # Legacy tracking-config keys (if any sneak through from older callers)
-        # — silently drop. Cross-process MCP log capture is a follow-up.
-        payload_kwargs.pop("__benchmax_telemetry_run_id", None)
-        payload_kwargs.pop("__benchmax_telemetry_api_key", None)
 
         kwargs: Dict[str, Any] = {
             "completion": completion,

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,6 @@ dependencies = [
     { name = "cloudpickle" },
     { name = "datasets" },
     { name = "httpx" },
-    { name = "job-telemetry" },
     { name = "json-repair" },
     { name = "openai" },
     { name = "pydantic" },
@@ -318,7 +317,6 @@ requires-dist = [
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = "~=2.12.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "job-telemetry", editable = "../job-telemetry" },
     { name = "json-repair", specifier = ">=0.59.10" },
     { name = "keybert", marker = "extra == 'rag'", specifier = ">=0.8" },
     { name = "langchain-text-splitters", marker = "extra == 'rag'", specifier = ">=0.3.0" },
@@ -1012,9 +1010,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
     { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
     { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
     { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
     { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
     { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
@@ -1265,43 +1261,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
-]
-
-[[package]]
-name = "job-telemetry"
-version = "0.1.0"
-source = { editable = "../job-telemetry" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "pyjwt" },
-    { name = "requests" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.9.0" },
-    { name = "opentelemetry-api", specifier = "==1.41.1" },
-    { name = "opentelemetry-exporter-otlp-proto-common", specifier = "==1.41.1" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = "==1.41.1" },
-    { name = "opentelemetry-proto", specifier = "==1.41.1" },
-    { name = "opentelemetry-sdk", specifier = "==1.41.1" },
-    { name = "pyjwt", specifier = ">=2.8.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
-    { name = "requests", specifier = ">=2.28.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
-]
-provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pyright", specifier = ">=1.1.408" },
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "ruff", specifier = ">=0.15.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
job-telemetry was a hard dependency but never imported anywhere in benchmax. It only appeared in:
- core dependencies (no code behind it) — made `pip install benchmax` unresolvable since job-telemetry isn't on PyPI
- a [tool.uv.sources] editable path to ../job-telemetry
- the SkyPilot MCP-host setup command (installed but unused)
- two defensive proxy_server.py pop()s for legacy __benchmax_telemetry_* keys that nothing in the codebase sets

Remove all four. Refreshes uv.lock. This matches what was published as 0.1.2.dev25.