### PR TITLE
fix: Arrow-safe trace serialization + structured content normalization

### DIFF
--- a/src/benchmax/traces/__init__.py
+++ b/src/benchmax/traces/__init__.py
@@ -1,3 +1,9 @@
+from .adapter import normalize_message, normalize_structured_message
 from .pipeline import TracesPipeline, ImportanceFilterConfig
 
-__all__ = ["TracesPipeline", "ImportanceFilterConfig"]
+__all__ = [
+    "TracesPipeline",
+    "ImportanceFilterConfig",
+    "normalize_message",
+    "normalize_structured_message",
+]

--- a/src/benchmax/traces/__init__.py
+++ b/src/benchmax/traces/__init__.py
@@ -1,9 +1,8 @@
-from .adapter import normalize_message, normalize_structured_message
+from .adapter import normalize_message
 from .pipeline import TracesPipeline, ImportanceFilterConfig
 
 __all__ = [
     "TracesPipeline",
     "ImportanceFilterConfig",
     "normalize_message",
-    "normalize_structured_message",
 ]

--- a/src/benchmax/traces/adapter.py
+++ b/src/benchmax/traces/adapter.py
@@ -179,7 +179,7 @@ class NormalizedTrace:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> NormalizedTrace:
         """Reconstruct from a dict produced by ``to_dict``."""
