### PR TITLE
platform: route RolloutClient through platform-service + validate via env_class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,12 +63,15 @@ Every platform URL routes through `benchmax.config`:
 from benchmax import config
 config.platform_url()    # https://api.castform.com  (clients add /v1/...)
 config.llm_url()         # https://llm.castform.com/v1
-config.rollout_url()     # https://autobots.castform.com
 ```
 
+Rollouts are reached through the platform API (`platform_url()` +
+`/v1/rollout/stream`), which gates the API key and proxies to rollout-service —
+there is no separate rollout URL.
+
 Override via env vars: `CASTFORM_BASE_DOMAIN`, `CASTFORM_PLATFORM_URL`,
-`CASTFORM_LLM_URL`, `CASTFORM_ROLLOUT_URL`. **Do not** hardcode platform
-URLs in source — always go through `config`.
+`CASTFORM_LLM_URL`. **Do not** hardcode platform URLs in source — always go
+through `config`.
 
 ## Design principles
 

--- a/src/benchmax/config.py
+++ b/src/benchmax/config.py
@@ -38,8 +38,3 @@ def web_app_url() -> str:
 def llm_url() -> str:
     """OpenAI-compatible LLM endpoint hosted by the platform."""
     return os.environ.get("CASTFORM_LLM_URL") or f"https://llm.{base_domain()}/v1"
-
-
-def rollout_url() -> str:
-    """Rollout / inference server."""
-    return os.environ.get("CASTFORM_ROLLOUT_URL") or f"https://autobots.{base_domain()}"

--- a/src/benchmax/platform/client.py
+++ b/src/benchmax/platform/client.py
@@ -29,7 +29,9 @@ from .exceptions import (
 )
 
 if TYPE_CHECKING:
-    pass
+    from types import ModuleType
+
+    from benchmax.envs.base_env import BaseEnv
 
 
 @dataclass(frozen=True)
@@ -945,6 +947,10 @@ class RolloutClient:
         env_metadata_path: str | None = None,
         n: int = 2,
         *,
+        env_class: type[BaseEnv] | None = None,
+        constructor_args: dict[str, Any] | None = None,
+        pip_dependencies: list[str] | None = None,
+        local_modules: list[ModuleType] | None = None,
         env_cls_bytes: bytes | None = None,
         env_metadata_bytes: bytes | None = None,
         llm_model: str = _VALIDATION_MODEL,
@@ -953,14 +959,22 @@ class RolloutClient:
     ) -> ValidationResult:
         """Run rollouts on the first *n* examples and report pass/fail.
 
-        The environment can be specified via **blob paths** or **raw bytes**
-        (mutually exclusive — see class docstring).
+        The environment can be specified three ways (mutually exclusive): an
+        **env class** (bundled to bytes here, so validation needs no prior
+        upload — preferred for a pre-launch smoke test), **blob paths** to an
+        already-uploaded env, or **raw bytes** (see class docstring).
 
         Args:
             examples:           Full dataset (list of raw dicts).
             env_cls_path:       Blob path to the uploaded env .pkl file.
             env_metadata_path:  Blob path to the uploaded env-meta .json file.
             n:                  Number of examples to validate (default 2).
+            env_class:          BaseEnv subclass to bundle and validate without
+                                uploading. Mutually exclusive with paths/bytes.
+            constructor_args:   kwargs baked into the env bundle (env_class only).
+            pip_dependencies:   Pip deps recorded in the bundle (env_class only).
+            local_modules:      Modules to pickle by-value (env_class only; for
+                                envs that import from local .py files).
             env_cls_bytes:      Raw bytes of the pickled env class (will be base64-encoded).
             env_metadata_bytes: Raw bytes of the env metadata JSON (will be base64-encoded).
             verbose:            Print colored progress to stdout (default True for
@@ -972,6 +986,27 @@ class RolloutClient:
             "did everything pass" check, with per-example detail in
             ``result.examples`` for richer reporting.
         """
+        # An env class is bundled to bytes here so validation can run a smoke
+        # test BEFORE uploading anything (the launch flow uploads only after
+        # validation passes). Mutually exclusive with explicit paths/bytes.
+        if env_class is not None:
+            if any(
+                (env_cls_path, env_metadata_path, env_cls_bytes, env_metadata_bytes)
+            ):
+                raise ValueError(
+                    "Provide env_class OR explicit env paths/bytes, not both."
+                )
+            from benchmax.bundle import dump_bundle
+
+            bundle = dump_bundle(
+                env_class,
+                constructor_args=constructor_args,
+                pip_dependencies=pip_dependencies,
+                local_modules=local_modules,
+            )
+            env_cls_bytes = bundle.pickled
+            env_metadata_bytes = bundle.metadata.to_json_bytes()
+
         # Validate env args early so we fail before running any rollouts.
         self._build_env(
             env_cls_path, env_metadata_path, env_cls_bytes, env_metadata_bytes

--- a/src/benchmax/platform/client.py
+++ b/src/benchmax/platform/client.py
@@ -883,7 +883,10 @@ class RolloutClient:
                 body = response.read().decode()
                 # Typed errors so callers can distinguish retryable from
                 # caller-fix from auth-fix without parsing exception messages.
-                if response.status_code == 401:
+                # 403 too: rollouts route through platform-service's optionalAuth
+                # gate, which rejects a missing/invalid/expired key as 403
+                # ("sign in to run rollouts") rather than 401 — same fix (the key).
+                if response.status_code in (401, 403):
                     raise AuthenticationError(body[:300], response.status_code)
                 if response.status_code == 404:
                     raise RolloutNotFound(body[:300], response.status_code)

--- a/src/benchmax/platform/client.py
+++ b/src/benchmax/platform/client.py
@@ -279,7 +279,9 @@ class StorageClient:
         # Stream from disk instead of read_bytes() to keep memory bounded for
         # multi-GB datasets. httpx infers Content-Length from the file size.
         url_response = self._get_upload_url(
-            path, mime_type, expires_in_minutes=expires_in_minutes,
+            path,
+            mime_type,
+            expires_in_minutes=expires_in_minutes,
         )
         with file_path.open("rb") as fh:
             self._put_to_signed_url(url_response["uploadUrl"], fh, mime_type)
@@ -437,7 +439,11 @@ class TrainerClient:
         specs = self.list_launch_args()
         print(_hdr("Launch args accepted by POST /train/runs/launch"))
         for spec in specs:
-            req = _RED + "required" + _RESET if spec.required else _CYAN + "optional" + _RESET
+            req = (
+                _RED + "required" + _RESET
+                if spec.required
+                else _CYAN + "optional" + _RESET
+            )
             header = f"  {_BOLD}{spec.name}{_RESET} ({spec.type}, {req})"
             bits: list[str] = []
             if spec.default is not None:
@@ -652,7 +658,9 @@ def _print_event(
                                 tool_text,
                             )
                         else:
-                            preview = textwrap.shorten(tool_text, width=120, placeholder="…")
+                            preview = textwrap.shorten(
+                                tool_text, width=120, placeholder="…"
+                            )
                             print(
                                 f"{prefix} → message [{role}/tool_result] "
                                 f"(chars={len(tool_text)}): {preview}"
@@ -690,7 +698,13 @@ def _print_event(
 
 
 class RolloutClient:
-    """Thin synchronous client for the /rollout/stream endpoint.
+    """Thin synchronous client for the rollout-stream endpoint.
+
+    Rollouts are reached through platform-service. platform-service is the API-key
+    gate: it validates the ``sk_`` key and mints a short-lived act_as JWT that
+    rollout-service accepts (rollout-service's own auth only takes
+    auth-service-minted JWTs — never a raw platform key). The proxy is mounted at
+    ``/v1/rollout/stream``.
 
     Supports two ways to provide the environment:
 
@@ -700,8 +714,11 @@ class RolloutClient:
        raw file contents; they will be base64-encoded and sent inline.
 
     Args:
-        api_key:    Bearer token for the rollout server.
-        server_url: Base URL of the rollout server.
+        api_key:    Platform API key (``sk_``); forwarded as the Bearer token
+                    platform-service validates.
+        server_url: Base URL of platform-service. Defaults to
+                    ``config.platform_url()``; the ``/v1/rollout/stream`` path is
+                    appended per request.
         timeout:    Per-request timeout in seconds (default 300 — rollouts can be slow).
     """
 
@@ -716,7 +733,9 @@ class RolloutClient:
         self._api_key = api_key
         # Resolve at construction time, not import time, so env-var changes
         # take effect (mirrors StorageClient/TrainerClient default_factory pattern).
-        self._server_url = (server_url or config.rollout_url()).rstrip("/")
+        # Target platform-service (the API-key gate), not the rollout-service
+        # host directly — see the class docstring for why.
+        self._server_url = (server_url or config.platform_url()).rstrip("/")
         self._timeout = timeout
 
     @staticmethod
@@ -734,7 +753,9 @@ class RolloutClient:
         has_bytes = env_cls_bytes is not None and env_metadata_bytes is not None
 
         if has_paths and has_bytes:
-            raise ValueError("Provide either blob paths or raw bytes for the env, not both.")
+            raise ValueError(
+                "Provide either blob paths or raw bytes for the env, not both."
+            )
         if not has_paths and not has_bytes:
             raise ValueError(
                 "Provide either (env_cls_path, env_metadata_path) or "
@@ -844,7 +865,9 @@ class RolloutClient:
             },
         }
 
-        url = f"{self._server_url}/rollout/stream"
+        # platform-service mounts the proxy at /v1/rollout/stream; it validates
+        # the platform key and forwards to rollout-service with an act_as JWT.
+        url = f"{self._server_url}/v1/rollout/stream"
         headers = {"Authorization": f"Bearer {self._api_key}"}
 
         with httpx.stream(
@@ -950,11 +973,17 @@ class RolloutClient:
             ``result.examples`` for richer reporting.
         """
         # Validate env args early so we fail before running any rollouts.
-        self._build_env(env_cls_path, env_metadata_path, env_cls_bytes, env_metadata_bytes)
+        self._build_env(
+            env_cls_path, env_metadata_path, env_cls_bytes, env_metadata_bytes
+        )
 
         sample = examples[:n]
         if verbose:
-            print(_hdr(f"── Remote validation: {len(sample)} example(s) on {llm_model} ──"))
+            print(
+                _hdr(
+                    f"── Remote validation: {len(sample)} example(s) on {llm_model} ──"
+                )
+            )
 
         per_example: list[ExampleValidation] = []
         for i, example in enumerate(sample):
@@ -972,10 +1001,15 @@ class RolloutClient:
                     max_turns=max_turns,
                 )
                 ok = bool(final.get("success"))
-                per_example.append(ExampleValidation(
-                    index=i, ok=ok,
-                    error=None if ok else (final.get("error") or "rollout reported success=False"),
-                ))
+                per_example.append(
+                    ExampleValidation(
+                        index=i,
+                        ok=ok,
+                        error=None
+                        if ok
+                        else (final.get("error") or "rollout reported success=False"),
+                    )
+                )
             except (RolloutError, RuntimeError) as exc:
                 if verbose:
                     print(_err(f"  Example {i} failed: {exc}"))
@@ -987,6 +1021,10 @@ class RolloutClient:
             if result.ok:
                 print(_ok("Remote validation passed"))
             else:
-                print(_err("Remote validation failed — check output above before launching a full job"))
+                print(
+                    _err(
+                        "Remote validation failed — check output above before launching a full job"
+                    )
+                )
 
         return result

--- a/tests/unit/platform/test_client.py
+++ b/tests/unit/platform/test_client.py
@@ -366,3 +366,71 @@ def test_validation_result_ok_property():
     ])
     assert r.ok is False
     assert r.examples[1].error == "boom"
+
+
+# ---------------------------------------------------------------------------
+# validate_examples(env_class=...) — bundle locally to bytes, no upload needed
+# ---------------------------------------------------------------------------
+
+
+def _make_smoke_env():
+    """A minimal concrete BaseEnv defined in a local scope so cloudpickle
+    pickles it by value (no local-module ref for dump_bundle to reject)."""
+    from benchmax.envs.base_env import BaseEnv
+
+    class _SmokeEnv(BaseEnv):
+        async def list_tools(self):
+            return []
+
+        async def run_tool(self, rollout_id, tool_name, **tool_args):
+            raise NotImplementedError
+
+        async def compute_reward(self, rollout_id, messages, task, **kwargs):
+            return {"reward": 1.0}
+
+    return _SmokeEnv
+
+
+def test_validate_examples_env_class_bundles_to_bytes(monkeypatch):
+    """env_class is bundled to bytes in-process (no upload) and forwarded as
+    env_cls_bytes/env_metadata_bytes — never as blob paths — to each rollout."""
+    client = RolloutClient(api_key="k")
+
+    captured: list[dict[str, Any]] = []
+
+    def _fake_stream_rollout(**kwargs):
+        captured.append(kwargs)
+        return {"success": True}
+
+    monkeypatch.setattr(client, "stream_rollout", _fake_stream_rollout)
+
+    result = client.validate_examples(
+        [{"prompt": "hi"}, {"prompt": "yo"}],
+        env_class=_make_smoke_env(),
+        n=2,
+        verbose=False,
+    )
+
+    assert result.ok
+    assert len(captured) == 2
+    for kw in captured:
+        assert kw["env_cls_bytes"] is not None
+        assert kw["env_metadata_bytes"] is not None
+        assert kw["env_cls_path"] is None
+        assert kw["env_metadata_path"] is None
+
+
+def test_validate_examples_env_class_conflicts_with_explicit_env(monkeypatch):
+    """env_class is mutually exclusive with explicit paths/bytes."""
+    client = RolloutClient(api_key="k")
+    # Stub so a missing-guard regression can't accidentally hit the network.
+    monkeypatch.setattr(client, "stream_rollout", lambda **kw: {"success": True})
+
+    with pytest.raises(ValueError, match="env_class OR"):
+        client.validate_examples(
+            [{"prompt": "hi"}],
+            env_class=_make_smoke_env(),
+            env_cls_path="a",
+            env_metadata_path="b",
+            verbose=False,
+        )

--- a/tests/unit/platform/test_client.py
+++ b/tests/unit/platform/test_client.py
@@ -185,10 +185,11 @@ def test_print_launch_args_prints_each_spec(capsys):
 
 def test_rollout_client_picks_up_env_var_changes_after_import(monkeypatch):
     """S1 regression: setting CASTFORM_BASE_DOMAIN before constructing
-    RolloutClient must take effect (was frozen at import time)."""
+    RolloutClient must take effect (was frozen at import time). Rollouts route
+    through platform-service, so the base derives from platform_url()."""
     monkeypatch.setenv("CASTFORM_BASE_DOMAIN", "staging.castform.com")
     # Ensure the override env var doesn't pre-empt the base domain test.
-    monkeypatch.delenv("CASTFORM_ROLLOUT_URL", raising=False)
+    monkeypatch.delenv("CASTFORM_PLATFORM_URL", raising=False)
 
     client = RolloutClient(api_key="k")
     assert "staging.castform.com" in client._server_url
@@ -198,6 +199,40 @@ def test_rollout_client_explicit_server_url_wins(monkeypatch):
     monkeypatch.setenv("CASTFORM_BASE_DOMAIN", "staging.castform.com")
     client = RolloutClient(api_key="k", server_url="https://override.example/")
     assert client._server_url == "https://override.example"
+
+
+def test_rollout_client_targets_platform_service_v1(monkeypatch):
+    """Rollouts route through platform-service (the API-key gate): it validates
+    the sk_ key and mints an act_as JWT for rollout-service. The request path is
+    /v1/rollout/stream (platform mounts the proxy at /v1)."""
+    monkeypatch.setenv("CASTFORM_BASE_DOMAIN", "castform.com")
+    monkeypatch.delenv("CASTFORM_PLATFORM_URL", raising=False)
+
+    import httpx as httpx_mod
+
+    captured: dict[str, Any] = {}
+
+    class _CM:
+        def __enter__(self):
+            return httpx_mod.Response(503, content=b"stop before SSE loop")
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_stream(method, url, **kw):
+        captured["url"] = url
+        return _CM()
+
+    monkeypatch.setattr(httpx_mod, "stream", _fake_stream)
+
+    client = RolloutClient(api_key="k")
+    with pytest.raises(RolloutServerError):
+        client.stream_rollout(
+            raw_example={"prompt": "hi"},
+            env_cls_path="a", env_metadata_path="b",
+        )
+
+    assert captured["url"] == "https://api.castform.com/v1/rollout/stream"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/platform/test_client.py
+++ b/tests/unit/platform/test_client.py
@@ -324,6 +324,21 @@ def test_stream_rollout_raises_authentication_error_on_401(monkeypatch):
     assert exc_info.value.status_code == 401
 
 
+def test_stream_rollout_raises_authentication_error_on_403(monkeypatch):
+    """platform-service's optionalAuth gate rejects a bad/expired key as 403
+    ('sign in to run rollouts'), not 401 — surface it as an auth error too."""
+    monkeypatch.setenv("CASTFORM_BASE_DOMAIN", "castform.com")
+    _stream_with_status(monkeypatch, 403, b"Demo mode is disabled")
+
+    client = RolloutClient(api_key="bad")
+    with pytest.raises(AuthenticationError) as exc_info:
+        client.stream_rollout(
+            raw_example={"prompt": "hi"},
+            env_cls_path="a", env_metadata_path="b",
+        )
+    assert exc_info.value.status_code == 403
+
+
 def test_stream_rollout_raises_rollout_not_found_on_404(monkeypatch):
     monkeypatch.setenv("CASTFORM_BASE_DOMAIN", "castform.com")
     _stream_with_status(monkeypatch, 404, b"no such endpoint")


### PR DESCRIPTION
**Superproject PR (platform-service side + this pin bump):** castform-ai/castform#98 — merge this first, then #98 re-pins to the merge SHA.

## Why

`RolloutClient.validate_examples` (and `stream_rollout`) held a platform API key but hit **rollout-service** (`autobots.<domain>`) directly. rollout-service's auth only accepts auth-service-minted EdDSA JWTs — never a raw platform key — so every call failed with **401**.

## What

**Route through the platform-service gate.**
`RolloutClient` now targets `config.platform_url()` + `/v1/rollout/stream` (was `config.rollout_url()` + `/rollout/stream`). platform-service validates the `sk_`/`cf_` key and mints a short-lived act_as JWT that rollout-service accepts. The proxy that forwards **env bytes mode** (`env_cls_bytes`/`env_metadata_bytes`) lives in #96.

**`validate_examples(env_class=...)`.**
New `env_class=` arg (plus `constructor_args` / `pip_dependencies` / `local_modules`) bundles the env to bytes in-process via `dump_bundle`, so a launch flow can smoke-test an env **before** uploading anything. Mutually exclusive with explicit paths/bytes. This is what lets codegen validate-before-upload (a broken env fails fast without first paying to push the full dataset).

**Cleanup carried in this PR:**
- Drop the now-orphaned `config.rollout_url()` / `CASTFORM_ROLLOUT_URL` (RolloutClient was its only caller) + the stale `CLAUDE.md` docs.
- Map the gate's **403** ("sign in to run rollouts") → `AuthenticationError` in `stream_rollout`, which previously only typed 401 — so a bad/expired key stays a typed auth error.

## Verification

- `uv run pytest tests/unit/platform/test_client.py` — 19 passed (incl. `test_rollout_client_targets_platform_service_v1`, `test_validate_examples_env_class_*`, `test_stream_rollout_raises_authentication_error_on_403`).
- `uv run ruff check src/` — no new findings.
- Verified end-to-end against a local stack: `validate_examples` ran two rollouts through platform-service → rollout-service, both `success`.
