### PR TITLE
fix(rag/chroma): downgrade to vector-only when collection lacks BM25 index

### DIFF
--- a/src/benchmax/rag/corpus/chroma/client.py
+++ b/src/benchmax/rag/corpus/chroma/client.py
@@ -169,7 +169,70 @@ class ChromaClient:
                 kwargs["metadata"] = metadata
             self._collection = client.get_or_create_collection(**kwargs)
 
+        # When the caller supplies no embed_fn we rely on the collection's own
+        # (server-side) embedding function. Repair it if chromadb can't.
+        if self.embed_fn is None:
+            self._repair_cloud_embedding_function(self._collection)
+
         return self._collection
+
+    @staticmethod
+    def _repair_cloud_embedding_function(collection: Any) -> None:
+        """Attach a working EF when chromadb can't rebuild a Cloud hosted one.
+
+        A Chroma Cloud collection embedded with the hosted ``chroma-cloud-qwen``
+        function stores ``task=None`` in its config, but chromadb's
+        ``build_from_config`` asserts ``task`` is required and raises
+        "Could not build embedding function chroma-cloud-qwen" on *any* text
+        query (legacy ``query()`` and the Search API alike). The bug is present
+        through at least chromadb 1.5.9 (latest at time of writing), so a version
+        bump is not a fix.
+
+        ``Collection._embed`` prefers an explicitly-set ``_embedding_function``
+        over the config-loaded one, so we build the EF directly (its constructor
+        accepts ``task=None``) and attach it — sidestepping the broken loader.
+        The embedding itself still happens server-side at embed.trychroma.com, so
+        results match what the collection was indexed with. Reads the raw
+        ``configuration_json`` dict rather than the ``configuration`` property,
+        because the property is exactly what triggers the failing rebuild.
+
+        Best-effort and fully guarded: any deviation in chromadb internals or a
+        missing API key leaves the collection untouched (current behavior).
+        """
+        # chromadb sets _embedding_function to a DefaultEmbeddingFunction when no
+        # EF is supplied, and its _embed() ignores that default (falling through
+        # to the config loader). So only a real, non-default EF means "already
+        # resolved" — don't override that.
+        existing = getattr(collection, "_embedding_function", None)
+        if existing is not None and type(existing).__name__ != "DefaultEmbeddingFunction":
+            return
+        try:
+            ef_config = (collection._model.configuration_json or {}).get(
+                "embedding_function"
+            ) or {}
+        except Exception:
+            return
+        if ef_config.get("name") != "chroma-cloud-qwen":
+            return
+        try:
+            from chromadb.utils.embedding_functions.chroma_cloud_qwen_embedding_function import (
+                ChromaCloudQwenEmbeddingFunction,
+                ChromaCloudQwenEmbeddingModel,
+            )
+
+            raw_model = ef_config.get("model")
+            model = (
+                ChromaCloudQwenEmbeddingModel(raw_model)
+                if raw_model
+                else ChromaCloudQwenEmbeddingModel.QWEN3_EMBEDDING_0p6B
+            )
+            collection._embedding_function = ChromaCloudQwenEmbeddingFunction(
+                model=model,
+                task=ef_config.get("task"),
+                api_key_env_var=ef_config.get("api_key_env_var", "CHROMA_API_KEY"),
+            )
+        except Exception:
+            return
 
     @staticmethod
     def _has_bm25_index(collection: Any) -> bool:

--- a/src/benchmax/rag/corpus/chroma/client.py
+++ b/src/benchmax/rag/corpus/chroma/client.py
@@ -150,6 +150,17 @@ class ChromaClient:
                 self.modes = {"vector"}
                 self.ranking = {"cosine"}
 
