### PR TITLE
fix(rag/chroma): keep lexical fallback for hybrid (regression from #48)

### DIFF
--- a/src/benchmax/rag/corpus/chroma/source.py
+++ b/src/benchmax/rag/corpus/chroma/source.py
@@ -642,19 +642,21 @@ class ChromaChunkSource:
         # lack a BM25 index, in which case modes was downgraded to vector-only.
         modes = self._current_modes()
 
-        # Pick mode. An explicit `mode` restricts to that strategy (clamped to
-        # what the collection supports); mode=None keeps the "best available"
-        # default. Clamping is what lets callers (e.g. the QA metadata-linker)
-        # force vector search to recover from a lexical/hybrid failure.
+        # Pick mode. "hybrid"/None use the best available strategy and KEEP
+        # lexical enabled as a fallback: hybrid = dense + sparse, and when we
+        # can't produce dense query vectors (no embed_fn, the usual remote case)
+        # the per-query loop below degrades to the sparse/lexical leg — which
+        # needs no embedding. Only an explicit "vector" disables lexical; that's
+        # the dense-only recovery path a caller uses after a lexical/hybrid
+        # failure. (Disabling lexical for "hybrid" silently forced vector search,
+        # which made remote collections dense-embed every query — slow, and on a
+        # default-EF collection it pulls the all-MiniLM model.)
         if mode == "vector":
             use_hybrid = use_lexical = False
         elif mode == "lexical":
             use_hybrid = False
             use_lexical = "lexical" in modes
-        elif mode == "hybrid":
-            use_hybrid = "hybrid" in modes
-            use_lexical = False
-        else:  # None or unrecognized -> best available
+        else:  # "hybrid", None, or unrecognized -> best available
             use_hybrid = "hybrid" in modes
             use_lexical = "lexical" in modes
 

--- a/tests/unit/rag/corpus/chroma/test_configurations.py
+++ b/tests/unit/rag/corpus/chroma/test_configurations.py
@@ -626,6 +626,31 @@ class TestSearchModeClamp:
         results = source.search_related(primary, ["q"], top_k=5, mode="hybrid")
         assert results[0]["chunk"].content == "v"
 
+    def test_hybrid_without_embed_fn_degrades_to_lexical_not_vector(self):
+        """mode='hybrid' + no client embed_fn must run LEXICAL, not vector.
+
+        Remote collections have no embed_fn, so dense query vectors can't be
+        produced. Hybrid must degrade to its sparse/lexical leg (no embedding),
+        not fall through to vector search — which would force chromadb to embed
+        every query (slow; pulls the all-MiniLM model on a default-EF collection).
+        """
+        col = FakeCollection(count=5)
+        source = make_source(col, files=NoFileFakeFiles())  # embed_fn=None
+        source._chroma.modes = {"vector", "lexical", "hybrid"}
+        source._chroma.search_api = True
+
+        captured: list[str | None] = []
+
+        def _capture(spec):
+            captured.append(spec.get("mode"))
+            return []
+
+        source._search_with_scores = _capture  # type: ignore[method-assign]
+        source.search_related(
+            Chunk(content="src", metadata=()), ["q"], top_k=3, mode="hybrid"
+        )
+        assert captured == ["lexical"]
+
     def test_search_related_refreshes_modes_from_client(self):
         """search_related re-syncs _search_capabilities from _chroma.modes.
 


### PR DESCRIPTION
## Summary
Follow-up to #48. The mode-honoring change in #48 introduced a regression for **remote collections that are queried in hybrid mode without a client-side embedder** — QA-gen hangs instead of running fast.

### Root cause
`search_related` only computes dense query vectors when `embed_fn` is set (the usual remote case has none). The per-query loop falls through `hybrid → lexical → vector`:
- **Before #48:** the `mode` arg was ignored, so both `use_hybrid` and `use_lexical` were on. With no dense vectors, the hybrid leg was skipped and it ran **lexical/BM25 server-side** — fast, no embedding.
- **#48:** honoring `mode="hybrid"` (what the metadata-linker passes) set `use_lexical=False`. With no vectors, hybrid is skipped *and* lexical is disabled, so it fell through to **vector search** → chromadb dense-embeds every query. On a `default`-EF collection that pulls the `all-MiniLM-L6-v2` ONNX model (~80MB), which is network-starved across executor workers and effectively hangs.

### Fix
Requesting `hybrid` now keeps lexical enabled as its fallback (hybrid = dense + sparse). Only an explicit `vector` disables lexical — the dense-only recovery path a caller uses after a lexical/hybrid failure. Restores the pre-#48 behavior: remote collections without a client embedder use server-side BM25.

## Validation
- `pytest tests/unit/rag/corpus/chroma/` — 80 pass (added a regression test asserting `mode="hybrid"` + no `embed_fn` selects the **lexical** spec, not vector)
- `ruff check` clean
- **Live Chroma Cloud** (`cgft-cloud-e2e-test`, `EF=default` + BM25 index): `search_related(mode="hybrid")` now runs lexical server-side in ~0.2s with **no model download** (was: vector → hang).