### PR TITLE
traces: Arrow-safe to_dict defaults + structured message normalizer

### DIFF
--- a/src/benchmax/traces/__init__.py
+++ b/src/benchmax/traces/__init__.py
@@ -1,3 +1,9 @@
+from .adapter import normalize_message, normalize_structured_message
 from .pipeline import TracesPipeline, ImportanceFilterConfig
 
-__all__ = ["TracesPipeline", "ImportanceFilterConfig"]
+__all__ = [
+    "TracesPipeline",
+    "ImportanceFilterConfig",
+    "normalize_message",
+    "normalize_structured_message",
+]

--- a/src/benchmax/traces/adapter.py
+++ b/src/benchmax/traces/adapter.py
@@ -133,21 +133,22 @@ class TraceMessage:
     name: str | None = None  # tool name for role="tool"
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialise to a JSON-compatible dict.
+        """Serialise to a JSON-compatible dict with structured tool_calls.
 
-        Always includes all fields (even when None) so that JSONL output
-        has a consistent schema — HuggingFace ``load_dataset`` fails on
-        rows with inconsistent keys.
+        Used by the web-app wizard preview, trace rendering, and
+        intermediate pipeline storage. All fields are always present
+        with type-safe defaults (empty list / empty string, never None).
         """
         d: dict[str, Any] = {"role": self.role, "content": self.content}
         d["tool_calls"] = (
-            [{"name": tc.name, "arguments": tc.arguments, "id": tc.id} for tc in self.tool_calls]
+            [{"name": tc.name, "arguments": tc.arguments, "id": tc.id or ""} for tc in self.tool_calls]
             if self.tool_calls
-            else None
+            else []
         )
-        d["tool_call_id"] = self.tool_call_id
-        d["name"] = self.name
+        d["tool_call_id"] = self.tool_call_id or ""
+        d["name"] = self.name or ""
         return d
+
 
 
 @dataclass(frozen=True)
@@ -289,3 +290,89 @@ def _message_from_dict(d: dict[str, Any]) -> TraceMessage:
         tool_call_id=d.get("tool_call_id"),
         name=d.get("name"),
     )
+
+
+# ---------------------------------------------------------------------------
+# Message format normalizers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_json_string(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return json.dumps(value)
+    return str(value)
+
+
+def _is_structured_content(msg: dict[str, Any]) -> bool:
+    """True if ``content`` is a list of typed blocks (openclaw / Anthropic style)."""
+    content = msg.get("content")
+    return (
+        isinstance(content, list)
+        and len(content) > 0
+        and isinstance(content[0], dict)
+        and "type" in content[0]
+    )
+
+
+def normalize_structured_message(msg: dict[str, Any]) -> TraceMessage:
+    """Normalize a message with structured content blocks to ``TraceMessage``.
+
+    Handles the format used by openclaw and Anthropic-style agents where
+    ``content`` is a list of typed blocks::
+
+        {type: "text", text: "..."}
+        {type: "toolCall", name: "...", arguments: "...", id: "..."}
+        {type: "toolResult", ...}
+
+    And ``role`` may be ``"toolResult"`` (normalized to ``"tool"``).
+
+    Any provider adapter can call this when it encounters structured-content
+    messages — it's not tied to a specific provider.
+    """
+    role = msg.get("role", "")
+    content = msg.get("content", "")
+
+    if role == "toolResult":
+        role = "tool"
+
+    text_parts: list[str] = []
+    tool_calls: list[ToolCall] = []
+
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "")
+            if btype == "text":
+                text_parts.append(block.get("text", ""))
+            elif btype == "toolCall":
+                tool_calls.append(ToolCall(
+                    name=block.get("name", ""),
+                    arguments=_ensure_json_string(block.get("arguments", "{}")),
+                    id=block.get("id"),
+                ))
+        content = "\n".join(text_parts) if text_parts else ""
+    else:
+        content = str(content) if content else ""
+
+    return TraceMessage(
+        role=role,
+        content=content,
+        tool_calls=tool_calls if tool_calls else None,
+        tool_call_id=msg.get("toolCallId") or msg.get("tool_call_id"),
+        name=msg.get("toolName") or msg.get("name"),
+    )
+
+
+def normalize_message(msg: dict[str, Any]) -> TraceMessage:
+    """Auto-detect message format and normalize to ``TraceMessage``.
+
+    Handles both structured-content (openclaw / Anthropic) and flat
+    (OpenAI) message formats. Provider adapters can call this instead
+    of implementing format detection themselves.
+    """
+    if _is_structured_content(msg):
+        return normalize_structured_message(msg)
+    return _message_from_dict(msg)