+        # get_or_create_collection returns a PRE-EXISTING collection as-is: when
+        # one already exists (e.g. linked from Chroma Cloud, built outside
+        # benchmax), our BM25 schema is never applied and no exception fires. The
+        # collection then has no `bm25_embedding` sparse index, so any lexical /
+        # hybrid query raises "key not found in schema". Verify the index is
+        # actually present and downgrade to vector-only when it isn't, so the
+        # advertised capabilities match what the collection can serve.
+        if created_with_schema and not self._has_bm25_index(self._collection):
+            self.modes = {"vector"}
+            self.ranking = {"cosine"}
+
         if not created_with_schema:
             metadata: dict[str, str] = {}
             if self.distance_metric:
@@ -159,6 +170,29 @@ class ChromaClient:
             self._collection = client.get_or_create_collection(**kwargs)
 
         return self._collection
+
+    @staticmethod
+    def _has_bm25_index(collection: Any) -> bool:
+        """True when *collection* exposes a usable BM25 sparse index.
+
+        Mirrors Chroma's own query-time gate
+        (``CollectionCommon._embed_knn_string_queries``): a string query against
+        ``BM25_KEY`` only succeeds when the key is present in the schema with an
+        enabled sparse-vector index that carries an embedding function. Any
+        introspection failure is treated as "not ready" — vector-only is always
+        safe, whereas falsely advertising BM25 surfaces as a hard error mid-run.
+        """
+        try:
+            schema = collection.schema
+        except Exception:
+            return False
+        if schema is None or BM25_KEY not in getattr(schema, "keys", {}):
+            return False
+        sparse = getattr(schema.keys[BM25_KEY], "sparse_vector", None)
+        index = getattr(sparse, "sparse_vector_index", None)
+        if index is None or not getattr(index, "enabled", False):
+            return False
+        return getattr(getattr(index, "config", None), "embedding_function", None) is not None
 
     def _build_schema(self) -> Any:
         from chromadb import Schema, SparseVectorIndexConfig

