### PR TITLE
fix(example_id): drop null-valued dict keys in canonical hash (v:2 -> v:3)

### DIFF
--- a/src/benchmax/envs/example_id.py
+++ b/src/benchmax/envs/example_id.py
@@ -78,9 +78,6 @@ def _normalize(v: Any) -> Any:
                     f"dict keys must be str for canonical hashing; got {type(k).__name__}"
                 )
             nx = _normalize(x)
-            # Drop null-valued keys (v:3): Arrow fills schema-unified columns
-            # with null where a row omits a key, json.loads omits it entirely;
-            # stripping makes both loaders agree. List nulls are kept (above).
             if nx is None:
                 continue
             out[k] = nx

--- a/src/benchmax/envs/example_id.py
+++ b/src/benchmax/envs/example_id.py
@@ -1,24 +1,23 @@
 """Canonical example identity.
 
 ``canonical_example_id(prompt_messages, task)`` returns a SHA-256 hex digest
-that is stable across processes and languages: a TypeScript port lives in
-``platform-service/src/lib/canonical-example-id.ts`` and is exercised by a
-parity test.
+stable across processes. Identity is computed only here, in Python — both the
+trainer and rollout-service hash via this module.
 
-Determinism is achieved by:
-- normalizing numeric values so JSON output matches between Python and JS
-  (JS has no int/float distinction; integer-valued floats are coerced to int,
-  -0.0 to 0; NaN/Inf are rejected).
-- rejecting values whose JSON serialization diverges between Python and JS:
-  non-string dict keys, integers outside JS ``Number.MAX_SAFE_INTEGER``,
-  byte strings, lone surrogates, and unknown types.
-- emitting canonical JSON with sorted keys, no whitespace, and no ASCII
-  escaping (modern JSON.stringify also preserves non-ASCII).
+Normalization keeps the digest loader-independent:
+- integer-valued floats → int, -0.0 → 0; NaN/Inf rejected.
+- dict keys whose value is ``None`` are dropped, so a key absent in one loader
+  and present-but-null in another (Arrow schema-unification) hashes the same;
+  nulls *inside lists* are kept (length/order are identity).
+- ambiguous values rejected: non-str dict keys, ints beyond
+  ``Number.MAX_SAFE_INTEGER``, byte strings, lone surrogates, unknown types.
+- canonical JSON: sorted keys, no whitespace, no ASCII escaping.
 
-The hash is computed over ``{"v": 2, "prompt_messages": ..., "task": ...}``.
-v:2 bump went together with the ``seed_messages`` → ``prompt_messages``
-field rename in 2026-05; v:1 hashes are obsolete.
+Payload tag ``v:3``. History: v:1→v:2 = the 2026-05 ``seed_messages`` →
+``prompt_messages`` rename; v:2→v:3 = drop null-valued dict keys (loader skew).
+Older hashes are obsolete.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -78,7 +77,13 @@ def _normalize(v: Any) -> Any:
                 raise ValueError(
                     f"dict keys must be str for canonical hashing; got {type(k).__name__}"
                 )
-            out[k] = _normalize(x)
+            nx = _normalize(x)
+            # Drop null-valued keys (v:3): Arrow fills schema-unified columns
+            # with null where a row omits a key, json.loads omits it entirely;
+            # stripping makes both loaders agree. List nulls are kept (above).
+            if nx is None:
+                continue
+            out[k] = nx
         return out
     raise ValueError(
         f"type {type(v).__name__} is not JSON-canonicalizable; "
@@ -90,7 +95,7 @@ def canonical_example_id(
     prompt_messages: Messages,
     task: dict[str, Any] | None,
 ) -> str:
-    payload = {"v": 2, "prompt_messages": prompt_messages, "task": task}
+    payload = {"v": 3, "prompt_messages": prompt_messages, "task": task}
     serialized = json.dumps(
         _normalize(payload),
         sort_keys=True,

--- a/tests/unit/envs/test_example_id.py
+++ b/tests/unit/envs/test_example_id.py
@@ -1,15 +1,15 @@
 """Golden-hash tests for ``canonical_example_id``.
 
