### PR TITLE
Remove staging/prod env concept from URL resolution

### DIFF
--- a/src/benchmax/cli.py
+++ b/src/benchmax/cli.py
@@ -11,19 +11,19 @@ from __future__ import annotations
 import argparse
 import sys
 
+from benchmax import config
 from benchmax.platform import credentials
 from benchmax.platform.device_auth import DeviceAuthError
 from benchmax.platform.login import _login
 
 
-def _cmd_login(args: argparse.Namespace) -> int:
-    env = "staging" if args.env == "staging" else None
+def _cmd_login(_args: argparse.Namespace) -> int:
     try:
-        _login(env)
+        _login()
     except DeviceAuthError as exc:
         print(f"Login failed: {exc}", file=sys.stderr)
         return 1
-    print(f"\n✓ Logged in to {args.env}.")
+    print(f"\n✓ Logged in to {config.base_domain()}.")
     return 0
 
 
@@ -38,19 +38,18 @@ def _cmd_whoami(_args: argparse.Namespace) -> int:
     if not session:
         print("Not logged in. Run `castform login`.", file=sys.stderr)
         return 1
-    env = session.get("env", "prod")
     jwt = credentials._session_jwt()  # mints from the session; None if invalid/expired/offline
     if not jwt:
         print(
-            f"Session present (env: {env}), but couldn't reach auth-service to "
-            "verify it (offline, or the session expired). If this persists, run "
+            "Session present, but couldn't reach auth-service to verify it "
+            "(offline, or the session expired). If this persists, run "
             "`castform login` again.",
             file=sys.stderr,
         )
         return 1
     claims = credentials._jwt_claims(jwt)
     who = claims.get("email") or claims.get("sub", "<unknown>")
-    print(f"Logged in as {who} (env: {env}).")
+    print(f"Logged in as {who} ({config.base_domain()}).")
     return 0
 
 
@@ -59,12 +58,6 @@ def main(argv: list[str] | None = None) -> int:
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_login = sub.add_parser("login", help="Sign in via your browser")
-    p_login.add_argument(
-        "--env",
-        choices=["prod", "staging"],
-        default="prod",
-        help="Environment to sign in to (staging is internal-only)",
-    )
     p_login.set_defaults(func=_cmd_login)
 
     sub.add_parser("logout", help="Clear the cached session").set_defaults(func=_cmd_logout)

--- a/src/benchmax/config.py
+++ b/src/benchmax/config.py
@@ -1,8 +1,11 @@
 """Centralized URL configuration for the Castform platform.
 
-All URLs derive from a single base domain. Set ``CASTFORM_BASE_DOMAIN`` to
-point at a different environment (e.g. ``staging.castform.com``); individual
-URL components may be overridden via their own env vars when needed.
+All URLs derive from a single base domain, resolved from exactly two places: the
+``CASTFORM_BASE_DOMAIN`` env var, or the built-in ``castform.com`` default.
+Individual URLs may be overridden via their own env vars
+(``CASTFORM_PLATFORM_URL`` / ``CASTFORM_LLM_URL`` / ``CASTFORM_AUTH_URL`` /
+``CASTFORM_WEB_APP_URL``) — e.g. point platform at ``http://localhost:3000`` for
+local dev while auth keeps talking to the real host.
 
 Usage::
 
@@ -16,38 +19,10 @@ DEFAULT_BASE_DOMAIN = "castform.com"
 
 
 def base_domain() -> str:
-    """Resolve the platform base domain.
-
-    Precedence: explicit ``CASTFORM_BASE_DOMAIN`` → the cached device-auth
-    session's ``env`` (``staging`` → ``castform.dev``) → ``prod`` default
-    (``castform.com``). The ``env`` claim travels with the credential, so a
-    logged-in SDK routes to the same environment it authenticated against —
-    URL and credential can't desync. A prod session carries no ``env`` marker
-    (``None`` → prod), so only internal staging logins deviate from the default.
-    """
-    override = os.environ.get("CASTFORM_BASE_DOMAIN")
-    if override:
-        return override
-    if _session_env() == "staging":
-        return "castform.dev"
-    return DEFAULT_BASE_DOMAIN
-
-
-def _session_env() -> str | None:
-    """The ``env`` from the cached device-auth session, if any.
-
-    Lazy import: ``config`` is a leaf that ``benchmax.platform`` depends on, so a
-    top-level import would cycle (platform/__init__ → client → config)."""
-    try:
-        from benchmax.platform.credentials import read_castform_session
-
-        session = read_castform_session()
-    except Exception:
-        return None
-    if not session:
-        return None
-    env = session.get("env")
-    return env if isinstance(env, str) else None
+    """Resolve the platform base domain: ``CASTFORM_BASE_DOMAIN`` or the
+    ``castform.com`` default. To target another environment (e.g. internal
+    staging), export ``CASTFORM_BASE_DOMAIN=castform.dev``."""
+    return os.environ.get("CASTFORM_BASE_DOMAIN") or DEFAULT_BASE_DOMAIN
 
 
 def platform_url() -> str:
@@ -75,7 +50,6 @@ def auth_url() -> str:
     """Auth-service base URL (device-authorization + JWT mint endpoints).
 
     Used by ``castform login`` and the per-process session→JWT mint. Derives from