--- a/src/benchmax/rag/corpus/chroma/source.py
+++ b/src/benchmax/rag/corpus/chroma/source.py
@@ -564,7 +564,7 @@ class ChromaChunkSource:
 
         Picks the best available mode: hybrid > lexical > vector.
         """
-        modes = self._search_capabilities["modes"]
+        modes = self._current_modes()
         if "hybrid" in modes:
             vector = self.embed_query(text_query)
             return self.search(
@@ -597,6 +597,19 @@ class ChromaChunkSource:
             )
         )
 
+    def _current_modes(self) -> set[SearchMode]:
+        """Return live search modes, refreshing capabilities after lazy init.
+
+        ``get_collection()`` is cached/idempotent; calling it ensures any
+        capability downgrade (e.g. a collection lacking a BM25 index) has been
+        applied before we read modes. ``_search_capabilities`` is frozen at
+        construction — before that lazy init — so re-sync it from the client.
+        """
+        self._chroma.get_collection()
+        self._search_capabilities["modes"] = cast(set[SearchMode], self._chroma.modes)
+        self._search_capabilities["ranking"] = set(self._chroma.ranking)
+        return self._search_capabilities["modes"]
+
     def search_related(
         self,
         source: Chunk,
@@ -625,10 +638,25 @@ class ChromaChunkSource:
         source_file = self._files.chunk_file_path(source) if file_aware else None
         source_idx = self._files.chunk_index(source) if file_aware else None
 
-        # Pick best mode
-        modes = self._search_capabilities["modes"]
-        use_hybrid = "hybrid" in modes
-        use_lexical = "lexical" in modes
+        # Refresh capabilities before choosing a mode: the backing collection may
+        # lack a BM25 index, in which case modes was downgraded to vector-only.
+        modes = self._current_modes()
+
+        # Pick mode. An explicit `mode` restricts to that strategy (clamped to
+        # what the collection supports); mode=None keeps the "best available"
+        # default. Clamping is what lets callers (e.g. the QA metadata-linker)
+        # force vector search to recover from a lexical/hybrid failure.
+        if mode == "vector":
+            use_hybrid = use_lexical = False
+        elif mode == "lexical":
+            use_hybrid = False
+            use_lexical = "lexical" in modes
+        elif mode == "hybrid":
+            use_hybrid = "hybrid" in modes
+            use_lexical = False
+        else:  # None or unrecognized -> best available
+            use_hybrid = "hybrid" in modes
+            use_lexical = "lexical" in modes
 
         # Batch-embed all queries when embed_fn available and vectors needed
         vectors: list[list[float]] | None = None

--- a/tests/unit/rag/corpus/chroma/test_configurations.py
+++ b/tests/unit/rag/corpus/chroma/test_configurations.py
@@ -490,6 +490,99 @@ class TestBm25Downgrade:
 
 
 # ---------------------------------------------------------------------------
+# Chroma Cloud hosted embedding-function repair
+# ---------------------------------------------------------------------------
+
+
+class _FakeModel:
+    def __init__(self, cfg):
+        self.configuration_json = cfg
+
+
+class _FakeCloudCollection:
+    """Minimal stand-in for a chromadb Collection's EF-relevant internals."""
+
+    def __init__(self, cfg, ef=None):
+        self._model = _FakeModel(cfg)
+        self._embedding_function = ef
+
+
+_QWEN_CFG = {
+    "embedding_function": {
+        "name": "chroma-cloud-qwen",
+        "model": "Qwen/Qwen3-Embedding-0.6B",
+        "task": None,
+    }
+}
+
+_QWEN_EF_PATH = (
+    "chromadb.utils.embedding_functions."
+    "chroma_cloud_qwen_embedding_function.ChromaCloudQwenEmbeddingFunction"
+)
+
+
+class TestCloudQwenEmbeddingRepair:
+    """chromadb's build_from_config rejects chroma-cloud-qwen's task=None config
+    (through >=1.5.9), breaking every text query. _repair_cloud_embedding_function
+    attaches a directly-built EF so _embed uses it instead of the broken loader.
+    """
+
+    def test_attaches_ef_for_cloud_qwen_config(self):
+        from benchmax.rag.corpus.chroma.client import ChromaClient
+
+        col = _FakeCloudCollection(_QWEN_CFG)
+        sentinel = object()
+        with patch(_QWEN_EF_PATH, return_value=sentinel) as ef_cls:
+            ChromaClient._repair_cloud_embedding_function(col)
+        assert col._embedding_function is sentinel
+        # task=None must be forwarded (the value chromadb chokes on).
+        assert ef_cls.call_args.kwargs["task"] is None
+
+    def test_repairs_over_default_embedding_function(self):
+        """A DefaultEmbeddingFunction means 'unresolved' — chromadb ignores it."""
+        from benchmax.rag.corpus.chroma.client import ChromaClient
+
+        class DefaultEmbeddingFunction:  # name is what the guard checks
+            pass
+
+        col = _FakeCloudCollection(_QWEN_CFG, ef=DefaultEmbeddingFunction())
+        sentinel = object()
+        with patch(_QWEN_EF_PATH, return_value=sentinel):
+            ChromaClient._repair_cloud_embedding_function(col)
+        assert col._embedding_function is sentinel
+
+    def test_leaves_real_embedding_function_untouched(self):
+        from benchmax.rag.corpus.chroma.client import ChromaClient
+
+        real_ef = object()  # type name != DefaultEmbeddingFunction
+        col = _FakeCloudCollection(_QWEN_CFG, ef=real_ef)
+        with patch(_QWEN_EF_PATH, return_value=object()):
+            ChromaClient._repair_cloud_embedding_function(col)
+        assert col._embedding_function is real_ef
+
+    def test_ignores_non_cloud_qwen_config(self):
+        from benchmax.rag.corpus.chroma.client import ChromaClient
+
+        col = _FakeCloudCollection({"embedding_function": {"name": "openai"}})
+        ChromaClient._repair_cloud_embedding_function(col)
+        assert col._embedding_function is None
+
+    def test_guarded_against_broken_internals(self):
+        """Any deviation in chromadb internals is a no-op, never a crash."""
+        from benchmax.rag.corpus.chroma.client import ChromaClient
+
+        class _Boom:
+            @property
+            def configuration_json(self):
+                raise RuntimeError("internals changed")
+
+        col = _FakeCloudCollection({})
+        col._model = _Boom()
+        ChromaClient._repair_cloud_embedding_function(col)  # must not raise
+        assert col._embedding_function is None
+
+
+# ---------------------------------------------------------------------------
 # search_related / search_text honor and clamp the requested mode
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/rag/corpus/chroma/test_configurations.py
+++ b/tests/unit/rag/corpus/chroma/test_configurations.py
@@ -13,6 +13,7 @@ Covers degraded/variant customer configurations:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -24,10 +25,29 @@ from fakes.chroma import (
 )
 
 from benchmax.rag.chunkers.models import Chunk