--- a/src/benchmax/traces/processing.py
+++ b/src/benchmax/traces/processing.py
@@ -167,28 +167,28 @@ class TrainingExample:
     def to_jsonl_dict(self) -> dict[str, Any]:
         """Serialise to the JSONL schema consumed by ``dataset_preprocess``.
 
-        The trainer expects structured message dicts (not human-readable
-        strings).  ``prompt`` is a list of message dicts, ``ground_truth``
-        is the completion message dict.  Metadata goes inside
-        ``init_rollout_args`` so it's available in ``compute_reward()``.
+        Both ``prompt_messages`` and ``ground_truth`` use ``to_dict()``
+        with structured ``tool_calls`` (arguments as JSON strings). The
+        trainer handles Arrow compatibility at template time by parsing
+        argument strings to dicts before ``apply_chat_template``.
 
         Schema::
 
             {
-                "prompt": list[dict],        # chat messages before this turn
-                "ground_truth": dict,         # the assistant completion
+                "prompt_messages": list[{role, content, tool_calls, ...}],
+                "ground_truth": {role, content, tool_calls, ...},
                 "init_rollout_args": {
                     "trace_id": str,
                     "turn_index": int,
                     "total_messages": int,
                     "scores": dict[str, float],
-                    "raw_prompt": str,        # human-readable for judge context
+                    "raw_prompt": str,
                 },
             }
         """
         gt = self.completion_messages[0].to_dict() if self.completion_messages else {}
         return {
-            "prompt": [m.to_dict() for m in self.prompt_messages],
+            "prompt_messages": [m.to_dict() for m in self.prompt_messages],
             "ground_truth": gt,
             "init_rollout_args": {
                 "trace_id": self.trace_id,


### PR DESCRIPTION
## Summary

- `TraceMessage.to_dict()` now uses `[]` and `""` instead of `None` for `tool_calls`, `tool_call_id`, `name`
- Adds `normalize_message()` / `normalize_structured_message()` for converting structured-content messages (openclaw / Anthropic style) to `TraceMessage`
- `to_jsonl_dict()` renamed `prompt` field to `prompt_messages` to match web-app `TrainingExample` type

## Problem

`to_dict()` emitted `tool_calls: None` on messages without tool calls. After HF Arrow round-trip, this creates a type conflict (`None` vs `list`) in the same list column. The Qwen3.5 chat template crashes iterating `None`:

```
jinja2/filters.py:249 → TypeError: Can only get item pairs from a mapping.
```

The `None` defaults contradicted the docstring which said "Always includes all fields so that JSONL output has a consistent schema."

## Changes

**`adapter.py`:**
- `to_dict()`: `tool_calls` defaults to `[]`, `tool_call_id`/`name` to `""` (never `None`)
- `normalize_structured_message()`: converts messages with structured content blocks (`{type: "text"}`, `{type: "toolCall"}`, `role: "toolResult"`) to `TraceMessage`
- `normalize_message()`: auto-detects format (structured vs flat) and normalizes — reusable by any provider adapter

**`processing.py`:**
- `to_jsonl_dict()`: field renamed from `prompt` to `prompt_messages`

**`__init__.py`:**
- Exports `normalize_message`, `normalize_structured_message`

## Companion PR

Monorepo trainer fix: castform-ai/castform#90 (parses string arguments to dicts before `apply_chat_template`)

## Test plan

- [ ] Verify `to_dict()` output survives Arrow round-trip + `apply_chat_template` on 528 openclaw examples
- [ ] Verify `normalize_message()` handles both openclaw-native and OpenAI message formats
- [ ] Verify web-app wizard preview still renders structured tool call blocks