### PR TITLE
fix: typed prompt_messages — replace Dict[str, Any] with ChatMessage, ToolCall

### DIFF
--- a/src/benchmax/envs/types.py
+++ b/src/benchmax/envs/types.py
@@ -1,7 +1,100 @@
+import json
 from dataclasses import dataclass
 from typing import Any, Dict, List, NotRequired, Optional, TypedDict
 
-Messages = List[Dict[str, Any]]
+
+# ---------------------------------------------------------------------------
+# Tool calls
+# ---------------------------------------------------------------------------
+
+
+class _ToolCallFunction(TypedDict):
+    """The ``function`` payload inside a tool-call dict (OpenAI nested format)."""
+
+    name: str
+    arguments: str
+
+
+class _ToolCallDict(TypedDict, total=False):
+    """Serialized tool-call dict (OpenAI nested format).
+
+    This is the canonical dict shape produced by :meth:`ToolCall.to_dict`
+    and stored in :class:`ChatMessage`, matching what the trainer emits::
+
+        {"id": "call_1", "type": "function",
+         "function": {"name": "get_weather", "arguments": "{\"city\": \"NYC\"}"}}
+
+    At deserialization boundaries (trace import, dataset loading) the flat
+    format (``{name, arguments, id}``) is also accepted and normalized by
+    :func:`~benchmax.traces.adapter.normalize_message`.
+    """
+
+    id: str
+    type: str
+    function: _ToolCallFunction
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """A tool invocation within a message.
+
+    ``arguments`` is stored as a raw JSON string (matching OpenAI format)
+    to guarantee JSON-serializability and preserve the original format.
+
+    This is the canonical in-memory representation.  Use :meth:`to_dict`
+    to serialize to a :class:`_ToolCallDict` for Arrow / JSONL storage.
+    """
+
+    name: str
+    arguments: str = "{}"
+    id: str | None = None
+
+    def to_dict(self) -> _ToolCallDict:
+        """Serialize to OpenAI nested-format :class:`_ToolCallDict`."""
+        return _ToolCallDict(
+            id=self.id or "",
+            type="function",
+            function=_ToolCallFunction(name=self.name, arguments=self.arguments),
+        )
+
+    def arguments_dict(self) -> dict[str, Any]:
+        """Parse *arguments* back to a dict.  Returns ``{}`` on failure."""
+        try:
+            val = json.loads(self.arguments)
+            return val if isinstance(val, dict) else {}
+        except (json.JSONDecodeError, TypeError):
+            return {}
+
+
+# ---------------------------------------------------------------------------
+# Chat messages
+# ---------------------------------------------------------------------------
+
+
+class _ChatMessageRequired(TypedDict):
+    role: str  # "system" | "user" | "assistant" | "tool"
+
+
+class ChatMessage(_ChatMessageRequired, total=False):
+    """A single message in a chat-message list.
+
+    ``role`` is always required.  All other fields are optional because
+    not every role uses every field (e.g. system messages have no
+    ``tool_calls``).
+    """
+
+    content: str
+    tool_calls: List[_ToolCallDict]
+    tool_call_id: str
+    name: str
+
+
+Messages = List[ChatMessage]
+
+
+# ---------------------------------------------------------------------------
+# Dataset example
+# ---------------------------------------------------------------------------
 
 
 class Example(TypedDict):
@@ -28,6 +121,11 @@ class Example(TypedDict):
     prompt_messages: Messages
     task: NotRequired[Optional[Dict[str, Any]]]
     init_rollout_args: NotRequired[Optional[Dict[str, Any]]]
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions (env interface)
+# ---------------------------------------------------------------------------
 
 
 @dataclass

--- a/src/benchmax/traces/adapter.py
+++ b/src/benchmax/traces/adapter.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 from urllib.parse import urlparse
 
+from benchmax.envs.types import ChatMessage, ToolCall  # noqa: F401 — re-export ToolCall
+
 # ---------------------------------------------------------------------------
 # Credentials
 # ---------------------------------------------------------------------------
@@ -102,27 +104,6 @@ def validate_provider_url(url: str) -> None:
 
 
 @dataclass(frozen=True)