+from benchmax.rag.corpus.chroma.client import BM25_KEY
 from benchmax.rag.corpus.search_schema.search_exceptions import (
     UnsupportedSearchModeError,
 )
 from benchmax.rag.corpus.search_schema.search_types import SearchSpec
+
+
+def _fake_schema(*, has_bm25: bool, enabled: bool = True):
+    """Build a stand-in for chromadb's Schema object.
+
+    Mirrors the attribute chain ChromaClient._has_bm25_index walks:
+    schema.keys[BM25_KEY].sparse_vector.sparse_vector_index.{enabled,config}.
+    """
+    if not has_bm25:
+        return SimpleNamespace(keys={})
+    index = SimpleNamespace(
+        enabled=enabled,
+        config=SimpleNamespace(embedding_function=object()),
+    )
+    value_type = SimpleNamespace(
+        sparse_vector=SimpleNamespace(sparse_vector_index=index)
+    )
+    return SimpleNamespace(keys={BM25_KEY: value_type})
 
 # ---------------------------------------------------------------------------
 # Capabilities
@@ -209,7 +229,9 @@ class TestSearchTextFlow:
         """search_text picks hybrid mode when Search API + BM25 available."""
         col = FakeCollection(count=5)
         source = make_source(col)
-        # Enable hybrid/lexical
+        # Enable hybrid/lexical. _chroma.modes is the source of truth — search_text
+        # re-syncs capabilities from it after lazy collection init.
+        source._chroma.modes = {"vector", "lexical", "hybrid"}
         source._search_capabilities["modes"] = {"vector", "lexical", "hybrid"}
         source._chroma.search_api = True
 
@@ -227,6 +249,7 @@ class TestSearchTextFlow:
         """search_text picks lexical when hybrid is unavailable."""
         col = FakeCollection(count=5)
         source = make_source(col)
+        source._chroma.modes = {"vector", "lexical"}
         source._search_capabilities["modes"] = {"vector", "lexical"}
         source._chroma.search_api = True
 
@@ -403,6 +426,133 @@ class TestBm25Downgrade:
         # get_or_create_collection called twice: once with schema (failed),
         # once without (succeeded)
         assert mock_client.get_or_create_collection.call_count == 2