-        messages = [_message_from_dict(m) for m in data.get("messages", [])]
+        messages = [normalize_message(m) for m in data.get("messages", [])]
         return cls(
             id=data["id"],
             messages=messages,
@@ -272,32 +272,8 @@ class TraceAdapter(Protocol):
 # ---------------------------------------------------------------------------
 
 
-def _message_from_dict(d: dict[str, Any]) -> TraceMessage:
-    tool_calls = None
-    if "tool_calls" in d and d["tool_calls"]:
-        tool_calls = [
-            ToolCall(
-                name=tc.get("name", ""),
-                arguments=tc.get("arguments", "{}"),
-                id=tc.get("id"),
-            )
-            for tc in d["tool_calls"]
-        ]
-    return TraceMessage(
-        role=d["role"],
-        content=d.get("content", ""),
-        tool_calls=tool_calls,
-        tool_call_id=d.get("tool_call_id"),
-        name=d.get("name"),
-    )
-
-
-# ---------------------------------------------------------------------------
-# Message format normalizers
-# ---------------------------------------------------------------------------
-
-
 def _ensure_json_string(value: Any) -> str:
+    """Coerce to a JSON string. Dicts get serialised, strings pass through."""
     if isinstance(value, str):
         return value
     if isinstance(value, dict):
@@ -305,42 +281,69 @@ def _ensure_json_string(value: Any) -> str:
     return str(value)
 
 
-def _is_structured_content(msg: dict[str, Any]) -> bool:
-    """True if ``content`` is a list of typed blocks (openclaw / Anthropic style)."""
-    content = msg.get("content")
-    return (
-        isinstance(content, list)
-        and len(content) > 0
-        and isinstance(content[0], dict)
-        and "type" in content[0]
-    )
+def _extract_tool_calls(msg: dict[str, Any]) -> list[ToolCall]:
+    """Extract tool calls from any format.
 
-
-def normalize_structured_message(msg: dict[str, Any]) -> TraceMessage:
-    """Normalize a message with structured content blocks to ``TraceMessage``.
-
-    Handles the format used by openclaw and Anthropic-style agents where
-    ``content`` is a list of typed blocks::
-
-        {type: "text", text: "..."}
-        {type: "toolCall", name: "...", arguments: "...", id: "..."}
-        {type: "toolResult", ...}
-
-    And ``role`` may be ``"toolResult"`` (normalized to ``"tool"``).
-
-    Any provider adapter can call this when it encounters structured-content
-    messages — it's not tied to a specific provider.
+    Handles:
+      - OpenAI flat: ``tool_calls: [{name, arguments, id}]``
+      - OpenAI nested: ``tool_calls: [{id, type, function: {name, arguments}}]``
+      - Legacy single: ``function: {name, arguments}``
     """
-    role = msg.get("role", "")
-    content = msg.get("content", "")
+    raw = msg.get("tool_calls")
+    if raw and isinstance(raw, list):
+        calls = []
+        for tc in raw:
+            if not isinstance(tc, dict):
+                continue
+            func = tc.get("function")
+            if isinstance(func, dict) and "name" in func:
+                calls.append(ToolCall(
+                    name=func["name"],
+                    arguments=_ensure_json_string(func.get("arguments", "{}")),
+                    id=tc.get("id"),
+                ))
+            elif "name" in tc:
+                calls.append(ToolCall(
+                    name=tc["name"],
+                    arguments=_ensure_json_string(tc.get("arguments", "{}")),
+                    id=tc.get("id"),
+                ))
+        if calls:
+            return calls
 
+    func = msg.get("function")
+    if isinstance(func, dict) and "name" in func:
+        return [ToolCall(
+            name=func["name"],
+            arguments=_ensure_json_string(func.get("arguments", "{}")),
+            id=msg.get("id"),
+        )]
+
+    return []
+
+
+def normalize_message(msg: dict[str, Any]) -> TraceMessage:
+    """Normalize any message dict into a ``TraceMessage``.
+
+    Auto-detects and handles:
+      - Structured content blocks (openclaw / Anthropic): ``content``
+        is a list of ``{type: "text"}``, ``{type: "toolCall"}`` dicts
+      - Flat OpenAI format: ``content`` is a string, ``tool_calls`` field
+      - Nested OpenAI format: ``tool_calls[].function.{name, arguments}``
+      - Legacy format: ``function: {name, arguments}``
+      - Role aliases: ``toolResult`` → ``tool``
+      - Field aliases: ``toolCallId`` → ``tool_call_id``,
+        ``toolName`` → ``name``
+    """
+    role = msg.get("role") or "assistant"
     if role == "toolResult":
         role = "tool"
 
-    text_parts: list[str] = []
+    content = msg.get("content", "")
     tool_calls: list[ToolCall] = []
 
-    if isinstance(content, list):
+    if isinstance(content, list) and content and isinstance(content[0], dict) and "type" in content[0]:
+        text_parts: list[str] = []
         for block in content:
             if not isinstance(block, dict):
                 continue
@@ -355,7 +358,11 @@ def normalize_structured_message(msg: dict[str, Any]) -> TraceMessage:
                 ))
         content = "\n".join(text_parts) if text_parts else ""
     else:
-        content = str(content) if content else ""
+        if content is None:
+            content = ""
+        elif not isinstance(content, str):
+            content = str(content)
+        tool_calls = _extract_tool_calls(msg)
 
     return TraceMessage(
         role=role,
@@ -364,15 +371,3 @@ def normalize_structured_message(msg: dict[str, Any]) -> TraceMessage:
         tool_call_id=msg.get("toolCallId") or msg.get("tool_call_id"),
         name=msg.get("toolName") or msg.get("name"),
     )
-
-
-def normalize_message(msg: dict[str, Any]) -> TraceMessage:
-    """Auto-detect message format and normalize to ``TraceMessage``.
-
-    Handles both structured-content (openclaw / Anthropic) and flat
-    (OpenAI) message formats. Provider adapters can call this instead
-    of implementing format detection themselves.
-    """
-    if _is_structured_content(msg):
-        return normalize_structured_message(msg)
-    return _message_from_dict(msg)

--- a/src/benchmax/traces/adapter.py
+++ b/src/benchmax/traces/adapter.py
@@ -90,7 +90,7 @@ def validate_provider_url(url: str) -> None:
         # temporarily unreachable or not yet provisioned.  We allow this
         # through — the actual HTTP request will fail with a clear error.
         # Note: this creates a small TOCTOU window where DNS rebinding
-        # could bypass validation, but practical risk is low in Modal.
+        # could bypass validation, but practical risk is low in sandboxed environments.
         return
     if addr.is_private or addr.is_reserved or addr.is_loopback or addr.is_link_local:
         raise ValueError(f"Provider URL resolves to private/reserved IP: {addr}")
@@ -135,9 +135,8 @@ class TraceMessage:
     def to_dict(self) -> dict[str, Any]:
         """Serialise to a JSON-compatible dict with structured tool_calls.
 
-        Used by the web-app wizard preview, trace rendering, and
-        intermediate pipeline storage. All fields are always present
-        with type-safe defaults (empty list / empty string, never None).
+        All fields are always present with type-safe defaults (empty
+        list / empty string, never None) for Arrow serialization safety.
         """
         d: dict[str, Any] = {"role": self.role, "content": self.content}
         d["tool_calls"] = (
@@ -163,7 +162,7 @@ class NormalizedTrace:
     errors: list[str] | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialise for JSON transport (e.g. Modal ↔ wizard)."""
+        """Serialise for JSON transport."""
         d: dict[str, Any] = {
             "id": self.id,
             "messages": [m.to_dict() for m in self.messages],

--- a/src/benchmax/traces/adapter.py
+++ b/src/benchmax/traces/adapter.py
@@ -133,21 +133,22 @@ class TraceMessage:
     name: str | None = None  # tool name for role="tool"
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialise to a JSON-compatible dict.
+        """Serialise to a JSON-compatible dict with structured tool_calls.
 
-        Always includes all fields (even when None) so that JSONL output
-        has a consistent schema — HuggingFace ``load_dataset`` fails on
-        rows with inconsistent keys.
+        Used by the web-app wizard preview, trace rendering, and
+        intermediate pipeline storage. All fields are always present
+        with type-safe defaults (empty list / empty string, never None).
         """
         d: dict[str, Any] = {"role": self.role, "content": self.content}
         d["tool_calls"] = (
-            [{"name": tc.name, "arguments": tc.arguments, "id": tc.id} for tc in self.tool_calls]
+            [{"name": tc.name, "arguments": tc.arguments, "id": tc.id or ""} for tc in self.tool_calls]
             if self.tool_calls
-            else None
+            else []
         )
-        d["tool_call_id"] = self.tool_call_id
-        d["name"] = self.name
+        d["tool_call_id"] = self.tool_call_id or ""
+        d["name"] = self.name or ""
         return d
+
 
 
 @dataclass(frozen=True)
@@ -289,3 +290,89 @@ def _message_from_dict(d: dict[str, Any]) -> TraceMessage:
         tool_call_id=d.get("tool_call_id"),
         name=d.get("name"),
     )
+
+
+# ---------------------------------------------------------------------------
+# Message format normalizers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_json_string(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return json.dumps(value)
+    return str(value)
+
+
+def _is_structured_content(msg: dict[str, Any]) -> bool:
+    """True if ``content`` is a list of typed blocks (openclaw / Anthropic style)."""
+    content = msg.get("content")
+    return (
+        isinstance(content, list)
+        and len(content) > 0
+        and isinstance(content[0], dict)
+        and "type" in content[0]
+    )
+
+
+def normalize_structured_message(msg: dict[str, Any]) -> TraceMessage:
+    """Normalize a message with structured content blocks to ``TraceMessage``.
+
+    Handles the format used by openclaw and Anthropic-style agents where
+    ``content`` is a list of typed blocks::
+
+        {type: "text", text: "..."}
+        {type: "toolCall", name: "...", arguments: "...", id: "..."}
+        {type: "toolResult", ...}
+
+    And ``role`` may be ``"toolResult"`` (normalized to ``"tool"``).
+
+    Any provider adapter can call this when it encounters structured-content
+    messages — it's not tied to a specific provider.
+    """
+    role = msg.get("role", "")
+    content = msg.get("content", "")
+
+    if role == "toolResult":
+        role = "tool"
+
+    text_parts: list[str] = []
+    tool_calls: list[ToolCall] = []
+
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "")
+            if btype == "text":
+                text_parts.append(block.get("text", ""))
+            elif btype == "toolCall":
+                tool_calls.append(ToolCall(
+                    name=block.get("name", ""),
+                    arguments=_ensure_json_string(block.get("arguments", "{}")),
+                    id=block.get("id"),
+                ))
+        content = "\n".join(text_parts) if text_parts else ""
+    else:
+        content = str(content) if content else ""
+
+    return TraceMessage(
+        role=role,
+        content=content,
+        tool_calls=tool_calls if tool_calls else None,
+        tool_call_id=msg.get("toolCallId") or msg.get("tool_call_id"),
+        name=msg.get("toolName") or msg.get("name"),
+    )
+
+
+def normalize_message(msg: dict[str, Any]) -> TraceMessage:
+    """Auto-detect message format and normalize to ``TraceMessage``.
+
+    Handles both structured-content (openclaw / Anthropic) and flat
+    (OpenAI) message formats. Provider adapters can call this instead
+    of implementing format detection themselves.
+    """
+    if _is_structured_content(msg):
+        return normalize_structured_message(msg)
+    return _message_from_dict(msg)

