### PR TITLE
feat(cli): open the device-auth URL in the browser

### DIFF
--- a/src/benchmax/platform/login.py
+++ b/src/benchmax/platform/login.py
@@ -13,9 +13,32 @@ from __future__ import annotations
 import os
 import sys
 import time
+import webbrowser
 
 from . import credentials
 from .device_auth import poll_for_token, request_device_code
+
+
+def _maybe_open_browser(url: str) -> None:
+    """Best-effort: open the verification URL so the user needn't copy it.
+
+    The link and code are always printed above (the real path); opening is just
+    convenience, and done immediately (a blocking prompt would stall the approval
+    poll). Skipped when there's no useful local browser to open — a
+    non-interactive stdin, an SSH session (the browser would spawn on the remote
+    host, not the user's machine), or an explicit ``CASTFORM_NO_BROWSER`` opt-out
+    — then the user opens the printed link themselves.
+    """
+    if (
+        not sys.stdin.isatty()
+        or os.environ.get("SSH_CONNECTION")
+        or os.environ.get("CASTFORM_NO_BROWSER")
+    ):
+        return
+    try:
+        webbrowser.open(url)
+    except Exception:
+        pass  # best-effort; the printed link is the fallback
 
 
 def _login() -> None:
@@ -27,6 +50,7 @@ def _login() -> None:
     verification = dc.get("verification_uri_complete") or dc["verification_uri"]
     print(f"\nTo sign in, open this URL in your browser:\n\n    {verification}\n")
     print(f"and confirm this code:  {dc['user_code']}\n")
+    _maybe_open_browser(verification)
     print("Waiting for approval…")
 
     tok = poll_for_token(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -47,6 +47,9 @@ def stub_flow(monkeypatch):
     monkeypatch.setattr(
         credentials, "write_castform_session", lambda s: captured.update(session=s)
     )
+    # This test is about session writing, not browser UX — stub the open so it
+    # never launches a real browser (e.g. under `pytest -s`, where stdin is a tty).
+    monkeypatch.setattr(login, "_maybe_open_browser", lambda _u: None)
     return captured
 
 
@@ -67,7 +70,9 @@ def test_login_failure_returns_1(monkeypatch):
 def test_logout_clears_session(monkeypatch):
     called = {}
     monkeypatch.setattr(
-        credentials, "clear_castform_session", lambda: called.setdefault("cleared", True)
+        credentials,
+        "clear_castform_session",
+        lambda: called.setdefault("cleared", True),
     )
     assert cli._cmd_logout(argparse.Namespace()) == 0
     assert called["cleared"]
@@ -82,7 +87,9 @@ def test_whoami_logged_in_shows_email(monkeypatch, capsys):
     monkeypatch.setattr(
         credentials, "read_castform_session", lambda: {"access_token": "x"}
     )
-    claims = base64.urlsafe_b64encode(json.dumps({"email": "a@b.com"}).encode()).rstrip(b"=")
+    claims = base64.urlsafe_b64encode(json.dumps({"email": "a@b.com"}).encode()).rstrip(
+        b"="
+    )
     monkeypatch.setattr(credentials, "_session_jwt", lambda: f"h.{claims.decode()}.s")
     assert cli._cmd_whoami(argparse.Namespace()) == 0
     assert "a@b.com" in capsys.readouterr().out
@@ -112,3 +119,51 @@ def test_ensure_session_logs_in_when_interactive(monkeypatch):
     monkeypatch.setattr(login, "_login", lambda: called.setdefault("login", True))
     login.ensure_session(interactive=True)
     assert called.get("login")
+
+
+class _FakeStdin:
+    def __init__(self, tty: bool):
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+def test_maybe_open_browser_opens_on_tty(monkeypatch):
+    monkeypatch.setattr(login.sys, "stdin", _FakeStdin(True))
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
+    monkeypatch.delenv("CASTFORM_NO_BROWSER", raising=False)
+    opened = {}
+    monkeypatch.setattr(login.webbrowser, "open", lambda u: opened.setdefault("url", u))
+    login._maybe_open_browser("https://app.x/device?user_code=ABCD")
+    assert opened["url"] == "https://app.x/device?user_code=ABCD"
+
+
+def test_maybe_open_browser_skips_over_ssh(monkeypatch):
+    monkeypatch.setattr(login.sys, "stdin", _FakeStdin(True))
+    monkeypatch.setenv("SSH_CONNECTION", "1.2.3.4 5 6.7.8.9 22")
+    monkeypatch.delenv("CASTFORM_NO_BROWSER", raising=False)
+    opened = {}
+    monkeypatch.setattr(login.webbrowser, "open", lambda u: opened.setdefault("url", u))
+    login._maybe_open_browser("https://app.x/device")
+    assert "url" not in opened
+
+
+def test_maybe_open_browser_skips_non_interactive(monkeypatch):
+    monkeypatch.setattr(login.sys, "stdin", _FakeStdin(False))
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
+    monkeypatch.delenv("CASTFORM_NO_BROWSER", raising=False)
+    opened = {}
+    monkeypatch.setattr(login.webbrowser, "open", lambda u: opened.setdefault("url", u))
+    login._maybe_open_browser("https://app.x/device")
+    assert "url" not in opened
+
+
+def test_maybe_open_browser_opt_out(monkeypatch):
+    monkeypatch.setattr(login.sys, "stdin", _FakeStdin(True))
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
+    monkeypatch.setenv("CASTFORM_NO_BROWSER", "1")
+    opened = {}
+    monkeypatch.setattr(login.webbrowser, "open", lambda u: opened.setdefault("url", u))
+    login._maybe_open_browser("https://app.x/device")
+    assert "url" not in opened


### PR DESCRIPTION
## What
The `castform login` device flow already prints the verification URL + user code. This also **opens the prefilled `verification_uri_complete`** (`/device?user_code=…`) in a browser so the user needn't copy it.

## Behavior
- Opened **immediately** — not behind a "Press Enter" prompt. A blocking prompt would sit in front of the approval poll, so a user who opened the link themselves would hang at the prompt until pressing Enter (and then get a redundant second tab). `input()` can't be interrupted by the poll, so a prompt can't coexist with concurrent polling.
- The printed link + code stay the **always-present fallback**.
- Auto-open is **skipped** when there's no useful local browser:
  - non-interactive stdin,
  - an SSH session (`SSH_CONNECTION`) — a browser would spawn on the remote host, not the user's machine,
  - explicit `CASTFORM_NO_BROWSER` opt-out.
- `webbrowser.open` is best-effort (wrapped); the printed link covers any failure.

Pairs with the castform redirect fix (castform#173): prefilled URL → sign-in → returns to `/device` → approve.

## Tests
4 `_maybe_open_browser` tests (opens-on-tty, skips-over-SSH, skips-non-interactive, opt-out) + a guard so the existing `_login` test doesn't try to open a browser. 103 platform tests pass; ruff clean.