+
+    def test_existing_collection_without_bm25_index_downgrades(self):
+        """A pre-existing collection (no BM25 index) downgrades to vector-only.
+
+        get_or_create_collection returns an existing collection as-is, so the
+        schema-based create "succeeds" without applying our BM25 index. The
+        index-readiness probe must catch that and drop lexical/hybrid, or a
+        later query raises "key not found in schema".
+        """
+        from benchmax.rag.corpus.chroma.client import BM25_KEY, ChromaClient
+
+        with patch("benchmax.rag.corpus.chroma.client.has_search_api", return_value=True):
+            chroma = ChromaClient(collection_name="t", host="h", enable_bm25=True)
+        assert chroma.modes == {"vector", "lexical", "hybrid"}
+
+        existing = SimpleNamespace(schema=_fake_schema(has_bm25=False))
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection = MagicMock(return_value=existing)
+        chroma._raw_client = mock_client
+
+        with patch.object(ChromaClient, "_build_schema", return_value={"sentinel": 1}):
+            result = chroma.get_collection()
+
+        assert result is existing
+        assert chroma.modes == {"vector"}
+        assert chroma.ranking == {"cosine"}
+        # Schema branch "succeeded" -> no fallback create.
+        assert mock_client.get_or_create_collection.call_count == 1
+        assert BM25_KEY not in existing.schema.keys
+
+    def test_collection_with_bm25_index_keeps_lexical_hybrid(self):
+        """A collection that actually has the BM25 index keeps lexical+hybrid."""
+        from benchmax.rag.corpus.chroma.client import ChromaClient
+
+        with patch("benchmax.rag.corpus.chroma.client.has_search_api", return_value=True):
+            chroma = ChromaClient(collection_name="t", host="h", enable_bm25=True)
+
+        indexed = SimpleNamespace(schema=_fake_schema(has_bm25=True))
+        mock_client = MagicMock()
+        mock_client.get_or_create_collection = MagicMock(return_value=indexed)
+        chroma._raw_client = mock_client
+
+        with patch.object(ChromaClient, "_build_schema", return_value={"sentinel": 1}):
+            chroma.get_collection()
+
+        assert chroma.modes == {"vector", "lexical", "hybrid"}
+        assert chroma.ranking == {"cosine", "bm25"}
+
+    def test_index_probe_treats_missing_schema_as_not_ready(self):
+        """No schema attr / None schema -> downgrade (vector is always safe)."""
+        from benchmax.rag.corpus.chroma.client import ChromaClient
+
+        assert ChromaClient._has_bm25_index(SimpleNamespace(schema=None)) is False
+        assert ChromaClient._has_bm25_index(object()) is False  # no .schema attr
+        # Key present but sparse index disabled -> not usable.
+        assert (
+            ChromaClient._has_bm25_index(
+                SimpleNamespace(schema=_fake_schema(has_bm25=True, enabled=False))
+            )
+            is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# search_related / search_text honor and clamp the requested mode
+# ---------------------------------------------------------------------------
+
+
+class TestSearchModeClamp:
+    def test_explicit_vector_mode_forces_vector_path(self):
+        """mode='vector' uses the query() vector path even when hybrid is available.
+
+        Lets the QA metadata-linker force vector search to recover from a
+        lexical/hybrid failure without depending on capability state.
+        """
+        col = FakeCollection(
+            query_results_per_call=[make_query_result(["v"])],
+            count=5,
+        )
+        source = make_source(col, files=NoFileFakeFiles())
+        source._chroma.modes = {"vector", "lexical", "hybrid"}
+        source._chroma.search_api = True
+
+        primary = Chunk(content="src", metadata=())
+        results = source.search_related(primary, ["q"], top_k=5, mode="vector")
+        assert results[0]["chunk"].content == "v"
+        # Vector path went through the legacy query() API, not collection.search().
+        assert col._last_query_kwargs["query_texts"] == ["q"]
+
+    def test_downgraded_modes_clamp_stale_hybrid_request_to_vector(self):
+        """A stale mode='hybrid' is clamped to vector when the index is gone.
+
+        Mirrors the linker passing best_search_mode='hybrid' against a
+        collection whose capabilities were downgraded to vector-only.
+        """
+        col = FakeCollection(
+            query_results_per_call=[make_query_result(["v"])],
+            count=5,
+        )
+        source = make_source(col, files=NoFileFakeFiles())
+        source._chroma.modes = {"vector"}  # downgraded
+        source._chroma.search_api = True
+
+        primary = Chunk(content="src", metadata=())
+        results = source.search_related(primary, ["q"], top_k=5, mode="hybrid")
+        assert results[0]["chunk"].content == "v"
+
+    def test_search_related_refreshes_modes_from_client(self):
+        """search_related re-syncs _search_capabilities from _chroma.modes.
+
+        A source whose capabilities still advertise hybrid (frozen at
+        construction) but whose client was downgraded must not attempt hybrid.
+        """
+        col = FakeCollection(
+            query_results_per_call=[make_query_result(["v"])],
+            count=5,
+        )
+        source = make_source(col, files=NoFileFakeFiles())
+        # Stale capabilities say hybrid; client is the source of truth (vector).
+        source._search_capabilities["modes"] = {"vector", "lexical", "hybrid"}
+        source._chroma.modes = {"vector"}
+        source._chroma.search_api = True
+
+        primary = Chunk(content="src", metadata=())
+        results = source.search_related(primary, ["q"], top_k=5)
+        assert results[0]["chunk"].content == "v"
+        assert source._search_capabilities["modes"] == {"vector"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
QA generation against a pre-existing Chroma Cloud collection (linked via the platform-service wizard) failed in the metadata-linker. Two independent bugs surface in sequence; both are fixed here and validated end-to-end against a **live Chroma Cloud collection** (hosted qwen embedder, no BM25 index).

### Bug 1 — false BM25 capability
`get_or_create_collection(schema=...)` returns an **existing** collection as-is, so a collection built outside benchmax never gets our BM25 sparse index and no exception fires. Capabilities kept advertising `lexical`/`hybrid`, and the linker's hybrid query hit a collection with no `bm25_embedding` key:

> `ValueError: Cannot embed string query for key 'bm25_embedding': key not found in schema.`

Compounded by `search_related` **ignoring its `mode` parameter**, so the linker's retry-without-mode re-ran the same hybrid query.

### Bug 2 — chroma-cloud-qwen EF can't be rebuilt
After the BM25 downgrade, the vector fallback hit a second, unrelated chromadb bug. A Cloud collection embedded with the hosted `chroma-cloud-qwen` function stores `task=None`, but chromadb's `build_from_config` asserts `task` is required:

> `ValueError: Could not build embedding function chroma-cloud-qwen ... Config is missing a required field`

This breaks **every** text query (legacy `query()` and Search API), and is present through at least chromadb **1.5.9** (latest) — a version bump is not a fix.

## Changes
- **`client.py` `get_collection`**
  - Probes the returned collection's schema (`_has_bm25_index`) and downgrades `modes`/`ranking` to vector-only when the BM25 index isn't actually present (mirrors Chroma's own query-time gate).
  - `_repair_cloud_embedding_function`: when no user `embed_fn` is set and the collection's stored EF is `chroma-cloud-qwen`, builds the EF directly (its constructor accepts `task=None`) and attaches it as `_embedding_function`, which `Collection._embed` prefers over the config-loaded one. Reads raw `configuration_json` (not the `.configuration` property, which triggers the rebuild); fully guarded; treats a `DefaultEmbeddingFunction` as unresolved.
- **`source.py`** — `search_related` honors its `mode` arg (clamped to supported modes); new `_current_modes()` re-syncs capabilities from the client after lazy collection init, so the downgrade is visible at mode-selection time. Used by `search_related` and `search_text`.

## Effect
QA-gen against an externally-built Chroma Cloud collection now works automatically: it downgrades to vector search and embeds queries via the collection's hosted function. Lexical/hybrid still requires ingesting the collection *through* benchmax so the BM25 index is created.

## Validation
- `pytest tests/unit/rag/corpus/chroma/` — **79 pass** (added: BM25 downgrade/probe, mode-clamp/refresh, and cloud-qwen EF repair)
- `ruff check` clean; no new mypy errors
- **Live Chroma Cloud** (`Demo / customer-support-messages`, hosted qwen, no BM25 index): reproduced both errors pre-fix; post-fix `search_related` returns relevant results with no error.

## Follow-up (separate, not in this PR)
benchmax's vector path uses the legacy `query()` API. Routing vector search through the Search API (server-side embed) would reduce reliance on client-side EF reconstruction for Cloud collections. Out of scope here.