-    the same base domain as everything else, so a session minted against ``staging``
-    talks to ``auth.castform.dev`` and a ``prod`` session to ``auth.castform.com``.
+    the same base domain as everything else, or ``CASTFORM_AUTH_URL`` to override.
     """
     return os.environ.get("CASTFORM_AUTH_URL") or f"https://auth.{base_domain()}"

--- a/src/benchmax/envs/telestich/example.py
+++ b/src/benchmax/envs/telestich/example.py
@@ -42,7 +42,7 @@ from benchmax.rubrics import rubric as rubric_mod
 #
 # Defaults route through ``benchmax.config``: the prod LLM endpoint is
 # ``https://llm.castform.com/v1`` and the platform control plane is
-# ``https://api.castform.com``. Point at staging or a different env by setting
+# ``https://api.castform.com``. Point at a different environment by setting
 # ``CASTFORM_BASE_DOMAIN`` (or override URLs individually via
 # ``CASTFORM_PLATFORM_URL`` / ``CASTFORM_LLM_URL``).
 from benchmax import config

--- a/src/benchmax/platform/credentials.py
+++ b/src/benchmax/platform/credentials.py
@@ -123,8 +123,7 @@ def read_castform_session() -> dict | None:
     world/group-readable credential is not trusted. Written by ``castform
     login`` (Phase 4); schema::
 
-        {"access_token": str, "refresh_token": str, "expires_at": int,
-         "env": "staging"}   # env omitted for prod (the default)
+        {"access_token": str, "refresh_token": str, "expires_at": int}
 
     ``refresh_token`` is reserved for the per-process mint/refresh added with the
     device flow (Phase 3/4); today only ``access_token`` / ``env`` are consumed.

--- a/src/benchmax/platform/login.py
+++ b/src/benchmax/platform/login.py
@@ -18,21 +18,11 @@ from . import credentials
 from .device_auth import poll_for_token, request_device_code
 
 
-def _auth_url(env: str | None) -> str:
-    """Auth host for a login. There's no cached session yet to derive from, so
-    map the chosen env directly; ``CASTFORM_AUTH_URL`` (local dev) always wins."""
-    override = os.environ.get("CASTFORM_AUTH_URL")
-    if override:
-        return override
-    base = os.environ.get("CASTFORM_BASE_DOMAIN") or (
-        "castform.dev" if env == "staging" else "castform.com"
-    )
-    return f"https://auth.{base}"
-
-
-def _login(env: str | None) -> None:
+def _login() -> None:
     """Run the device flow and cache the session. Raises DeviceAuthError on failure."""
-    auth = _auth_url(env)
+    from benchmax import config
+
+    auth = config.auth_url()
     dc = request_device_code(auth)
     verification = dc.get("verification_uri_complete") or dc["verification_uri"]
     print(f"\nTo sign in, open this URL in your browser:\n\n    {verification}\n")
@@ -51,13 +41,10 @@ def _login(env: str | None) -> None:
         session["refresh_token"] = tok["refresh_token"]
     if tok.get("expires_in"):
         session["expires_at"] = int(time.time()) + int(tok["expires_in"])
-    # prod carries no env marker (the default); only internal staging logins set it.
-    if env == "staging":
-        session["env"] = "staging"
     credentials.write_castform_session(session)
 
 
-def ensure_session(env: str | None = None, *, interactive: bool | None = None) -> None:
+def ensure_session(*, interactive: bool | None = None) -> None:
     """Make sure a platform credential is available; auto-login if interactive.
 
     No-op when one already resolves (``ACT_AS_TOKEN_PATH`` / ``PLATFORM_API_KEY`` /
@@ -78,4 +65,4 @@ def ensure_session(env: str | None = None, *, interactive: bool | None = None) -
         interactive = sys.stdin.isatty() and sys.stdout.isatty()
     if not interactive or os.environ.get("CASTFORM_NO_AUTO_LOGIN"):
         return
-    _login(env)
+    _login()

--- a/tests/unit/platform/test_credentials.py
+++ b/tests/unit/platform/test_credentials.py
@@ -192,10 +192,10 @@ def test_read_castform_session_malformed_returns_none(tmp_path, monkeypatch):
 
 def test_write_session_creates_dir_and_0600(tmp_path, monkeypatch):
     monkeypatch.setenv(_CRED_PATH_ENV, str(tmp_path / "sub" / "credentials.json"))
-    write_castform_session({"access_token": "sess_abc", "env": "staging"})
+    write_castform_session({"access_token": "sess_abc", "refresh_token": "r"})
     p = tmp_path / "sub" / "credentials.json"
     assert oct(p.stat().st_mode & 0o777) == "0o600"
-    assert read_castform_session() == {"access_token": "sess_abc", "env": "staging"}
+    assert read_castform_session() == {"access_token": "sess_abc", "refresh_token": "r"}
 
 
 def test_clear_session_removes_file_and_jwt_cache(tmp_path, monkeypatch):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -50,23 +50,18 @@ def stub_flow(monkeypatch):
     return captured
 
 
-def test_login_prod_omits_env_marker(stub_flow):
-    assert cli._cmd_login(argparse.Namespace(env="prod")) == 0
+def test_login_writes_session(stub_flow):
+    assert cli._cmd_login(argparse.Namespace()) == 0
     s = stub_flow["session"]
     assert s["access_token"] == "sess_abc"
-    assert "env" not in s  # prod carries no marker
+    assert "env" not in s  # no env concept — domain comes from config/env var
     assert s["expires_at"] > 0
-
-
-def test_login_staging_sets_env(stub_flow):
-    cli._cmd_login(argparse.Namespace(env="staging"))
-    assert stub_flow["session"]["env"] == "staging"
 
 
 def test_login_failure_returns_1(monkeypatch):
     monkeypatch.setenv("CASTFORM_AUTH_URL", "http://localhost:4300")
     monkeypatch.setattr(login, "request_device_code", _raise_device_auth)
-    assert cli._cmd_login(argparse.Namespace(env="prod")) == 1
+    assert cli._cmd_login(argparse.Namespace()) == 1
 
 
 def test_logout_clears_session(monkeypatch):
@@ -85,7 +80,7 @@ def test_whoami_not_logged_in(monkeypatch):
 
 def test_whoami_logged_in_shows_email(monkeypatch, capsys):
     monkeypatch.setattr(
-        credentials, "read_castform_session", lambda: {"access_token": "x", "env": "staging"}
+        credentials, "read_castform_session", lambda: {"access_token": "x"}
     )
     claims = base64.urlsafe_b64encode(json.dumps({"email": "a@b.com"}).encode()).rstrip(b"=")
     monkeypatch.setattr(credentials, "_session_jwt", lambda: f"h.{claims.decode()}.s")
@@ -96,7 +91,7 @@ def test_whoami_logged_in_shows_email(monkeypatch, capsys):
 def test_ensure_session_noop_when_credential_resolves(monkeypatch):
     monkeypatch.setattr(credentials, "platform_bearer", lambda: "tok")
     called = {}
-    monkeypatch.setattr(login, "_login", lambda env=None: called.setdefault("login", True))
+    monkeypatch.setattr(login, "_login", lambda: called.setdefault("login", True))
     login.ensure_session()
     assert "login" not in called
 
@@ -105,7 +100,7 @@ def test_ensure_session_skips_when_not_interactive(monkeypatch):
     monkeypatch.delenv("CASTFORM_NO_AUTO_LOGIN", raising=False)
     monkeypatch.setattr(credentials, "platform_bearer", _raise_runtime)
     called = {}
-    monkeypatch.setattr(login, "_login", lambda env=None: called.setdefault("login", True))
+    monkeypatch.setattr(login, "_login", lambda: called.setdefault("login", True))
     login.ensure_session(interactive=False)
     assert "login" not in called
 
@@ -114,6 +109,6 @@ def test_ensure_session_logs_in_when_interactive(monkeypatch):
     monkeypatch.delenv("CASTFORM_NO_AUTO_LOGIN", raising=False)
     monkeypatch.setattr(credentials, "platform_bearer", _raise_runtime)
     called = {}
-    monkeypatch.setattr(login, "_login", lambda env=None: called.setdefault("login", True))
+    monkeypatch.setattr(login, "_login", lambda: called.setdefault("login", True))
     login.ensure_session(interactive=True)
     assert called.get("login")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,55 +2,43 @@
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from benchmax import config
 
-_CRED_PATH_ENV = "CASTFORM_CREDENTIALS_PATH"
-
 
 @pytest.fixture(autouse=True)
-def _clear_url_env(monkeypatch, tmp_path):
-    """Hermetic defaults: no explicit URL/domain overrides, and the session
-    cache points at a non-existent file so a real ~/.castform can't leak in."""
-    for var in ("CASTFORM_BASE_DOMAIN", "CASTFORM_PLATFORM_URL", "CASTFORM_LLM_URL"):
+def _clear_url_env(monkeypatch):
+    """Hermetic defaults: no explicit URL/domain overrides leaking from the env."""
+    for var in (
+        "CASTFORM_BASE_DOMAIN",
+        "CASTFORM_PLATFORM_URL",
+        "CASTFORM_LLM_URL",
+        "CASTFORM_AUTH_URL",
+    ):
         monkeypatch.delenv(var, raising=False)
-    monkeypatch.setenv(_CRED_PATH_ENV, str(tmp_path / "no-creds.json"))
-
-
-def _write_session(tmp_path, monkeypatch, data):
-    f = tmp_path / "credentials.json"
-    f.write_text(json.dumps(data))
-    f.chmod(0o600)
-    monkeypatch.setenv(_CRED_PATH_ENV, str(f))
 
 
 def test_base_domain_defaults_to_prod():
     assert config.base_domain() == "castform.com"
 
 
-def test_base_domain_from_staging_session(tmp_path, monkeypatch):
-    _write_session(tmp_path, monkeypatch, {"access_token": "x", "env": "staging"})
+def test_base_domain_from_env_var(monkeypatch):
+    monkeypatch.setenv("CASTFORM_BASE_DOMAIN", "castform.dev")
     assert config.base_domain() == "castform.dev"
 
 
-def test_prod_session_has_no_env_marker(tmp_path, monkeypatch):
-    """A prod session carries no env marker → prod default (no redundant field)."""
-    _write_session(tmp_path, monkeypatch, {"access_token": "x"})
-    assert config.base_domain() == "castform.com"
-
-
-def test_explicit_base_domain_overrides_session(tmp_path, monkeypatch):
-    _write_session(tmp_path, monkeypatch, {"access_token": "x", "env": "staging"})
-    monkeypatch.setenv("CASTFORM_BASE_DOMAIN", "castform.com")
-    assert config.base_domain() == "castform.com"
-
-
-def test_staging_session_drives_both_platform_and_llm_urls(tmp_path, monkeypatch):
-    """The env claim travels with the credential, so api + llm both route to the
-    same env — structurally preventing the .dev->.com misroute class."""
-    _write_session(tmp_path, monkeypatch, {"access_token": "x", "env": "staging"})
+def test_base_domain_drives_all_service_urls(monkeypatch):
+    """One domain knob routes every service URL together."""
+    monkeypatch.setenv("CASTFORM_BASE_DOMAIN", "castform.dev")
     assert config.platform_url() == "https://api.castform.dev"
     assert config.llm_url() == "https://llm.castform.dev/v1"
+    assert config.auth_url() == "https://auth.castform.dev"
+
+
+def test_per_service_override_wins(monkeypatch):
+    """A per-service URL override beats the derived domain — e.g. point platform
+    at a local server while auth keeps talking to the real host."""
+    monkeypatch.setenv("CASTFORM_PLATFORM_URL", "http://localhost:3000")
+    assert config.platform_url() == "http://localhost:3000"
+    assert config.auth_url() == "https://auth.castform.com"


### PR DESCRIPTION
URL/domain selection now comes from exactly two sources: the CASTFORM_BASE_DOMAIN env var or the castform.com default. Drops the staging/prod "env" concept entirely:

- config: base_domain() is now just `CASTFORM_BASE_DOMAIN or default`; removed _session_env() and the session-env -> domain map.
- login: _login()/ensure_session() lose their `env` param; _auth_url() removed (uses config.auth_url()); session no longer stores an `env` key.
- cli: `castform login` drops `--env`; whoami/login report the resolved base domain instead of a stored env marker.
- credentials: documented session schema drops `env`.

Per-service overrides (CASTFORM_PLATFORM_URL / _LLM_URL / _AUTH_URL / _WEB_APP_URL) are unchanged and remain the way to point one service at localhost while the rest stay remote.

Tests updated to the env-var model; obsolete env-marker tests removed.

Migration: an existing ~/.castform session with `env: staging` is now ignored — internal staging users export CASTFORM_BASE_DOMAIN=castform.dev.