### PR TITLE
fix(platform): validate blob-path segments in upload_training_run

### DIFF
--- a/src/benchmax/platform/training_run.py
+++ b/src/benchmax/platform/training_run.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -44,6 +45,24 @@ class UploadedTrainingRun:
     env_metadata_path: str
     train_dataset_path: str
     eval_dataset_path: str
+
+
+# Mirrors the platform's blob-path guard (isSafeBlobPath): the upload endpoint
+# rejects keys whose segments fall outside this charset, since a stray
+# `?`/`#`/space breaks the trainer's SAS-URL parsing downstream. Fail loud here
+# with an actionable message instead of letting the user hit an opaque 400.
+_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _validate_blob_path(path: str, *, source: str) -> None:
+    for seg in path.split("/"):
+        if not seg or seg in (".", "..") or not _SAFE_SEGMENT.fullmatch(seg):
+            raise ValueError(
+                f"Invalid storage path segment {seg!r} in {path!r} (from {source}). "
+                f"Path segments may contain only letters, digits, '.', '_', '-'. "
+                f"The platform rejects others (e.g. '?', '#', spaces) because they "
+                f"break blob-URL parsing. Use a run_name without such characters."
+            )
 
 
 def upload_training_run(
@@ -119,6 +138,11 @@ def upload_training_run(
             train_jsonl.encode() + eval_jsonl.encode()
         ).hexdigest()[:8]
         dataset_prefix = f"datasets/{run_name}/{dataset_hash}"
+
+    # Reject unsafe keys before uploading — covers both the run_name-derived
+    # defaults and any caller-supplied env_prefix/dataset_prefix override.
+    _validate_blob_path(env_prefix, source="env_prefix/run_name")
+    _validate_blob_path(dataset_prefix, source="dataset_prefix/run_name")
 
     with tempfile.TemporaryDirectory() as tmp:
         tmpdir = Path(tmp)

--- a/tests/unit/platform/test_experiment.py
+++ b/tests/unit/platform/test_experiment.py
@@ -215,6 +215,35 @@ def test_upload_training_run_requires_api_key_or_storage_client():
         )
 
 
+def test_upload_training_run_rejects_unsafe_run_name():
+    """A run_name with a URL-breaking char fails loud before any upload."""
+    storage = FakeStorageClient()
+    with pytest.raises(ValueError, match="Invalid storage path segment"):
+        upload_training_run(
+            env_class=MinimalEnv,
+            train_dataset=[{"a": 1}],
+            eval_dataset=[{"a": 1}],
+            run_name="rag-is-eval-fixed?",
+            storage_client=storage,  # type: ignore[arg-type]
+            local_modules=[_TEST_MODULE],
+        )
+    assert storage.uploads == []  # nothing uploaded
+
+
+def test_upload_training_run_rejects_unsafe_prefix_override():
+    storage = FakeStorageClient()
+    with pytest.raises(ValueError, match="Invalid storage path segment"):
+        upload_training_run(
+            env_class=MinimalEnv,
+            train_dataset=[],
+            eval_dataset=[],
+            run_name="ok",
+            env_prefix="custom/bad name/env",
+            storage_client=storage,  # type: ignore[arg-type]
+            local_modules=[_TEST_MODULE],
+        )
+
+
 def test_upload_training_run_passes_constructor_args_through_to_bundle():
     """constructor_args should reach the bundled metadata."""
     captured: dict[str, bytes] = {}


### PR DESCRIPTION
Reject run_name / env_prefix / dataset_prefix segments outside [A-Za-z0-9._-] before uploading, mirroring the platform's isSafeBlobPath guard. Fails loud with an actionable message instead of letting a stray '?'/'#'/space produce an opaque 400 from SAS-URL parsing downstream.