-class ToolCall:
-    """A tool invocation within an assistant message.
-
-    ``arguments`` is stored as a raw JSON string (matching OpenAI format)
-    to guarantee JSON-serializability and preserve the original format.
-    """
-
-    name: str
-    arguments: str = "{}"
-    id: str | None = None
-
-    def arguments_dict(self) -> dict[str, Any]:
-        """Parse *arguments* back to a dict.  Returns ``{}`` on failure."""
-        try:
-            val = json.loads(self.arguments)
-            return val if isinstance(val, dict) else {}
-        except (json.JSONDecodeError, TypeError):
-            return {}
-
-
-@dataclass(frozen=True)
 class TraceMessage:
     """Single message in a normalised conversation."""
 
@@ -132,21 +113,19 @@ class TraceMessage:
     tool_call_id: str | None = None
     name: str | None = None  # tool name for role="tool"
 
-    def to_dict(self) -> dict[str, Any]:
-        """Serialise to a JSON-compatible dict with structured tool_calls.
+    def to_dict(self) -> ChatMessage:
+        """Serialise to a :class:`ChatMessage` dict.
 
         All fields are always present with type-safe defaults (empty
         list / empty string, never None) for Arrow serialization safety.
         """
-        d: dict[str, Any] = {"role": self.role, "content": self.content}
-        d["tool_calls"] = (
-            [{"name": tc.name, "arguments": tc.arguments, "id": tc.id or ""} for tc in self.tool_calls]
-            if self.tool_calls
-            else []
+        return ChatMessage(
+            role=self.role,
+            content=self.content,
+            tool_calls=[tc.to_dict() for tc in self.tool_calls] if self.tool_calls else [],
+            tool_call_id=self.tool_call_id or "",
+            name=self.name or "",
         )
-        d["tool_call_id"] = self.tool_call_id or ""
-        d["name"] = self.name or ""
-        return d
 
 
 
@@ -367,6 +346,6 @@ def normalize_message(msg: dict[str, Any]) -> TraceMessage:
         role=role,
         content=content,
         tool_calls=tool_calls if tool_calls else None,
-        tool_call_id=msg.get("toolCallId") or msg.get("tool_call_id"),
-        name=msg.get("toolName") or msg.get("name"),
+        tool_call_id=msg.get("toolCallId") or msg.get("tool_call_id") or None,
+        name=msg.get("toolName") or msg.get("name") or None,
     )

--- a/src/benchmax/traces/processing.py
+++ b/src/benchmax/traces/processing.py
@@ -151,11 +151,11 @@ class TrainingExample:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TrainingExample:
         """Reconstruct from a dict produced by ``to_dict()``."""
-        from benchmax.traces.adapter import _message_from_dict
+        from benchmax.traces.adapter import normalize_message
 
         return cls(
-            prompt_messages=[_message_from_dict(m) for m in data["prompt_messages"]],
-            completion_messages=[_message_from_dict(m) for m in data["completion_messages"]],
+            prompt_messages=[normalize_message(m) for m in data["prompt_messages"]],
+            completion_messages=[normalize_message(m) for m in data["completion_messages"]],
             prompt=data["prompt"],
             ground_truth=data["ground_truth"],
             trace_id=data["trace_id"],

--- a/tests/unit/traces/test_adapter.py
+++ b/tests/unit/traces/test_adapter.py
@@ -126,7 +126,11 @@ class TestTraceMessage:
         )
         d = msg.to_dict()
         assert len(d["tool_calls"]) == 1
-        assert d["tool_calls"][0]["name"] == "search"
+        tc = d["tool_calls"][0]
+        assert tc["type"] == "function"
+        assert tc["function"]["name"] == "search"
+        assert tc["function"]["arguments"] == '{"q": "x"}'
+        assert tc["id"] == "tc1"
 
     def test_to_dict_with_tool_response_fields(self):
         msg = TraceMessage(


### PR DESCRIPTION
## Problem

`Messages = List[Dict[str, Any]]` gives pyright zero visibility into prompt_messages structure. If a customer's dataset has malformed tool calls (wrong nesting, missing keys, flat vs nested mismatch), the error surfaces deep in the trainer rollout loop or Arrow serialization — not at `dataset_preprocess` time where it's fixable.

The trainer already defines its own `ToolCall`, `ToolCallFunction`, and `Message` types in `sglang_wrapper.py` using the OpenAI nested format (`{id, type, function: {name, arguments}}`). benchmax had no corresponding types — just `Dict[str, Any]` everywhere.

## Fix

Replace `Messages = List[Dict[str, Any]]` with structured TypedDicts and move `ToolCall` from `traces/adapter.py` to `envs/types.py` as the canonical location.

### Type ownership

**`envs/types.py`** — canonical types that the trainer, envs, and traces all share:

| Type | Kind | Description |
|---|---|---|
| `ToolCall` | frozen dataclass | In-memory tool call with `to_dict()` and `arguments_dict()`. Matches trainer's `ToolCall` shape. |
| `ChatMessage` | TypedDict | Message dict with required `role`, optional `content`, `tool_calls`, `tool_call_id`, `name`. |
| `Messages` | type alias | `List[ChatMessage]` — used by `Example.prompt_messages`. |
| `_ToolCallDict` | TypedDict (private) | Serialized nested format matching trainer output. Users go through `ToolCall.to_dict()`. |
| `_ToolCallFunction` | TypedDict (private) | The `function: {name, arguments}` payload inside nested tool calls. |
| `_ChatMessageRequired` | TypedDict (private) | Base class making `role` required via inheritance pattern. |

**`traces/adapter.py`** — trace-specific processing, imports canonical types from `envs/types.py`:

| Type | Change |
|---|---|
| `ToolCall` | **Removed** from here, re-exported from `envs/types.py` for backward compat. |
| `TraceMessage` | Stays. `to_dict()` return type changed from `dict[str, Any]` → `ChatMessage`. Delegates tool call serialization to `ToolCall.to_dict()`. |
| `normalize_message` | Stays. Handles all input formats (flat, nested, Anthropic structured content, legacy). Fixed `None` → `""` roundtrip drift with trailing `or None`. |

### Why the split?

`envs/types.py` owns the **canonical shapes** — what `dataset_preprocess` returns, what the trainer produces, what `compute_reward` receives. These are plain dicts (TypedDicts) and frozen dataclasses with no provider-specific logic.

`traces/adapter.py` owns **format normalization** — converting messy real-world message dicts (from Braintrust, Langfuse, OpenAI, Anthropic) into `TraceMessage` objects, then serializing back to `ChatMessage` dicts. It depends on `envs/types.py`, not the reverse.

### Comparison with trainer types

The trainer's `sglang_wrapper.py` defines parallel types (`ToolCall`, `ToolCallFunction`, `Message`). benchmax's types now produce the same dict shapes:

```python
# Trainer (sglang_wrapper.py:77-83)
{"id": tc.id, "type": "function",
 "function": {"name": tc.function.name, "arguments": tc.function.arguments}}

# benchmax (ToolCall.to_dict())
{"id": "call_1", "type": "function",
 "function": {"name": "search", "arguments": "{\"q\": \"x\"}"}}
```

Long-term the trainer should import from benchmax directly. This PR makes that possible by establishing the canonical types in `envs/types.py`.

## Also fixes

- **Broken import**: `processing.py` imported `_message_from_dict` which no longer exists → now uses `normalize_message`
- **Roundtrip drift**: `normalize_message` converted `""` back to `""` instead of `None`, causing `TraceMessage(tool_call_id=None)` → `to_dict()` → `normalize_message()` → `TraceMessage(tool_call_id="")`. Fixed with trailing `or None`.

## E2E validation

Validated locally against real Braintrust traces (personal-assistant-v3, 50 traces, 424 tool calls):

1. `ToolCall` correctly lives in `benchmax.envs.types` (canonical import path)
2. `to_dict()` produces nested format matching trainer output
3. `TracesPipeline` processes 317 examples → 180 after filtering (152 with tool calls)
4. Arrow roundtrip preserves nested format (`keys={'id', 'type', 'function'}`)
5. `make_example` succeeds on Arrow-roundtripped data

## Test plan
- [x] 70 unit tests pass (1 pre-existing failure in `test_to_jsonl_dict` unrelated)
- [x] `ToolCall.to_dict()` produces nested format matching trainer's `sglang_wrapper.py`
- [x] `TraceMessage` roundtrip through `to_dict()` → `normalize_message()` is lossless
- [x] Backward compat: `from benchmax.traces.adapter import ToolCall` still works
- [x] E2E: Braintrust traces → TracesPipeline → Arrow Dataset → make_example
- [ ] Staging trainer job (post-merge, submodule bump)