-These pin the byte-level output of the hash function. The same expected
-hashes are checked by the TypeScript port's parity test in
-``platform-service``. If you change any expected value here, you MUST
-update both sides and bump the ``v`` payload tag in
-``benchmax.envs.example_id`` — existing rollouts in the database key on the
-old hash and would silently misgroup.
+These pin the byte-level hash output. Changing any expected value REQUIRES
+bumping the ``v`` payload tag in ``benchmax.envs.example_id`` — existing
+rollouts key on the old hash and would silently misgroup.
 """
+
 from __future__ import annotations
 
+import json
 import math
+from pathlib import Path
 
 import pytest
 
@@ -22,7 +22,7 @@ GOLDEN_CASES = [
         "bare_single_user",
         [{"role": "user", "content": "Hello"}],
         None,
-        "04d553add09f1f28f35139014176fe64cf3cbbecb0de22e99370c49b3e35088b",
+        "93a9b71ec42f0fcce151bbdc71ece1fe86bdccedd6090a28b2c81f307115bc36",
     ),
     (
         "multi_turn",
@@ -33,25 +33,25 @@ GOLDEN_CASES = [
             {"role": "user", "content": "Solve 2+2"},
         ],
         {"ground_truth": "4"},
-        "dcf4e5fcce040c41d527b27c3c6e9c4f1df0745c7f48c3f11b0e21a4500ea5fa",
+        "b418bf2def5cef378a7f30ab864c623dbdf211934c4d224612676ca73c3b3e2a",
     ),
     (
         "task_none",
         [{"role": "user", "content": "x"}],
         None,
-        "e4d534ac3d401153ec029cd68bae30cdcbe03314cc69296ffc48ce4458dddff8",
+        "8871e98f9164dbbfd053c9bc2fc8a2f98abcd5633914199fd31db11bb64113ba",
     ),
     (
         "task_empty_dict",
         [{"role": "user", "content": "x"}],
         {},
-        "5d6763943667224756336ff9ffc2eff2e9267ac8a815745db54a75373073134a",
+        "bd1bc06ed235f44cf956940931610ce5059b437b607a4160585cede249eac63a",
     ),
     (
         "unicode",
         [{"role": "user", "content": "你好 émoji 🚀"}],
         {"locale": "zh-CN"},
-        "d1f6a202e088221a60711f105c02e8cfce9da69c14ef479efcbf7416d63280b9",
+        "d824c3a7c891e80bc7420c9eb9c7d90e62b95b8acb01e1dcfc3f11cd527a56c1",
     ),
     (
         "nested_task",
@@ -62,7 +62,7 @@ GOLDEN_CASES = [
             "max_steps": 5,
             "scoring": {"weights": {"correctness": 1, "format": 0}},
         },
-        "cee4165ba98d0c7b7ac8b12ce2587bdad88e38ef63d2235a071423fb3968915d",
+        "48809c34889a18c84e323c495f33a726be7cfc71d6e863cb5d06513429bb2889",
     ),
 ]
 
@@ -85,6 +85,30 @@ def test_key_order_independent() -> None:
     assert a == b
 
 
+def test_null_dict_key_dropped() -> None:
+    """v:3: a None-valued key hashes the same as the key being absent."""
+    msg = [{"role": "user", "content": "q"}]
+    assert canonical_example_id(msg, {"x": None}) == canonical_example_id(msg, {})
+    assert canonical_example_id(msg, {"a": 1, "b": None}) == canonical_example_id(
+        msg, {"a": 1}
+    )
+    assert canonical_example_id(
+        msg, {"m": {"h2": "H", "h3": None}}
+    ) == canonical_example_id(msg, {"m": {"h2": "H"}})
+
+
+def test_list_nulls_preserved() -> None:
+    """Nulls inside lists are identity-bearing — only dict keys are dropped."""
+    msg = [{"role": "user", "content": "q"}]
+    assert canonical_example_id(msg, {"x": [1, None, 3]}) != canonical_example_id(
+        msg, {"x": [1, 3]}
+    )
+    # nulls are still stripped within dict elements of a list
+    assert canonical_example_id(
+        msg, {"x": [{"a": 1, "b": None}]}
+    ) == canonical_example_id(msg, {"x": [{"a": 1}]})
+
+
 def test_int_vs_float_normalized() -> None:
     """Integer-valued floats hash the same as ints (JS Number has no int/float
     distinction, so the algorithm normalizes both sides)."""
@@ -96,7 +120,9 @@ def test_bool_not_int() -> None:
     """Booleans must stay as JSON booleans, not be coerced to 0/1."""
     msg = [{"role": "user", "content": "q"}]
     assert canonical_example_id(msg, {"x": True}) != canonical_example_id(msg, {"x": 1})
-    assert canonical_example_id(msg, {"x": False}) != canonical_example_id(msg, {"x": 0})
+    assert canonical_example_id(msg, {"x": False}) != canonical_example_id(
+        msg, {"x": 0}
+    )
 
 
 def test_negative_zero_normalized() -> None:
@@ -162,3 +188,113 @@ def test_lone_surrogate_rejected() -> None:
     msg = [{"role": "user", "content": "q"}]
     with pytest.raises(ValueError, match="surrogates"):
         canonical_example_id(msg, {"x": "\ud800"})
+
+
+# Loader parity — the regression v:3 prevents. Trainer loads via HuggingFace
+# datasets (Arrow, schema-unifies columns → fills absent keys with null);
+# rollout-service uses json.loads (keeps only present keys). Pre-v:3 these
+# hashed the same example differently. These pin that they now agree.
+
+# Heterogeneous metadata: row 1 omits ``h3``, only the last carries ``h4`` —
+# Arrow injects ``h3: None`` AND ``h4: None`` into every other row.
+_HETEROGENEOUS_ROWS = [
+    {
+        "question": "q0",
+        "answer": "a0",
+        "reference_chunks": [
+            {
+                "id": "c0",
+                "metadata": {"h2": "H2a", "h3": "H3a", "file": "a.md", "index": 0},
+            }
+        ],
+    },
+    {
+        "question": "q1",
+        "answer": "a1",
+        "reference_chunks": [
+            {"id": "c1", "metadata": {"h2": "H2b", "file": "b.md", "index": 1}}
+        ],
+    },
+    {
+        "question": "q2",
+        "answer": "a2",
+        "reference_chunks": [
+            {
+                "id": "c2",
+                "metadata": {"index": 2, "file": "c.md", "h3": "H3c", "h2": "H2c"},
+            }
+        ],
+    },
+    {
+        "question": "q3",
+        "answer": "a3",
+        "reference_chunks": [
+            {
+                "id": "c3",
+                "metadata": {"h2": "H2d", "h3": None, "file": "d.md", "index": 3},
+            }
+        ],
+    },
+    {
+        "question": "q4",
+        "answer": "a4",
+        "reference_chunks": [
+            {
+                "id": "c5",
+                "metadata": {
+                    "h2": "H2g",
+                    "h3": "H3g",
+                    "h4": "H4g",
+                    "file": "g.md",
+                    "index": 6,
+                },
+            }
+        ],
+    },
+]
+
+
+def _project(row: dict) -> tuple[list, dict]:
+    """Mirror ``SearchEnv.dataset_preprocess`` — reference_chunks pass through."""
+    pm = [{"role": "user", "content": row.get("question", "")}]
+    task = {
+        "question": row.get("question", ""),
+        "ground_truth": row.get("answer"),
+        "reference_chunks": row.get("reference_chunks", []),
+    }
+    return pm, task
+
+
+def test_loader_parity_datasets_vs_json(tmp_path: Path) -> None:
+    """datasets/Arrow and json.loads yield identical ids per row (fails pre-v:3)."""
+    load_dataset = pytest.importorskip("datasets").load_dataset
+
+    path = tmp_path / "eval.jsonl"
+    path.write_text("\n".join(json.dumps(r) for r in _HETEROGENEOUS_ROWS) + "\n")
+
+    json_rows = [
+        json.loads(line) for line in path.read_text().splitlines() if line.strip()
+    ]
+    arrow_rows = [
+        dict(r) for r in load_dataset("json", data_files=str(path), split="train")
+    ]
+
+    assert len(json_rows) == len(arrow_rows) == len(_HETEROGENEOUS_ROWS)
+    for i, (jr, ar) in enumerate(zip(json_rows, arrow_rows)):
+        jpm, jt = _project(jr)
+        apm, at = _project(ar)
+        assert canonical_example_id(jpm, jt) == canonical_example_id(apm, at), (
+            f"row {i}: loaders disagree on canonical_example_id"
+        )
+
+
+def test_loader_mixed_numeric_string_column_fails_loud(tmp_path: Path) -> None:
+    """The residual Arrow coercion (number→string column) fails loud at load,
+    so it can't become a silent id skew like the null case did."""
+    datasets = pytest.importorskip("datasets")
+
+    path = tmp_path / "mixed.jsonl"
+    path.write_text(json.dumps({"x": 1}) + "\n" + json.dumps({"x": "a"}) + "\n")
+
+    with pytest.raises(Exception):  # noqa: B017 — pyarrow.lib.ArrowInvalid, surfaced via datasets
+        datasets.load_dataset("json", data_files=str(path), split="train")


