### PR TITLE
validate: check compute_group_reward server-side before launch

### DIFF
--- a/src/benchmax/platform/client.py
+++ b/src/benchmax/platform/client.py
@@ -74,10 +74,17 @@ class ValidationResult:
     """
 
     examples: list[ExampleValidation]
+    # Outcome of the compute_group_reward contract check, run on the real
+    # smoke-rollout transcripts. None when the env has no group reward, the
+    # env class wasn't supplied, or the check was skipped (deps not installed
+    # locally — it runs on the trainer instead). Its index is -1.
+    group_reward: ExampleValidation | None = None
 
     @property
     def ok(self) -> bool:
-        return all(ex.ok for ex in self.examples)
+        rollouts_ok = all(ex.ok for ex in self.examples)
+        group_ok = self.group_reward is None or self.group_reward.ok
+        return rollouts_ok and group_ok
 
     def __bool__(self) -> bool:
         return self.ok
@@ -960,6 +967,8 @@ class RolloutClient:
         llm_api_key: str = "",
         llm_model: str = _VALIDATION_MODEL,
         max_turns: int = 4,
+        check_group_reward: bool = True,
+        group_reward_samples: int = 2,
         verbose: bool = True,
     ) -> ValidationResult:
         """Run rollouts on the first *n* examples and report pass/fail.
@@ -991,6 +1000,19 @@ class RolloutClient:
                                 ``llm_base_url`` points outside the platform LLM
                                 endpoint (stream_rollout refuses to forward the
                                 platform key to a third-party host).
+            check_group_reward: After the rollouts, run a REAL same-example
+                                group through rollout-service (one example,
+                                samples_per_example=N) so the env's
+                                ``compute_group_reward`` executes server-side in
+                                the trainer image, over co-located siblings —
+                                the trainer/external-eval path. A server-side
+                                failure (raise or contract violation) comes back
+                                as ``group_reward_error`` and fails validation.
+                                Only fires when ``env_class`` is given and the
+                                env overrides the method.
+            group_reward_samples: Size of that group (the batch's
+                                ``samples_per_example``). Costs this many extra
+                                rollouts; ignored unless the group check runs.
             verbose:            Print colored progress to stdout (default True for
                                 interactive/notebook UX). Set False for programmatic
                                 callers that consume the returned ValidationResult.
@@ -1025,6 +1047,18 @@ class RolloutClient:
         self._build_env(
             env_cls_path, env_metadata_path, env_cls_bytes, env_metadata_bytes
         )
+
+        # compute_group_reward runs on a whole rollout GROUP, which the
+        # per-example smoke above never forms (each is a group of 1). Run a real
+        # same-example group server-side (run_group, below) so the env method
+        # executes on the trainer's path; the server reports any failure as
+        # group_reward_error. Needs the env_class, and is pointless unless the
+        # env overrides the no-op default.
+        want_group = False
+        if check_group_reward and env_class is not None:
+            from .validation import overrides_compute_group_reward
+
+            want_group = overrides_compute_group_reward(env_class)
 
         sample = examples[:n]
         if verbose:
@@ -1066,7 +1100,55 @@ class RolloutClient:
                     print(_err(f"  Example {i} failed: {exc}"))
                 per_example.append(ExampleValidation(index=i, ok=False, error=str(exc)))
 
-        result = ValidationResult(examples=per_example)
+        group_reward: ExampleValidation | None = None
+        if want_group and sample and group_reward_samples >= 1:
+            # Faithful check: run a REAL same-example group through
+            # rollout-service (one example, samples_per_example=N) so the env's
+            # compute_group_reward runs server-side in the trainer image, over
+            # co-located siblings — exactly the trainer/external-eval path. A
+            # server-side failure comes back as group_reward_error per rollout.
+            if verbose:
+                print(
+                    _info(
+                        f"\n  Group reward — {group_reward_samples} server-side "
+                        "sibling(s) of example 0"
+                    )
+                )
+            try:
+                events = self.run_group(
+                    sample[0],
+                    samples=group_reward_samples,
+                    env_cls_path=env_cls_path,
+                    env_metadata_path=env_metadata_path,
+                    env_cls_bytes=env_cls_bytes,
+                    env_metadata_bytes=env_metadata_bytes,
+                    llm_base_url=llm_base_url,
+                    llm_api_key=llm_api_key,
+                    llm_model=llm_model,
+                    max_turns=max_turns,
+                    verbose=verbose,
+                )
+                group_reward = self._assess_group_events(
+                    events, group_reward_samples, verbose
+                )
+            except RolloutNotFound:
+                # The batch proxy (/v1/rollout/batch/stream) isn't deployed on
+                # this server yet — skip rather than fail, so the SDK can land
+                # ahead of platform-service. group_reward stays None; the offline
+                # local check still covered shape.
+                if verbose:
+                    print(
+                        _info(
+                            "  compute_group_reward: skipped — server has no "
+                            "/rollout/batch/stream yet"
+                        )
+                    )
+            except (RolloutError, RuntimeError) as exc:
+                if verbose:
+                    print(_err(f"  group reward check failed: {exc}"))
+                group_reward = ExampleValidation(index=-1, ok=False, error=str(exc))
+
+        result = ValidationResult(examples=per_example, group_reward=group_reward)
         if verbose:
             print()
             if result.ok:
@@ -1079,3 +1161,157 @@ class RolloutClient:
                 )
 
         return result
+
+    def run_group(
+        self,
+        example: dict[str, Any],
+        *,
+        samples: int,
+        env_cls_path: str | None = None,
+        env_metadata_path: str | None = None,
+        env_cls_bytes: bytes | None = None,
+        env_metadata_bytes: bytes | None = None,
+        llm_base_url: str | None = None,
+        llm_api_key: str = "",
+        llm_model: str = _VALIDATION_MODEL,
+        max_turns: int = 4,
+        verbose: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Run ONE example as a real ``samples``-member group; return its
+        ``rollout_completed`` events.
+
+        Submits a one-row batch with ``samples_per_example=samples`` to
+        ``/v1/rollout/batch/stream``. rollout-service co-locates the siblings on
+        one worker and runs ``env.compute_group_reward`` over them — the same
+        path the trainer/external-eval use, in the trainer image. Each event
+        carries ``success``, ``rewards`` and (on a server new enough to report
+        it) ``group_reward_error``. Raises the same typed errors as
+        ``stream_rollout`` on a non-200.
+        """
+        env = self._build_env(
+            env_cls_path, env_metadata_path, env_cls_bytes, env_metadata_bytes
+        )
+        # Resolve the LLM key exactly as stream_rollout does (see there for why
+        # the platform key is only auto-forwarded to the platform LLM host).
+        platform_llm_url = config.llm_url()
+        resolved_llm_url = llm_base_url or platform_llm_url
+        if not llm_api_key:
+            if resolved_llm_url == platform_llm_url:
+                llm_api_key = self._api_key
+            else:
+                raise ValueError(
+                    "llm_api_key is required when llm_base_url points outside the "
+                    f"platform LLM endpoint ({platform_llm_url}). Refusing to "
+                    "forward the platform API key to a third-party host."
+                )
+
+        payload = {
+            "dataset_bytes": base64.b64encode(json.dumps(example).encode()).decode(),
+            "is_dataset_standardized": False,
+            # One example → one group; compute_group_reward needs all siblings
+            # co-located on a single worker anyway. Pin to 1 so rollout-service
+            # doesn't spin up extra workers that get an empty partition and crash.
+            "concurrent_workers": 1,
+            "env": env,
+            "llm": {
+                "base_url": resolved_llm_url,
+                "api_key": llm_api_key,
+                "model": llm_model,
+            },
+            "options": {"max_turns": max_turns, "samples_per_example": samples},
+        }
+        # platform-service mounts the batch proxy at /v1/rollout/batch/stream; it
+        # validates the platform key and forwards to rollout-service with an
+        # act_as JWT, same as the single /v1/rollout/stream proxy.
+        url = f"{self._server_url}/v1/rollout/batch/stream"
+        headers = {"Authorization": f"Bearer {self._api_key}"}
+
+        completed: list[dict[str, Any]] = []
+        with httpx.stream(
+            "POST", url, json=payload, headers=headers, timeout=self._timeout
+        ) as response:
+            if response.status_code != 200:
+                body = response.read().decode()
+                if response.status_code in (401, 403):
+                    raise AuthenticationError(body[:300], response.status_code)
+                if response.status_code == 404:
+                    raise RolloutNotFound(body[:300], response.status_code)
+                if 500 <= response.status_code < 600:
+                    raise RolloutServerError(body[:300], response.status_code)
+                raise RolloutError(body[:300], response.status_code)
+
+            for event in _iter_sse(response):
+                etype = event.get("event")
+                if etype == "batch_started":
+                    if verbose:
+                        print(
+                            _info(
+                                f"  group batch started ({event.get('total')} rollouts)"
+                            )
+                        )
+                elif etype == "rollout_completed":
+                    completed.append(event)
+                elif etype == "worker_error":
+                    # A sandbox process crashed. Non-fatal to the group on its
+                    # own — the verdict comes from the rollout_completed events
+                    # (_assess_group_events fails if none succeeded). Surfaced
+                    # for visibility, not raised.
+                    if verbose:
+                        print(_err(f"  worker_error: {str(event.get('error'))[:200]}"))
+                elif etype == "error":
+                    raise RolloutError(str(event.get("error"))[:300], 500)
+                elif etype in ("batch_completed", "cancelled"):
+                    break
+        return completed
+
+    def _assess_group_events(
+        self,
+        events: list[dict[str, Any]],
+        samples: int,
+        verbose: bool,
+    ) -> ExampleValidation:
+        """Turn a group's ``rollout_completed`` events into a pass/fail verdict.
+
+        Fails when the server reported a ``group_reward_error`` for any sibling
+        — compute_group_reward raised or violated its contract (see
+        rollout-service's ``_compute_group_rewards_safe``). Also fails if every
+        group rollout failed (nothing to assess). Index -1.
+
+        Note: a server that predates ``group_reward_error`` can't report a
+        failure, so a green verdict there means "no failure observed", not
+        "verified" — the offline local check still covers shape regardless.
+        """
+        errors = [
+            e["group_reward_error"] for e in events if e.get("group_reward_error")
+        ]
+        if errors:
+            msg = str(errors[0])
+            if verbose:
+                print(_err(f"  compute_group_reward FAILED server-side: {msg}"))
+            return ExampleValidation(index=-1, ok=False, error=msg)
+
+        succeeded = [e for e in events if e.get("success")]
+        if not succeeded:
+            first = next(
+                (e.get("error") for e in events if e.get("error")),
+                "no successful group rollouts",
+            )
+            if verbose:
+                print(
+                    _err(
+                        "  group reward not validated — all group rollouts "
+                        f"failed: {first}"
+                    )
+                )
+            return ExampleValidation(
+                index=-1, ok=False, error=f"all group rollouts failed: {first}"
+            )
+
+        if verbose:
+            print(
+                _ok(
+                    "  compute_group_reward OK server-side on a group of "
+                    f"{len(succeeded)}"
+                )
+            )
+        return ExampleValidation(index=-1, ok=True)

--- a/src/benchmax/platform/validation.py
+++ b/src/benchmax/platform/validation.py
@@ -97,6 +97,74 @@ def _ensure_nest_asyncio() -> None:
         pass
 
 
+def overrides_compute_group_reward(env_or_cls: type | Any) -> bool:
+    """True if the env (class or instance) overrides ``compute_group_reward``.
+
+    The ``BaseEnv`` default is a no-op returning one empty dict per rollout, so
+    there's nothing to validate unless the env supplies its own group-relative
+    scoring. Guard the group-reward checks with this to skip the common case.
+    """
+    from benchmax.envs.base_env import BaseEnv
+
+    cls = env_or_cls if isinstance(env_or_cls, type) else type(env_or_cls)
+    return cls.compute_group_reward is not BaseEnv.compute_group_reward
+
+
+def assert_group_reward_contract(
+    env: Any,
+    rollout_ids: list[str],
+    messages_list: list[list[dict[str, Any]]],
+    tasks: list[dict[str, Any] | None],
+    init_args: dict[str, Any] | None = None,
+) -> str:
+    """Call ``compute_group_reward`` on one group and assert the trainer contract.
+
+    The trainer's RewardWorker hands a whole rollout group to
+    ``compute_group_reward`` and expects one ``dict[str, float]`` back per
+    rollout, paired by index. This runs that call and checks the return shape +
+    finiteness — the group-level counterpart to the per-rollout ``compute_reward``
+    checks, which never exercise this path.
+
+    Returns a short success summary. Raises ``ValueError`` on a contract
+    violation; lets whatever ``compute_group_reward`` itself raises propagate
+    (e.g. ``ImportError`` for a reward dep missing locally) so callers can decide
+    skip-vs-fail. Guard with :func:`overrides_compute_group_reward` first — a
+    non-overriding env would trivially pass against the no-op default.
+    """
+    init_args = init_args or {}
+    rewards = _run_async(
+        env.compute_group_reward(
+            rollout_ids=rollout_ids,
+            messages_list=messages_list,
+            tasks=tasks,
+            **init_args,
+        )
+    )
+
+    if not isinstance(rewards, list):
+        raise ValueError(
+            f"returned {type(rewards).__name__}, expected list[dict[str, float]]"
+        )
+    if len(rewards) != len(rollout_ids):
+        raise ValueError(
+            f"returned {len(rewards)} dict(s) for {len(rollout_ids)} rollout(s) — "
+            "must be one per rollout_id, paired by index"
+        )
+    for idx, r in enumerate(rewards):
+        if not isinstance(r, dict):
+            raise ValueError(
+                f"element {idx} is {type(r).__name__}, expected dict[str, float]"
+            )
+        bad = {
+            k: v
+            for k, v in r.items()
+            if not isinstance(v, (int, float)) or not math.isfinite(v)
+        }
+        if bad:
+            raise ValueError(f"element {idx} has non-finite/non-float values: {bad}")
+    return f"{len(rewards)} dict(s): {rewards}"
+
+
 def _run_local_checks(
     env_class: type,
     env_args: dict[str, Any],
@@ -108,7 +176,8 @@ def _run_local_checks(
 
     Mirrors how the trainer calls env methods — dataset_preprocess,
     load_dataset, list_tools/run_tool, compute_reward, a simulated rollout,
-    and pickle round-trips. Prints colored progress as it goes.
+    compute_group_reward (when overridden), and pickle round-trips. Prints
+    colored progress as it goes.
 
     Returns:
         ``(passed, failed)`` check counts. The caller owns the shared event
@@ -422,6 +491,57 @@ def _run_local_checks(
             print(f"  \u2717 simulated rollout failed: {type(exc).__name__}: {exc}")
             failed += 1
 
+    # 5c. compute_group_reward (group-relative scoring) ----------------------
+    # Only envs that override the BaseEnv no-op have group logic to check. The
+    # trainer batches a whole rollout GROUP into this call, so feed it a small
+    # group: the same example sampled twice, with distinct answers so any
+    # diversity/ranking logic has something to compare.
+    if (
+        env is not None
+        and isinstance(preprocessed, dict)
+        and "prompt_messages" in preprocessed
+    ):
+        if not overrides_compute_group_reward(env):
+            print(
+                "  - compute_group_reward: skipped"
+                " (not overridden \u2014 per-rollout rewards only)"
+            )
+        else:
+            try:
+                task = preprocessed.get("task")
+                init_args = preprocessed.get("init_rollout_args") or {}
+                seed = list(preprocessed["prompt_messages"])
+                group = [
+                    seed
+                    + [{"role": "assistant", "content": "First candidate answer."}],
+                    seed
+                    + [{"role": "assistant", "content": "A different second answer."}],
+                ]
+                summary = assert_group_reward_contract(
+                    env,
+                    rollout_ids=["grp-0", "grp-1"],
+                    messages_list=group,
+                    tasks=[task, task],
+                    init_args=init_args,
+                )
+                print(
+                    "  \u2713 compute_group_reward returns"
+                    f" list[dict[str, float]] ({summary})"
+                )
+                passed += 1
+            except Exception as exc:
+                print(
+                    f"  \u2717 compute_group_reward failed: {type(exc).__name__}: {exc}"
+                )
+                print(
+                    "    Fix: compute_group_reward(rollout_ids, messages_list,"
+                    " tasks, **kwargs) must return"
+                )
+                print(
+                    "    one finite dict[str, float] per rollout_id, paired by index."
+                )
+                failed += 1
+
     # ── 6. Pickle round-trip ─────────────────────────────────────
     # Use cloudpickle on both sides so envs that import from local modules
     # (registered via local_modules in dump_bundle) round-trip the same way
@@ -594,6 +714,7 @@ def validate_env(
     llm_base_url: str | None = None,
     llm_api_key: str | None = None,
     remote_examples: int = 2,
+    group_reward_samples: int = 2,
     llm_model: str | None = None,
     max_turns: int = 4,
     verbose: bool = True,
@@ -605,11 +726,15 @@ def validate_env(
     1. **Local contract checks** (``local=True``, the default) — run in-process
        with no network, mirroring how the trainer calls env methods
        (dataset_preprocess, load_dataset, list_tools/run_tool, compute_reward,
-       a simulated rollout, pickle round-trips).
+       a simulated rollout, compute_group_reward, pickle round-trips).
     2. **Remote smoke rollout** (runs when ``api_key`` is given) — bundles the
        env inline and runs ``remote_examples`` real rollouts on the platform,
        exactly as :meth:`RolloutClient.validate_examples` does, but without you
-       having to construct a client.
+       having to construct a client. It also runs a real same-example *group*
+       through rollout-service (one example, ``samples_per_example=N``) so the
+       env's ``compute_group_reward`` executes server-side in the trainer image,
+       over co-located siblings — the trainer/external-eval path. A server-side
+       failure comes back as ``group_reward_error`` and fails the report.
 
     Pass nothing but the env + dataset for a fast offline check; add
     ``api_key`` (and, if your script's environment differs from the SDK
@@ -653,6 +778,10 @@ def validate_env(
             points outside the platform LLM endpoint (BYOK) — the platform key
             is never forwarded to a third-party host.
         remote_examples: Number of examples to smoke-test remotely (default 2).
+        group_reward_samples: Size of the same-example sibling group used to
+            validate ``compute_group_reward`` server-side on the remote pass
+            (``samples_per_example`` for a one-example batch). Default 2; costs
+            that many extra rollouts, only when the env overrides group reward.
         llm_model: Override the validation model for the remote rollout.
         max_turns: Max conversation turns per remote rollout.
         verbose: Print progress + the roll-up summary (default True).
@@ -691,6 +820,12 @@ def validate_env(
             llm_base_url=llm_base_url,
             llm_api_key=llm_api_key or "",
             max_turns=max_turns,
+            # The group-reward check runs server-side (a real group through
+            # rollout-service), so it needs no local env deps — run it whenever
+            # the remote pass runs, including launch scripts (local=False),
+            # which is exactly the expensive run we want to guard.
+            check_group_reward=True,
+            group_reward_samples=group_reward_samples,
             verbose=verbose,
             **extra,
         )

--- a/tests/integration/test_group_reward_smoke.py
+++ b/tests/integration/test_group_reward_smoke.py
@@ -1,0 +1,106 @@
+"""Integration smoke for the faithful server-side compute_group_reward check.
+
+Drives validate_env(local=False) -> run_group -> /v1/rollout/batch/stream, so the
+env's compute_group_reward runs in a real sandbox worker over a co-located group:
+  GOOD env   -> valid group reward -> group_reward.ok is True
+  BROKEN env -> raises -> rollout-service reports group_reward_error -> ok is False
+
+Requires a staging deploy with the server side live (rollout-service +
+platform-service; PR castform-ai/castform#136). Credentials: set PLATFORM_API_KEY
+(and CASTFORM_BASE_DOMAIN / CASTFORM_PLATFORM_URL+CASTFORM_LLM_URL if not the
+default castform.dev), or load via .env.test. Skipped in CI; run locally:
+
+    PLATFORM_API_KEY=... uv run pytest -m integration tests/integration/test_group_reward_smoke.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+from benchmax.envs.base_env import BaseEnv
+from benchmax.envs.example_id import make_example
+from benchmax.envs.types import Example
+from benchmax.platform import validate_env
+
+pytestmark = pytest.mark.integration
+
+os.environ.setdefault("CASTFORM_PLATFORM_URL", "https://api.castform.dev")
+os.environ.setdefault("CASTFORM_LLM_URL", "https://llm.castform.dev/v1")
+
+
+class _GroupEnvBase(BaseEnv):
+    """Minimal env (no tools/corpus/judge) — a trivial per-sample reward so the
+    only interesting signal is compute_group_reward."""
+
+    system_prompt = "You are a helpful assistant. Answer in one short sentence."
+
+    @classmethod
+    def dataset_preprocess(cls, example, **kwargs) -> Example:
+        return make_example(
+            prompt_messages=[{"role": "user", "content": example.get("prompt", "")}],
+            task={"ground_truth": example.get("ground_truth", "")},
+            system_prompt=cls.system_prompt,
+        )
+
+    async def list_tools(self):
+        return []
+
+    async def run_tool(self, rollout_id, tool_name, **kwargs):
+        raise NotImplementedError
+
+    async def compute_reward(self, rollout_id, messages, task=None, **kwargs):
+        return {"nonempty": 1.0}
+
+
+class GoodGroupEnv(_GroupEnvBase):
+    async def compute_group_reward(self, rollout_ids, messages_list, tasks, **kwargs):
+        return [{"group_bonus": 0.25} for _ in rollout_ids]
+
+
+class BrokenGroupEnv(_GroupEnvBase):
+    async def compute_group_reward(self, rollout_ids, messages_list, tasks, **kwargs):
+        raise ValueError("intentional group-reward failure (integration smoke)")
+
+
+def _validate(env_cls: type):
+    api_key = os.environ.get("PLATFORM_API_KEY")
+    if not api_key:
+        pytest.skip("PLATFORM_API_KEY not set")
+    extra = {}
+    model = os.environ.get("GROUP_REWARD_TEST_MODEL")
+    if model:
+        extra["llm_model"] = model
+    return validate_env(
+        env_class=env_cls,
+        env_args={},
+        train_dataset=[{"prompt": "Say hello in one word.", "ground_truth": "hello"}],
+        api_key=api_key,
+        local=False,  # remote-only: exercise the real server-side group path
+        group_reward_samples=2,
+        pip_dependencies=[],
+        # Pickle this module's env classes by value (they live in a named module,
+        # not __main__), so the bundle is self-contained for the sandbox.
+        local_modules=[sys.modules[__name__]],
+        verbose=False,
+        **extra,
+    )
+
+
+def test_group_reward_good_passes():
+    report = _validate(GoodGroupEnv)
+    assert report.remote is not None
+    gr = report.remote.group_reward
+    assert gr is not None, "group reward check did not run (proxy not deployed?)"
+    assert gr.ok is True, f"expected pass, got {gr}"
+
+
+def test_group_reward_broken_surfaces_error():
+    report = _validate(BrokenGroupEnv)
+    assert report.remote is not None
+    gr = report.remote.group_reward
+    assert gr is not None, "group reward check did not run (proxy not deployed?)"
+    assert gr.ok is False, f"expected fail, got {gr}"
+    assert "group-reward failure" in (gr.error or "")

--- a/tests/unit/platform/test_client.py
+++ b/tests/unit/platform/test_client.py
@@ -478,3 +478,319 @@ def test_validate_examples_forwards_llm_base_url_and_key(monkeypatch):
     assert len(captured) == 1
     assert captured[0]["llm_base_url"] == "https://llm.castform.dev/v1"
     assert captured[0]["llm_api_key"] == "dev-key"
+
+
+# ---------------------------------------------------------------------------
+# validate_examples — faithful server-side compute_group_reward check
+#
+# The group reward runs SERVER-SIDE: validate_examples submits a one-example
+# batch with samples_per_example=N to rollout-service (run_group), which forms a
+# real co-located sibling group and runs compute_group_reward in the trainer
+# image. A failure comes back as group_reward_error per rollout. These tests
+# fake stream_rollout (per-example smoke) and run_group (the group batch).
+# ---------------------------------------------------------------------------
+
+
+def _make_group_env():
+    """A concrete BaseEnv that OVERRIDES compute_group_reward so the group check
+    fires. The body never runs here — the group reward executes server-side,
+    which run_group mocks away."""
+    from benchmax.envs.base_env import BaseEnv
+
+    class _GroupEnv(BaseEnv):
+        async def list_tools(self):
+            return []
+
+        async def run_tool(self, rollout_id, tool_name, **tool_args):
+            raise NotImplementedError
+
+        async def compute_reward(self, rollout_id, messages, task, **kwargs):
+            return {"r": 1.0}
+
+        async def compute_group_reward(self, rollout_ids, messages_list, tasks, **kw):
+            return [{"r": 1.0} for _ in rollout_ids]
+
+    return _GroupEnv
+
+
+def _completed(success=True, group_reward_error=None):
+    """A rollout_completed event in the shape run_group returns."""
+    e: dict[str, Any] = {"event": "rollout_completed", "success": success}
+    if group_reward_error is not None:
+        e["group_reward_error"] = group_reward_error
+    return e
+
+
+def test_validate_examples_runs_server_side_group(monkeypatch):
+    """Override + clean group → group reward validated server-side, result ok.
+    The group is examples[0] run as samples_per_example=N via run_group."""
+    client = RolloutClient(api_key="k")
+    monkeypatch.setattr(client, "stream_rollout", lambda **kw: {"success": True})
+    seen: dict[str, Any] = {}
+
+    def fake_run_group(example, *, samples, **kw):
+        seen["example"] = example
+        seen["samples"] = samples
+        return [_completed(), _completed()]
+
+    monkeypatch.setattr(client, "run_group", fake_run_group)
+
+    result = client.validate_examples(
+        [{"prompt": "hi"}],
+        env_class=_make_group_env(),
+        n=1,
+        group_reward_samples=2,
+        verbose=False,
+    )
+
+    assert result.ok
+    assert result.group_reward is not None and result.group_reward.ok
+    assert result.group_reward.index == -1
+    assert seen["example"] == {"prompt": "hi"}
+    assert seen["samples"] == 2
+
+
+def test_validate_examples_server_side_group_error_fails(monkeypatch):
+    """A server-reported group_reward_error fails the whole result."""
+    client = RolloutClient(api_key="k")
+    monkeypatch.setattr(client, "stream_rollout", lambda **kw: {"success": True})
+    monkeypatch.setattr(
+        client,
+        "run_group",
+        lambda example, *, samples, **kw: [
+            _completed(),
+            _completed(group_reward_error="ValueError: boom"),
+        ],
+    )
+
+    result = client.validate_examples(
+        [{"prompt": "hi"}],
+        env_class=_make_group_env(),
+        n=1,
+        verbose=False,
+    )
+
+    assert result.group_reward is not None
+    assert result.group_reward.ok is False
+    assert "boom" in (result.group_reward.error or "")
+    assert result.ok is False
+
+
+def test_validate_examples_skips_group_when_proxy_missing(monkeypatch):
+    """If the batch proxy isn't deployed yet (404), the group check is SKIPPED,
+    not failed — so the SDK can land ahead of platform-service's proxy."""
+    client = RolloutClient(api_key="k")
+    monkeypatch.setattr(client, "stream_rollout", lambda **kw: {"success": True})
+
+    def _not_found(*a, **k):
+        raise RolloutNotFound("no such endpoint", 404)
+
+    monkeypatch.setattr(client, "run_group", _not_found)
+
+    result = client.validate_examples(
+        [{"prompt": "hi"}],
+        env_class=_make_group_env(),
+        n=1,
+        verbose=False,
+    )
+
+    assert result.group_reward is None
+    assert result.ok is True
+
+
+def _counting_run_group(counter: dict[str, int]):
+    def _stub(*a, **k):
+        counter["n"] += 1
+        return []
+
+    return _stub
+
+
+def test_validate_examples_check_group_reward_false_skips_group(monkeypatch):
+    """check_group_reward=False → run_group is never called."""
+    client = RolloutClient(api_key="k")
+    monkeypatch.setattr(client, "stream_rollout", lambda **kw: {"success": True})
+    called = {"n": 0}
+    monkeypatch.setattr(client, "run_group", _counting_run_group(called))
+
+    result = client.validate_examples(
+        [{"prompt": "hi"}],
+        env_class=_make_group_env(),
+        n=1,
+        check_group_reward=False,
+        verbose=False,
+    )
+
+    assert result.group_reward is None
+    assert result.ok is True
+    assert called["n"] == 0
+
+
+def test_validate_examples_no_override_skips_group(monkeypatch):
+    """An env that doesn't override compute_group_reward → run_group not called."""
+    client = RolloutClient(api_key="k")
+    monkeypatch.setattr(client, "stream_rollout", lambda **kw: {"success": True})
+    called = {"n": 0}
+    monkeypatch.setattr(client, "run_group", _counting_run_group(called))
+
+    result = client.validate_examples(
+        [{"prompt": "hi"}],
+        env_class=_make_smoke_env(),  # no compute_group_reward override
+        n=1,
+        verbose=False,
+    )
+
+    assert result.group_reward is None
+    assert result.ok is True
+    assert called["n"] == 0
+
+
+# _assess_group_events — verdict logic over a group's rollout_completed events
+
+
+def test_assess_group_events_ok():
+    client = RolloutClient(api_key="k")
+    v = client._assess_group_events([_completed(), _completed()], 2, verbose=False)
+    assert v.ok is True and v.index == -1
+
+
+def test_assess_group_events_surfaces_error():
+    client = RolloutClient(api_key="k")
+    v = client._assess_group_events(
+        [_completed(), _completed(group_reward_error="TypeError: x")], 2, verbose=False
+    )
+    assert v.ok is False and "TypeError" in (v.error or "")
+
+
+def test_assess_group_events_all_failed():
+    client = RolloutClient(api_key="k")
+    events = [_completed(success=False), _completed(success=False)]
+    events[0]["error"] = "rollout blew up"
+    v = client._assess_group_events(events, 2, verbose=False)
+    assert v.ok is False and "blew up" in (v.error or "")
+
+
+# run_group — one-example batch + batch-SSE consumption
+
+
+def test_run_group_parses_batch_sse(monkeypatch):
+    """run_group POSTs a one-example batch (samples_per_example=N) to
+    /v1/rollout/batch/stream and collects the rollout_completed events."""
+    monkeypatch.setenv("CASTFORM_BASE_DOMAIN", "castform.com")
+    import httpx as httpx_mod
+
+    captured: dict[str, Any] = {}
+    lines = [
+        'data: {"event": "batch_started", "total": 2}',
+        "",
+        'data: {"event": "rollout_completed", "success": true}',
+        "",
+        'data: {"event": "rollout_completed", "success": true, '
+        '"group_reward_error": "ValueError: boom"}',
+        "",
+        'data: {"event": "batch_completed", "total": 2, "succeeded": 2, "failed": 0}',
+        "",
+    ]
+
+    class _FakeResp:
+        status_code = 200
+
+        def iter_lines(self):
+            return iter(lines)
+
+        def read(self):
+            return b""
+
+    class _CM:
+        def __enter__(self):
+            return _FakeResp()
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake_stream(method, url, **kw):
+        captured["url"] = url
+        captured["json"] = kw.get("json")
+        return _CM()
+
+    monkeypatch.setattr(httpx_mod, "stream", _fake_stream)
+
+    client = RolloutClient(api_key="k")
+    events = client.run_group(
+        {"prompt": "hi"},
+        samples=2,
+        env_cls_bytes=b"x",
+        env_metadata_bytes=b"y",
+        verbose=False,
+    )
+
+    assert captured["url"] == "https://api.castform.com/v1/rollout/batch/stream"
+    assert captured["json"]["options"]["samples_per_example"] == 2
+    # One group → one worker (siblings co-locate); pinning this avoids an empty
+    # second worker crashing on a no-example partition.
+    assert captured["json"]["concurrent_workers"] == 1
+    assert len(events) == 2
+    assert events[1]["group_reward_error"] == "ValueError: boom"
+
+
+def test_run_group_ignores_worker_error(monkeypatch):
+    """A worker_error event (e.g. a stray empty-partition worker) is non-fatal:
+    run_group keeps the rollout_completed events instead of raising."""
+    monkeypatch.setenv("CASTFORM_BASE_DOMAIN", "castform.com")
+    import httpx as httpx_mod
+
+    lines = [
+        'data: {"event": "batch_started", "total": 2}',
+        "",
+        'data: {"event": "worker_error", "exit_code": 1, "error": "empty partition"}',
+        "",
+        'data: {"event": "rollout_completed", "success": true}',
+        "",
+        'data: {"event": "rollout_completed", "success": true}',
+        "",
+        'data: {"event": "batch_completed", "total": 2, "succeeded": 2, "failed": 0}',
+        "",
+    ]
+
+    class _FakeResp:
+        status_code = 200
+
+        def iter_lines(self):
+            return iter(lines)
+
+        def read(self):
+            return b""
+
+    class _CM:
+        def __enter__(self):
+            return _FakeResp()
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(httpx_mod, "stream", lambda *a, **k: _CM())
+
+    client = RolloutClient(api_key="k")
+    events = client.run_group(
+        {"prompt": "hi"},
+        samples=2,
+        env_cls_bytes=b"x",
+        env_metadata_bytes=b"y",
+        verbose=False,
+    )
+    # worker_error didn't raise; both real rollouts came through.
+    assert len(events) == 2
+    assert all(e["success"] for e in events)
+
+
+def test_validation_result_group_reward_folds_into_ok():
+    """A failed group_reward makes the aggregate result falsey even when every
+    per-example rollout passed."""
+    passing = [ExampleValidation(0, True), ExampleValidation(1, True)]
+    assert ValidationResult(examples=passing).ok is True
+    good = ValidationResult(examples=passing, group_reward=ExampleValidation(-1, True))
+    assert good.ok is True
+    bad = ValidationResult(
+        examples=passing, group_reward=ExampleValidation(-1, False, "boom")
+    )
+    assert bad.ok is False

--- a/tests/unit/platform/test_validation.py
+++ b/tests/unit/platform/test_validation.py
@@ -9,13 +9,62 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
+from benchmax.envs.base_env import BaseEnv
 from benchmax.platform.client import ExampleValidation, ValidationResult
-from benchmax.platform.validation import ValidationReport, validate_env
+from benchmax.platform.validation import (
+    ValidationReport,
+    assert_group_reward_contract,
+    overrides_compute_group_reward,
+    validate_env,
+)
 
 
 class _DummyEnv:
     """Placeholder env class — never instantiated in these tests (remote path
     is faked, local path is skipped via local=False)."""
+
+
+# ---------------------------------------------------------------------------
+# Concrete envs for the local-layer group-reward checks. Module-level so
+# cloudpickle round-trips them by value (tests pass local_modules=[this]).
+# ---------------------------------------------------------------------------
+
+
+class _PlainEnv(BaseEnv):
+    """Passes every local check; does NOT override compute_group_reward."""
+
+    system_prompt = "sys"
+
+    async def list_tools(self):
+        return []
+
+    async def run_tool(self, rollout_id, tool_name, **tool_args):
+        return "ok"
+
+    async def compute_reward(self, rollout_id, messages, task, **kwargs):
+        return {"r": 1.0}
+
+
+class _GoodGroupEnv(_PlainEnv):
+    async def compute_group_reward(self, rollout_ids, messages_list, tasks, **kw):
+        return [{"r": 1.0} for _ in rollout_ids]
+
+
+class _NotListGroupEnv(_PlainEnv):
+    async def compute_group_reward(self, rollout_ids, messages_list, tasks, **kw):
+        return {"r": 1.0}  # not a list[dict]
+
+
+class _ShortGroupEnv(_PlainEnv):
+    async def compute_group_reward(self, rollout_ids, messages_list, tasks, **kw):
+        return [{"r": 1.0}]  # always length 1 → breaks 1:1 pairing
+
+
+class _NonFiniteGroupEnv(_PlainEnv):
+    async def compute_group_reward(self, rollout_ids, messages_list, tasks, **kw):
+        return [{"r": float("nan")} for _ in rollout_ids]
 
 
 def _install_fake_rollout(monkeypatch) -> dict[str, Any]:
@@ -128,3 +177,88 @@ def test_local_false_no_key_reports_nothing_ran(monkeypatch):
     assert report.local_ran is False
     assert report.remote_ran is False
     assert bool(report) is False
+
+
+# ---------------------------------------------------------------------------
+# Group-reward helpers
+# ---------------------------------------------------------------------------
+
+
+def test_overrides_compute_group_reward_predicate():
+    assert overrides_compute_group_reward(_GoodGroupEnv) is True
+    assert overrides_compute_group_reward(_GoodGroupEnv()) is True  # instance too
+    assert overrides_compute_group_reward(_PlainEnv) is False
+
+
+def test_contract_ok_returns_summary():
+    summary = assert_group_reward_contract(
+        _GoodGroupEnv(), ["a", "b"], [[], []], [None, None]
+    )
+    assert "2 dict" in summary
+
+
+def test_contract_raises_on_non_list():
+    with pytest.raises(ValueError, match="expected list"):
+        assert_group_reward_contract(_NotListGroupEnv(), ["a"], [[]], [None])
+
+
+def test_contract_raises_on_length_mismatch():
+    with pytest.raises(ValueError, match="one per rollout_id"):
+        assert_group_reward_contract(
+            _ShortGroupEnv(), ["a", "b"], [[], []], [None, None]
+        )
+
+
+def test_contract_raises_on_non_finite():
+    with pytest.raises(ValueError, match="non-finite"):
+        assert_group_reward_contract(_NonFiniteGroupEnv(), ["a"], [[]], [None])
+
+
+# ---------------------------------------------------------------------------
+# Local layer (5c) end-to-end through validate_env
+# ---------------------------------------------------------------------------
+
+_LOCAL_DATASET = [{"prompt": "hi"}, {"prompt": "yo"}]
+
+
+def _this_module():
+    import tests.unit.platform.test_validation as mod
+
+    return mod
+
+
+def test_local_group_reward_check_passes():
+    report = validate_env(
+        env_class=_GoodGroupEnv,
+        env_args={},
+        train_dataset=_LOCAL_DATASET,
+        local_modules=[_this_module()],
+        verbose=False,
+    )
+    assert report.local_ran is True
+    assert report.local_failed == 0
+    assert report.remote is None
+
+
+def test_local_group_reward_check_flags_bad_env(capsys):
+    report = validate_env(
+        env_class=_NotListGroupEnv,
+        env_args={},
+        train_dataset=_LOCAL_DATASET,
+        local_modules=[_this_module()],
+        verbose=False,
+    )
+    assert report.local_failed >= 1
+    assert "compute_group_reward failed" in capsys.readouterr().out
+
+
+def test_local_group_reward_skipped_when_not_overridden(capsys):
+    report = validate_env(
+        env_class=_PlainEnv,
+        env_args={},
+        train_dataset=_LOCAL_DATASET,
+        local_modules=[_this_module()],
+        verbose=False,
+    )
+    assert report.local_failed == 0
+    assert "compute_group_reward: skipped" in capsys.readouterr().out


### PR DESCRIPTION
## Why

`validate_env` / `validate_examples` only ever exercised `compute_reward`, never the optional `compute_group_reward` override — so a broken group reward (raise, wrong shape, non-finite values) slipped through to an expensive training/eval run.

## What

Adds a **server-side** group-reward check to pre-launch validation:

- **`RolloutClient.run_group(example, samples=N)`** submits a one-row batch with `samples_per_example=N` to the new `/v1/rollout/batch/stream` proxy, so the env's `compute_group_reward` runs **in the trainer image over co-located siblings** — the real trainer/external-eval path.
- **`validate_examples`** runs `examples[0]` as a real group and fails on a server-reported `group_reward_error` (`_assess_group_events`). `ValidationResult.group_reward` (index -1) folds into `.ok`.
- A fast **offline local check** ("5c") still runs a synthetic group with no cluster (`overrides_compute_group_reward` + `assert_group_reward_contract`).
- **Deploy-order safe:** a 404 from the batch proxy (platform-service not updated yet) is a **skip**, not a failure, so the SDK can land ahead of the proxy.
- `validate_env` runs the group check whenever the remote pass runs (incl. launch scripts) — it needs no local env deps now.

## Companion PR (deploy order)

Server side: **castform-ai/castform#136** (rollout-service `group_reward_error` + contract validation, and the `/v1/rollout/batch/stream` proxy). Deploy that first; this skips gracefully until the proxy is live.

## Testing

`pytest tests/unit/platform` green — `run_group` batch-SSE parse, `_assess_group_events` verdicts, the 404-skip, `validate_examples` wiring, and the local 5c check. (benchmax has no CI — run locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)