--- a/src/benchmax/traces/braintrust/message_extraction.py
+++ b/src/benchmax/traces/braintrust/message_extraction.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from benchmax.traces.adapter import ToolCall, TraceMessage
+from benchmax.traces.adapter import ToolCall, TraceMessage, normalize_message, _is_structured_content
 
 
 def extract_messages(trace: dict[str, Any]) -> list[TraceMessage]:
@@ -185,13 +185,15 @@ def _parse_output(output_data: Any) -> list[TraceMessage]:
 
 
 def _parse_msg(msg: dict[str, Any]) -> TraceMessage:
-    """Parse a single message dict, normalising tool_calls format variations.
+    """Parse a single message dict, handling both OpenAI and structured-content formats.
 
-    Braintrust tool_calls can appear as:
-    - ``msg["tool_calls"]`` — OpenAI format
-    - ``msg["function"]`` — older format
-    - ``msg["tool_calls"][i]["function"]`` — nested format
+    Delegates to ``normalize_message`` for structured-content messages
+    (openclaw / Anthropic style where ``content`` is a list of typed blocks).
+    Otherwise normalises tool_calls format variations directly.
     """
+    if _is_structured_content(msg):
+        return normalize_message(msg)
+
     role = msg.get("role", "assistant")
     content = msg.get("content", "")
     if content is None:

--- a/src/benchmax/traces/braintrust/message_extraction.py
+++ b/src/benchmax/traces/braintrust/message_extraction.py
@@ -7,10 +7,9 @@ Converts raw Braintrust span trees into flat ``TraceMessage`` lists using a
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
-from benchmax.traces.adapter import ToolCall, TraceMessage, normalize_message, _is_structured_content
+from benchmax.traces.adapter import TraceMessage, normalize_message
 
 
 def extract_messages(trace: dict[str, Any]) -> list[TraceMessage]:
@@ -185,87 +184,13 @@ def _parse_output(output_data: Any) -> list[TraceMessage]:
 
 
 def _parse_msg(msg: dict[str, Any]) -> TraceMessage:
-    """Parse a single message dict, handling both OpenAI and structured-content formats.
+    """Parse a single message dict into a TraceMessage.
 
-    Delegates to ``normalize_message`` for structured-content messages
-    (openclaw / Anthropic style where ``content`` is a list of typed blocks).
-    Otherwise normalises tool_calls format variations directly.
+    Delegates entirely to ``normalize_message`` which handles all format
+    variations (structured content blocks, OpenAI flat/nested, legacy
+    function calls).
     """
