### PR TITLE
fix(platform): keyless PlatformConfig() + export platform_bearer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchmax"
-version = "0.1.2.dev30"
+version = "0.1.2.dev29"
 description = "Framework-Agnostic RL Environments for LLM Fine-Tuning"
 readme = "README.md"
 authors = [{ name = "castie@castform.com" }]

--- a/src/benchmax/platform/__init__.py
+++ b/src/benchmax/platform/__init__.py
@@ -1,6 +1,7 @@
 """Castform platform clients (storage, training runs, rollout)."""
 
 from .client import RolloutClient, StorageClient, TrainerClient
+from .credentials import platform_bearer
 from .training_run import UploadedTrainingRun, upload_training_run
 from .validation import ValidationReport, validate_env
 
@@ -14,6 +15,10 @@ __all__ = [
     "TrainerClient",
     "UploadedTrainingRun",
     "ValidationReport",
+    # The seam token-getter: generated scripts pass it to a raw OpenAI client
+    # (e.g. the traces pivot), so it's part of the public surface alongside
+    # ensure_session — not just an internal credentials helper.
+    "platform_bearer",
     "ensure_session",
     "upload_training_run",
     "validate_env",

--- a/src/benchmax/rag/qa_generation/pipeline_config.py
+++ b/src/benchmax/rag/qa_generation/pipeline_config.py
@@ -196,7 +196,11 @@ class EnvBundleConfig:
 class PlatformConfig:
     """Top-level credentials."""
 
-    api_key: str
+    # Default to the credential seam (empty key → platform_bearer), matching
+    # every sibling config here and the keyless clients: pipeline.py threads this
+    # through resolve_token_provider / the now-keyless PostgresChunkSource +
+    # RolloutClient, so PlatformConfig() works without a baked key.
+    api_key: str = ""
     base_url: str = config.platform_url()
     llm_api_key: str = ""
     llm_base_url: str = field(default_factory=config.llm_url)

--- a/tests/unit/platform/test_keyless_public_api.py
+++ b/tests/unit/platform/test_keyless_public_api.py
@@ -1,0 +1,36 @@
+"""Public-API guards for the keyless device-auth surface.
+
+Two contracts the wizard codegen relies on (generated run.py scripts):
+  - ``platform_bearer`` is importable from ``benchmax.platform`` — generated
+    scripts hand it to a raw OpenAI client (e.g. the traces pivot).
+  - ``PlatformConfig()`` constructs with no key — an empty key resolves through
+    the credential seam, like every sibling config and the keyless clients.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import benchmax.platform as platform
+
+
+def test_platform_bearer_is_public() -> None:
+    # Re-exported at the package top level, not only in
+    # benchmax.platform.credentials, so `from benchmax.platform import
+    # platform_bearer` resolves.
+    from benchmax.platform import platform_bearer
+
+    assert callable(platform_bearer)
+    assert "platform_bearer" in platform.__all__
+
+
+def test_platform_config_is_keyless_by_default() -> None:
+    PlatformConfig = pytest.importorskip(
+        "benchmax.rag.qa_generation.pipeline_config"
+    ).PlatformConfig
+
+    cfg = PlatformConfig()  # no api_key — must not raise
+    assert cfg.api_key == ""
+    # URLs still resolve from config (session/env-derived), never None.
+    assert cfg.base_url
+    assert cfg.llm_base_url


### PR DESCRIPTION
Two small follow-ups to #43's per-request credential seam — both required by the keyless wizard codegen in castform (the generated `run.py`), and neither currently satisfied by `main`.

## Gap A — `platform_bearer` not importable from `benchmax.platform`
`#43` re-exports `ensure_session` from `benchmax.platform` but not `platform_bearer`. The generated traces-pivot script does:
```python
_llm = openai.AsyncOpenAI(base_url=config.llm_url(), api_key=platform_bearer())
```
i.e. `from benchmax.platform import ensure_session, platform_bearer` → `ImportError`. `platform_bearer` shows up in user-facing generated scripts, so it's public surface — re-export it alongside `ensure_session`.

## Gap B — `PlatformConfig()` requires `api_key`
`PlatformConfig.api_key` had no default, unlike every sibling config in `pipeline_config.py`. The keyless QA-gen path emits `PlatformConfig()` → `TypeError`. Runtime was already keyless (`pipeline.py` threads `cfg.platform.api_key` through `resolve_token_provider` / the keyless `PostgresChunkSource` + `RolloutClient`), so only the missing default blocked construction. Default it to `""` (seam fallback).

## Also
- Bump `0.1.2.dev30` → `dev31` so `pip install` downloads carry this (the wizard's downloaded scripts need it, not just the in-cluster build worker).
- New `tests/unit/platform/test_keyless_public_api.py` guards both contracts. 103 platform unit tests pass.

Unblocks the keyless codegen in castform#128 (RAG QA-gen regeneration + traces-pivot paths).