### PR DESCRIPTION
## Problem
The trainer (HuggingFace `datasets`/Arrow) and rollout-service (`json.loads`)
load the same eval JSONL with different loaders. Arrow unifies the column
schema across all rows, injecting `null` for keys absent from a given row;
`json.loads` keeps only the keys each line has. `canonical_example_id` hashed
`{"k": null}` differently from `{}`, so the two services produced **different
`example_id`s for the same example** — the external-eval comparison join
silently dropped ~70% of rows (reference run `a10afe5d`).

## Fix
- `_normalize` drops dict entries whose value normalizes to `None`, so both
  loaders hash identically. Nulls *inside lists* are preserved (list
  length/order are identity).
- Bump payload tag `v:2 -> v:3` — **every `example_id` changes.**

## Tests
- Regenerated the 6 golden hashes.
- Added: null-key-dropped, list-nulls-preserved, a `datasets`-vs-`json.loads`
  loader-parity regression (fails pre-v:3), and a test pinning that the one
  residual Arrow coercion (number->string column) fails **loud** at load
  rather than skewing ids silently. Strip-nulls covers 100% of the silent
  loader-divergence modes.

## ⚠️ Deploy lockstep (critical)
benchmax is a shared dep of **both** trainer and rollout-service. A `v:3`
build must reach **both together** — a run evaluated across a `v:3` trainer
and a `v:2` rollout-service re-creates the divergence. After merge: bump the
`core/benchmax` submodule pointer in castform and redeploy both services in a
quiet window (no eval runs in flight).

## Follow-ups (not in this PR)
- Retroactive `v:3` backfill of existing rows (reconciles old runs).
- Detection: overlap-threshold recalibration in `external-eval-verify`,
  invariant audit, property-based loader-parity fuzz.
- Dead TS port deletion (separate castform PR).
