### PR TITLE
fix: handle non-string ground_truth in rubric logging

### DIFF
--- a/src/benchmax/rubrics/rubric.py
+++ b/src/benchmax/rubrics/rubric.py
@@ -122,7 +122,7 @@ async def evaluate_single_rubric(
                 "│ llm_output   :\n%s\n"
                 "└──────────────────────────────────────────────────",
                 rubric.title,
-                (ground_truth or "").strip() or "(none)",
+                str(ground_truth or "").strip() or "(none)",
                 out["score"],
                 out["reasoning"],
                 content,
@@ -172,7 +172,7 @@ async def evaluate_rubric_ranking(
     if not nonempty:
         return {"scores": scores, "ranking": [], "reasoning": "All responses empty", "llm_output": ""}
 
-    use_gt = bool(ground_truth and ground_truth.strip())
+    use_gt = bool(ground_truth and str(ground_truth).strip())
     m = len(nonempty)
 
     if m == 1 and not use_gt:
@@ -275,7 +275,7 @@ async def evaluate_rubric_ranking(
                 "│ llm_output   :\n%s\n"
                 "└──────────────────────────────────────────────────",
                 rubric.title,
-                (ground_truth or "").strip() or "(none)",
+                str(ground_truth or "").strip() or "(none)",
                 ranking_fmt or "(empty)",
                 scores_fmt,
                 out["reasoning"],


### PR DESCRIPTION
## Problem

Rubric logging lines added in `2b751f9` call `.strip()` on `ground_truth` without `str()` wrapping. When `ground_truth` is a dict (e.g. completion_messages after Arrow roundtrip), every rubric evaluation hits `'dict' object has no attribute 'strip'`.

Scores still work (the exception is caught), but rubric debug logs are lost on every evaluation.

## Fix

Wrap with `str()` on lines 125, 175, and 278 — matching line 60 which already had it.

## Test plan
- [x] Verified the three `.strip()` callsites in `rubric.py`
- [x] No other files affected