-    if _is_structured_content(msg):
-        return normalize_message(msg)
-
-    role = msg.get("role", "assistant")
-    content = msg.get("content", "")
-    if content is None:
-        content = ""
-    content = str(content)
-
-    tool_calls = _normalize_tool_calls(msg)
-    tool_call_id = msg.get("tool_call_id")
-    name = msg.get("name")
-
-    return TraceMessage(
-        role=role,
-        content=content,
-        tool_calls=tool_calls if tool_calls else None,
-        tool_call_id=tool_call_id,
-        name=name,
-    )
-
-
-def _normalize_tool_calls(msg: dict[str, Any]) -> list[ToolCall]:
-    """Extract tool calls from a message, handling format variations."""
-    raw_calls = msg.get("tool_calls")
-    if not raw_calls:
-        # Try older "function" format
-        func = msg.get("function")
-        if func and isinstance(func, dict):
-            return [
-                ToolCall(
-                    name=func.get("name", ""),
-                    arguments=_ensure_json_string(func.get("arguments", "{}")),
-                    id=msg.get("id"),
-                )
-            ]
-        return []
-
-    if not isinstance(raw_calls, list):
-        return []
-
-    result: list[ToolCall] = []
-    for tc in raw_calls:
-        if not isinstance(tc, dict):
-            continue
-        # Handle nested function format: {"function": {"name": ..., "arguments": ...}}
-        func = tc.get("function", {})
-        if isinstance(func, dict) and "name" in func:
-            result.append(
-                ToolCall(
-                    name=func["name"],
-                    arguments=_ensure_json_string(func.get("arguments", "{}")),
-                    id=tc.get("id"),
-                )
-            )
-        elif "name" in tc:
-            # Direct format: {"name": ..., "arguments": ...}
-            result.append(
-                ToolCall(
-                    name=tc["name"],
-                    arguments=_ensure_json_string(tc.get("arguments", "{}")),
-                    id=tc.get("id"),
-                )
-            )
-
-    return result
-
-
-def _ensure_json_string(value: Any) -> str:
-    """Ensure *value* is a JSON string.  If it's a dict, serialise it."""
-    if isinstance(value, str):
-        return value
-    if isinstance(value, dict):
-        return json.dumps(value)
-    return str(value)
+    return normalize_message(msg)
 
 
 def _extract_tool_response(child: dict[str, Any]) -> TraceMessage | None:

--- a/src/benchmax/traces/processing.py
+++ b/src/benchmax/traces/processing.py
@@ -40,7 +40,7 @@ def detect_system_prompt(
     """Scan *all* traces for ``role=="system"`` messages.
 
     Returns the most common system prompt.  If multiple distinct prompts are
-    found, ``variants`` contains the alternatives so the wizard can surface a
+    found, ``variants`` contains the alternatives so callers can surface a
     warning.
     """
     prompts: list[str] = []
@@ -117,9 +117,9 @@ class TrainingExample:
     - ``prompt_messages`` / ``completion_messages`` — structured
       ``TraceMessage`` lists.  These are the authoritative training data,
       used by ``to_jsonl_dict()`` and consumed by ``dataset_preprocess``.
-    - ``prompt`` / ``ground_truth`` — human-readable summaries for display
-      in the wizard preview.  These are lossy (tool call arguments are
-      flattened to text) and should NOT be used for training.
+    - ``prompt`` / ``ground_truth`` — human-readable summaries for display.
+      These are lossy (tool call arguments are flattened to text) and
+      should NOT be used for training.
     """
 
     prompt_messages: list[TraceMessage]
@@ -331,7 +331,7 @@ def apply_heuristic_filters(
     """Filter examples using deterministic heuristics.
 
     Returns ``FilterResult`` with both kept and dropped examples (with
-    reasons) so the wizard can show what was filtered and why.
+    reasons) so callers can show what was filtered and why.
     """
     kept: list[TrainingExample] = []
     dropped: list[tuple[TrainingExample, DropReason]] = []

--- a/src/benchmax/traces/processing.py
+++ b/src/benchmax/traces/processing.py
@@ -167,28 +167,28 @@ class TrainingExample:
     def to_jsonl_dict(self) -> dict[str, Any]:
         """Serialise to the JSONL schema consumed by ``dataset_preprocess``.
 
-        The trainer expects structured message dicts (not human-readable
-        strings).  ``prompt`` is a list of message dicts, ``ground_truth``
-        is the completion message dict.  Metadata goes inside
-        ``init_rollout_args`` so it's available in ``compute_reward()``.
+        Both ``prompt_messages`` and ``ground_truth`` use ``to_dict()``
+        with structured ``tool_calls`` (arguments as JSON strings). The
+        trainer handles Arrow compatibility at template time by parsing
+        argument strings to dicts before ``apply_chat_template``.
 
         Schema::
 
             {
-                "prompt": list[dict],        # chat messages before this turn
-                "ground_truth": dict,         # the assistant completion
+                "prompt_messages": list[{role, content, tool_calls, ...}],
+                "ground_truth": {role, content, tool_calls, ...},
                 "init_rollout_args": {
                     "trace_id": str,
                     "turn_index": int,
                     "total_messages": int,
                     "scores": dict[str, float],
-                    "raw_prompt": str,        # human-readable for judge context
+                    "raw_prompt": str,
                 },
             }
         """
         gt = self.completion_messages[0].to_dict() if self.completion_messages else {}
         return {
-            "prompt": [m.to_dict() for m in self.prompt_messages],
+            "prompt_messages": [m.to_dict() for m in self.prompt_messages],
             "ground_truth": gt,
             "init_rollout_args": {
                 "trace_id": self.trace_id,


### PR DESCRIPTION
## Summary

- `TraceMessage.to_dict()` returns `[]`/`""` instead of `None` for optional fields, fixing `pyarrow.lib.ArrowInvalid: cannot mix list and non-list` when HF datasets serializes rows with inconsistent types.
- Single `normalize_message()` handles all message format variations: structured content blocks (openclaw/Anthropic), flat OpenAI, nested OpenAI, and legacy `function` field. Also normalizes role aliases (`toolResult`→`tool`) and field aliases (`toolCallId`→`tool_call_id`).
- `_extract_tool_calls()` consolidates all tool call parsing (flat, nested, legacy) into one function in `adapter.py`.
- Braintrust adapter's `_parse_msg` now delegates entirely to `normalize_message` — no duplicate parsing logic (-81 lines).
- `to_jsonl_dict()` schema: `prompt` key renamed to `prompt_messages` for consistency.

## Context

The Arrow crash affects any dataset where some messages have `tool_calls: [{...}]` and others have `tool_calls: None`. Previously, tool call parsing was duplicated between `adapter.py` and `braintrust/message_extraction.py`, each handling a subset of formats. Now there's one code path for all formats.

## Test plan

- [x] Flat OpenAI, nested OpenAI, legacy function, structured content blocks all normalize correctly
- [x] `to_dict()` returns `list` for `tool_calls`, `str` for `tool_call_id`/`name` (never `None`)
- [x] Braintrust `_parse_msg` delegates to `normalize_message` for all formats
- [x] E2E: fetch from all Braintrust projects → `build_training_examples` → JSONL → `Dataset.from_json` → `.map()` — no Arrow crash