### PR TITLE
fix(pinecone): ID-based sampling, namespace-scoped counts, sparse index guards

### DIFF
--- a/src/benchmax/rag/corpus/pinecone/index_client.py
+++ b/src/benchmax/rag/corpus/pinecone/index_client.py
@@ -60,9 +60,17 @@ class PineconeIndexClient:
         embed_model: Pinecone hosted embedding model name.  Ignored when
             ``embed_fn`` is provided.  Defaults to
             ``"multilingual-e5-large"``.
-        field_mapping: Maps *Pinecone metadata field names* → *internal
-            field names*.  Useful for "bring your own index" scenarios where
-            the user's metadata schema differs from the default.
+        field_mapping: Low-level escape hatch — maps *Pinecone metadata
+            field names* → *internal field names* for schemas that also
+            relocate structural fields (``file_path``, ``chunk_index``,
+            headers).  For the common "my text is under a different key"
+            case, prefer ``content_field``.
+        content_field: Pinecone metadata key holding the chunk text, for
+            "bring your own index" schemas that don't use ``content`` (e.g.
+            ``"summary"`` or ``"passage"``).  The canonical way to point at
+            your text column.  Empty / None means the default ``content``
+            key.  Raises if ``field_mapping`` already maps a *different*
+            key to ``content``.
     """
 
     def __init__(
@@ -75,6 +83,7 @@ class PineconeIndexClient:
         embed_fn: Callable[[list[str]], list[list[float]]] | None = None,
         embed_model: str = "multilingual-e5-large",
         field_mapping: dict[str, str] | None = None,
+        content_field: str | None = None,
     ) -> None:
         # Store config for lazy init / pickle safety.
         self._api_key = api_key
@@ -85,7 +94,24 @@ class PineconeIndexClient:
         self._namespace = namespace or ""
         self._embed_model = embed_model
         self.embed_fn = embed_fn or self._build_pinecone_embed_fn()
-        self._field_mapping = field_mapping or dict(DEFAULT_FIELD_MAPPING)
+        mapping = dict(field_mapping) if field_mapping else dict(DEFAULT_FIELD_MAPPING)
+        if content_field and content_field != "content":
+            conflicting = [
+                k
+                for k, v in mapping.items()
+                if v == "content" and k not in ("content", content_field)
+            ]
+            if field_mapping and conflicting:
+                raise ValueError(
+                    f"content_field={content_field!r} conflicts with field_mapping "
+                    f"entries {conflicting} that already map to 'content'. "
+                    "Specify the text column one way or the other."
+                )
+            # Drop the default content→content entry so the reverse mapping
+            # resolves "content" to the custom key unambiguously.
+            mapping.pop("content", None)
+            mapping[content_field] = "content"
+        self._field_mapping = mapping
         # Reverse mapping: internal name → pinecone metadata key
         self._reverse_mapping = {v: k for k, v in self._field_mapping.items()}
         self._index: Any | None = None

--- a/src/benchmax/rag/corpus/pinecone/index_client.py
+++ b/src/benchmax/rag/corpus/pinecone/index_client.py
@@ -80,7 +80,9 @@ class PineconeIndexClient:
         self._api_key = api_key
         self._index_name = index_name
         self._index_host = index_host
-        self._namespace = namespace
+        # Platform codegen may pass None for an unset namespace; Pinecone's
+        # default namespace is "".
+        self._namespace = namespace or ""
         self._embed_model = embed_model
         self.embed_fn = embed_fn or self._build_pinecone_embed_fn()
         self._field_mapping = field_mapping or dict(DEFAULT_FIELD_MAPPING)
@@ -91,6 +93,8 @@ class PineconeIndexClient:
         self._known_ids: list[str] | None = None
         # Cached vector dimension (detected on first embed or describe_index).
         self._vector_dim: int | None = None
+        # Cached index vector type ("dense" | "sparse"), probed lazily.
+        self._vector_type: str | None = None
 
     def _build_pinecone_embed_fn(self) -> Callable[[list[str]], list[list[float]]]:
         """Build an embed_fn using Pinecone's hosted Inference API.
@@ -157,6 +161,35 @@ class PineconeIndexClient:
                 self._index = pc.Index(self._index_name)
         return self._index
 
+    def vector_type(self) -> str:
+        """Return the index vector type, ``"dense"`` or ``"sparse"``.
+
+        Probes the index via ``describe_index_stats`` on first call and
+        caches the result.
+        """
+        if self._vector_type is None:
+            index = self._get_index()
+            stats = index.describe_index_stats()
+            self._vector_type = getattr(stats, "vector_type", None) or "dense"
+        return self._vector_type
+
+    def namespace_vector_count(self) -> int:
+        """Return the vector count for this client's namespace.
+
+        Scoped to the namespace, NOT the index-wide total — an index-wide
+        count would disagree with what list/fetch/query in this namespace
+        can actually see.  The SDK keys the default namespace as
+        ``"__default__"`` (the REST API uses ``""``).
+        """
+        stats = self._get_index().describe_index_stats()
+        namespaces = getattr(stats, "namespaces", None) or {}
+        ns_stats = namespaces.get(self._namespace or "__default__")
+        if ns_stats is None and not self._namespace:
+            ns_stats = namespaces.get("")
+        if ns_stats is None:
+            return 0
+        return int(getattr(ns_stats, "vector_count", 0) or 0)
+
     def zero_vector(self) -> list[float]:
         """Return a zero-vector with the correct dimension for this index.
 
@@ -168,6 +201,12 @@ class PineconeIndexClient:
             index = self._get_index()
             stats = index.describe_index_stats()
             self._vector_dim = stats.dimension
+        if self._vector_dim is None:
+            # Sparse indexes have no fixed dimension.
+            raise ValueError(
+                f"Pinecone index '{self._index_name}' has no dimension — it is "
+                "a sparse index, which has no dense zero-vector."
+            )
         return [0.0] * self._vector_dim
 
     # ------------------------------------------------------------------
@@ -305,6 +344,14 @@ class PineconeIndexClient:
         include_metadata: bool = True,
     ) -> Any:
         """Run a vector query against the index."""
+        if self.vector_type() == "sparse":
+            # A dense query vector against a sparse index is rejected by
+            # Pinecone with an opaque error; fail with an actionable one.
+            raise ValueError(
+                f"Pinecone index '{self._index_name}' is a sparse index — "
+                "search against sparse indexes is not supported yet. "
+                "Use a dense index."
+            )
         index = self._get_index()
         kwargs: dict[str, Any] = {
             "vector": vector,

--- a/src/benchmax/rag/corpus/pinecone/search.py
+++ b/src/benchmax/rag/corpus/pinecone/search.py
@@ -36,6 +36,8 @@ class PineconeSearch:
         embed_model: Pinecone hosted embedding model name. Ignored
             when ``embed_fn`` is provided.
         field_mapping: Maps Pinecone metadata keys to internal names.
+        content_field: Pinecone metadata key holding the chunk text — sugar
+            over ``field_mapping`` for BYO indexes that don't use ``content``.
         token_provider: Optional override — a callable resolving the key per
             call, or a literal key (string sugar). Defaults to reading
             ``PINECONE_API_KEY``.
@@ -50,6 +52,7 @@ class PineconeSearch:
         embed_fn: Callable[[list[str]], list[list[float]]] | None = None,
         embed_model: str = "multilingual-e5-large",
         field_mapping: dict[str, str] | None = None,
+        content_field: str | None = None,
         token_provider: str | TokenProvider | None = None,
     ) -> None:
         self._index_name = index_name
@@ -58,6 +61,7 @@ class PineconeSearch:
         self._embed_fn = embed_fn
         self._embed_model = embed_model
         self._field_mapping = field_mapping
+        self._content_field = content_field
         self._token_provider = as_token_provider(
             token_provider, env_token("PINECONE_API_KEY")
         )
@@ -75,6 +79,7 @@ class PineconeSearch:
                 embed_fn=self._embed_fn,
                 embed_model=self._embed_model,
                 field_mapping=self._field_mapping,
+                content_field=self._content_field,
             )
         return self._client
 

--- a/src/benchmax/rag/corpus/pinecone/source.py
+++ b/src/benchmax/rag/corpus/pinecone/source.py
@@ -67,8 +67,13 @@ class PineconeChunkSource:
         embed_model: Pinecone hosted embedding model name.  Ignored when
             ``embed_fn`` is provided.  Defaults to
             ``"multilingual-e5-large"``.
-        field_mapping: Maps Pinecone metadata field names to internal names.
-            Useful for "bring your own index" scenarios.
+        field_mapping: Low-level escape hatch — maps Pinecone metadata field
+            names to internal names when structural fields (``file_path``,
+            ``chunk_index``, headers) are also relocated.  For the common
+            case, prefer ``content_field``.
+        content_field: Pinecone metadata key holding the chunk text — the
+            canonical way to point at your text column for pre-existing
+            indexes that don't use ``content``.
 
     Example:
         >>> # Using Pinecone's built-in embeddings (simplest)
@@ -85,12 +90,12 @@ class PineconeChunkSource:
         ...     embed_fn=my_embed_fn,
         ... )
 
-        >>> # Pre-existing index with custom field names
+        >>> # Pre-existing index whose text lives under another key
         >>> source = PineconeChunkSource(
         ...     api_key="pcsk_...",
         ...     index_name="product-catalog",
         ...     embed_model="llama-text-embed-v2",
-        ...     field_mapping={"description": "content", "path": "file_path"},
+        ...     content_field="description",
         ... )
     """
 
@@ -104,6 +109,7 @@ class PineconeChunkSource:
         embed_fn: Callable[[list[str]], list[list[float]]] | None = None,
         embed_model: str = "multilingual-e5-large",
         field_mapping: dict[str, str] | None = None,
+        content_field: str | None = None,
     ) -> None:
         self._client = PineconeIndexClient(
             api_key=api_key,
@@ -113,6 +119,7 @@ class PineconeChunkSource:
             embed_fn=embed_fn,
             embed_model=embed_model,
             field_mapping=field_mapping,
+            content_field=content_field,
         )
         self._files = FileAwareness(self._client)
 
@@ -270,6 +277,22 @@ class PineconeChunkSource:
                 )
             )
         chunks = [_raw_to_chunk(r) for r in raws]
+
+        # Every fetched record decoding to empty content means the text key
+        # is wrong (BYO index whose schema doesn't use the configured field),
+        # not that the corpus is empty. Without this, the pipeline dies later
+        # with an unactionable "No eligible chunks were found".
+        if chunks and all(not c.content for c in chunks):
+            content_key = self._client._pc_field("content")
+            seen_keys = sorted(
+                {k for r in raws for k in r.get("metadata", {}) if not k.startswith("_")}
+            )
+            raise ValueError(
+                f"No text found under metadata field '{content_key}' in any "
+                f"sampled record. This index's metadata fields are: "
+                f"{seen_keys}. Set content_field to the one holding the "
+                f"chunk text."
+            )
 
         if min_chars > 0:
             chunks = [c for c in chunks if len(c.content) >= min_chars]

--- a/src/benchmax/rag/corpus/pinecone/source.py
+++ b/src/benchmax/rag/corpus/pinecone/source.py
@@ -26,6 +26,9 @@ from .index_client import PineconeIndexClient
 
 logger = logging.getLogger(__name__)
 
+#: Max IDs per vectors/fetch call — Pinecone caps fetch batches at 100.
+_FETCH_BATCH_SIZE = 100
+
 
 def _raw_to_chunk(raw: dict[str, Any]) -> Chunk:
     """Convert a raw dict from PineconeIndexClient to a Chunk."""
@@ -237,40 +240,40 @@ class PineconeChunkSource:
     # ------------------------------------------------------------------
 
     def get_chunk_count(self) -> int:
-        """Return the total number of vectors in the index."""
-        index = self._client._get_index()
-        stats = index.describe_index_stats()
-        return int(stats.total_vector_count or 0)
+        """Return the number of vectors in the configured namespace.
+
+        Scoped to the namespace this source reads from — an index-wide
+        total would disagree with what sampling/search can actually see.
+        """
+        return self._client.namespace_vector_count()
 
     def sample_chunks(self, n: int, min_chars: int = 0) -> list[Chunk]:
         """Return n randomly sampled chunks, optionally filtered by
         minimum length.
 
-        Uses a random vector query to get pseudo-random results
-        efficiently in a single API call.
+        Samples uniformly from the paginated ID listing and hydrates the
+        sample via fetch — no query vector involved, so the draw is
+        genuinely uniform (not nearest-to-a-random-point) and works for
+        dense and sparse indexes alike.
         """
-        # Generate a random vector for pseudo-random sampling
-        dim = len(self._client.zero_vector())
-        rand_vec = [random.gauss(0, 1) for _ in range(dim)]
-
-        # Fetch more than needed to allow for min_chars filtering
-        fetch_k = min(n * 3, 10000) if min_chars > 0 else min(n, 10000)
-        result = self._client.query(
-            vector=rand_vec,
-            top_k=fetch_k,
-            include_metadata=True,
-        )
-
-        matches = result.matches or []
-        if not matches:
+        # Oversample when a length filter will discard part of the draw
+        fetch_n = min(n * 3, 10000) if min_chars > 0 else min(n, 10000)
+        ids = self._client.sample_ids(fetch_n)
+        if not ids:
             return []
 
-        chunks = [_raw_to_chunk(self._client.match_to_raw(m)) for m in matches]
+        raws: list[dict[str, Any]] = []
+        for batch_start in range(0, len(ids), _FETCH_BATCH_SIZE):
+            raws.extend(
+                self._client.fetch_by_ids_raw(
+                    ids[batch_start : batch_start + _FETCH_BATCH_SIZE]
+                )
+            )
+        chunks = [_raw_to_chunk(r) for r in raws]
 
         if min_chars > 0:
             chunks = [c for c in chunks if len(c.content) >= min_chars]
 
-        # Shuffle to avoid bias from similarity ordering
         random.shuffle(chunks)
         return chunks[:n]
 

--- a/src/benchmax/rag/corpus/turbopuffer/namespace.py
+++ b/src/benchmax/rag/corpus/turbopuffer/namespace.py
@@ -19,6 +19,27 @@ from benchmax.rag.corpus.search_schema.search_types import (
 )
 
 
+def resolve_content_attr(
+    content_attr: list[str] | None, content_field: str | None
+) -> list[str] | None:
+    """Resolve the ``content_field`` sugar against an explicit ``content_attr``.
+
+    ``content_field`` is the canonical single-column param; ``content_attr``
+    is the low-level multi-field escape hatch.  Specifying the text column
+    both ways with different values raises instead of silently picking a
+    winner.
+    """
+    if not content_field:
+        return content_attr
+    if content_attr is not None and content_attr != [content_field]:
+        raise ValueError(
+            f"content_field={content_field!r} conflicts with "
+            f"content_attr={content_attr!r}. Specify the text column one way "
+            "or the other."
+        )
+    return [content_field]
+
+
 class TpufNamespace:
     """Thin wrapper around a Turbopuffer namespace.
 

--- a/src/benchmax/rag/corpus/turbopuffer/search.py
+++ b/src/benchmax/rag/corpus/turbopuffer/search.py
@@ -30,7 +30,12 @@ class TpufSearch:
     Args:
         namespace: Turbopuffer namespace name.
         region: Turbopuffer region (default ``"aws-us-east-1"``).
-        content_attr: List of BM25-indexed content fields.
+        content_attr: Low-level escape hatch — list of BM25-indexed content
+            fields for multi-field schemas. Prefer ``content_field``.
+        content_field: Turbopuffer attribute holding the chunk text — the
+            canonical single-column param. Must be BM25-indexed for lexical
+            search. Raises if ``content_attr`` is also supplied with a
+            different value.
         embed_fn: Custom embedding function. Required for vector/hybrid.
         vector_attr: Vector attribute name (default ``"vector"``).
         distance_metric: Distance metric (default ``"cosine_distance"``).
@@ -48,11 +53,14 @@ class TpufSearch:
         embed_fn: Callable[[list[str]], list[list[float]]] | None = None,
         vector_attr: str = "vector",
         distance_metric: str = "cosine_distance",
+        content_field: str | None = None,
         token_provider: str | TokenProvider | None = None,
     ) -> None:
+        from .namespace import resolve_content_attr
+
         self._namespace = namespace
         self._region = region
-        self._content_attr = content_attr
+        self._content_attr = resolve_content_attr(content_attr, content_field)
         self._embed_fn = embed_fn
         self._vector_attr = vector_attr
         self._distance_metric = distance_metric

--- a/src/benchmax/rag/corpus/turbopuffer/search.py
+++ b/src/benchmax/rag/corpus/turbopuffer/search.py
@@ -100,7 +100,6 @@ class TpufSearch:
         top_k: int = 10,
     ) -> list[dict[str, Any]]:
         """Search and return structured results."""
-        ns = self._get_client()
         modes = self.available_modes
         content_fields = self._content_attr or ["content"]
 
@@ -118,6 +117,11 @@ class TpufSearch:
                 f"Available modes: {modes}. "
                 f"{'Provide embed_fn for vector/hybrid.' if mode in ('vector', 'hybrid') else ''}"
             )
+
+        # Validate the request before constructing the client — an invalid
+        # mode should fail as such, not as a missing-credential error from
+        # the token provider.
+        ns = self._get_client()
 
         if mode == "lexical":
             rank_by = [content_fields[0], "BM25", query]

--- a/src/benchmax/rag/corpus/turbopuffer/source.py
+++ b/src/benchmax/rag/corpus/turbopuffer/source.py
@@ -23,7 +23,7 @@ from benchmax.rag.corpus.search_schema.search_types import (
 
 from .files import FileAwareness
 from .filter_mapper import to_turbopuffer_filters
-from .namespace import TpufNamespace
+from .namespace import TpufNamespace, resolve_content_attr
 
 _DEFAULT_RELATED_SEARCH_MODE: SearchMode = "lexical"
 _HYBRID_FUSION_RRF_K = 60.0
@@ -50,10 +50,15 @@ class TpufChunkSource:
         api_key: Turbopuffer API key
         namespace: Turbopuffer namespace name
         region: Turbopuffer region (default "aws-us-east-1")
-        content_attr: List of Turbopuffer attribute names to use as the chunk's
-            searchable text content. Defaults to ["content"]. For pre-existing
-            namespaces, supply the BM25-indexed field(s), e.g. ["description"]
-            or ["title", "content"].
+        content_attr: Low-level escape hatch — list of Turbopuffer attribute
+            names to use as the chunk's searchable text content (multi-field
+            schemas, e.g. ["title", "content"]). For the common single-column
+            case, prefer ``content_field``. Defaults to ["content"].
+        content_field: Turbopuffer attribute holding the chunk text — the
+            canonical way to point at your text column for pre-existing
+            namespaces that don't use ``content``. Must be BM25-indexed for
+            lexical search. Raises if ``content_attr`` is also supplied with
+            a different value.
         vector_attr: Name of the vector attribute in the namespace. Defaults to
             "vector". Set this if your namespace stores embeddings under a
             different attribute name.
@@ -64,11 +69,11 @@ class TpufChunkSource:
         >>> source.populate_from_folder("./docs", embed_fn=my_embed_fn)
         >>> chunks = source.sample_chunks(n=10, min_chars=400)
 
-        >>> # Pre-existing namespace with known BM25-indexed fields
+        >>> # Pre-existing namespace whose text lives under another key
         >>> source = TpufChunkSource(
         ...     api_key="tpuf_...",
         ...     namespace="product-catalog",
-        ...     content_attr=["description"],
+        ...     content_field="description",
         ... )
     """
 
@@ -81,12 +86,13 @@ class TpufChunkSource:
         embed_fn: Callable[[list[str]], list[list[float]]] | None = None,
         vector_attr: str = "vector",
         distance_metric: str = "cosine_distance",
+        content_field: str | None = None,
     ) -> None:
         self._client = TpufNamespace(
             api_key=api_key,
             namespace=namespace,
             region=region,
-            content_attr=content_attr,
+            content_attr=resolve_content_attr(content_attr, content_field),
             embed_fn=embed_fn,
             vector_attr=vector_attr,
             distance_metric=distance_metric,

--- a/tests/unit/rag/corpus/pinecone/test_search.py
+++ b/tests/unit/rag/corpus/pinecone/test_search.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import cloudpickle
 import pytest
 
+from benchmax.rag.corpus.pinecone.index_client import PineconeIndexClient
 from benchmax.rag.corpus.pinecone.search import PineconeSearch
 
 
@@ -28,27 +29,24 @@ class FakeIndex:
         return SimpleNamespace(dimension=3)
 
 
+def _fixed_embed(texts):
+    return [[0.1, 0.2, 0.3]] * len(texts)
+
+
 def _make_search(embed_fn=None) -> PineconeSearch:
     ps = PineconeSearch(
-        api_key="test",
-        index_name="test",
-        embed_fn=embed_fn or (lambda texts: [[0.1, 0.2, 0.3]] * len(texts)),
+        "test",
+        embed_fn=embed_fn or _fixed_embed,
+        token_provider=lambda: "test-key",
     )
-    # Inject fake client to avoid real Pinecone calls
-    from benchmax.rag.corpus.pinecone.index_client import PineconeIndexClient
-
-    client = PineconeIndexClient.__new__(PineconeIndexClient)
-    client._api_key = "test"
-    client._index_name = "test"
-    client._index_host = None
-    client._namespace = ""
-    client._embed_model = "test"
-    client.embed_fn = embed_fn or (lambda texts: [[0.1, 0.2, 0.3]] * len(texts))
-    client._field_mapping = {"content": "content"}
-    client._reverse_mapping = {"content": "content"}
+    # Inject a real client wired to a fake index — no real Pinecone calls.
+    client = PineconeIndexClient(
+        api_key="test-key",
+        index_name="test",
+        embed_fn=embed_fn or _fixed_embed,
+        field_mapping={"content": "content"},
+    )
     client._index = FakeIndex()
-    client._known_ids = None
-    client._vector_dim = 3
     ps._client = client
     return ps
 
@@ -99,15 +97,17 @@ class TestEmbed:
 
 class TestPickle:
     def test_roundtrip_preserves_config(self):
-        ps = PineconeSearch(api_key="k", index_name="idx", namespace="ns")
+        ps = PineconeSearch(
+            "idx", namespace="ns", token_provider=lambda: "k"
+        )
         data = cloudpickle.dumps(ps)
         restored = pickle.loads(data)
-        assert restored._api_key == "k"
         assert restored._index_name == "idx"
         assert restored._namespace == "ns"
+        assert restored._token_provider() == "k"
         assert restored._client is None  # stripped
 
     def test_available_modes_after_restore(self):
-        ps = PineconeSearch(api_key="k", index_name="idx")
+        ps = PineconeSearch("idx", token_provider=lambda: "k")
         restored = pickle.loads(cloudpickle.dumps(ps))
         assert restored.available_modes == ["vector"]

--- a/tests/unit/rag/corpus/pinecone/test_sparse_and_sampling.py
+++ b/tests/unit/rag/corpus/pinecone/test_sparse_and_sampling.py
@@ -1,0 +1,143 @@
+"""Sparse-index guards and ID-based sampling for the Pinecone corpus.
+
+Sparse indexes have no fixed dimension, so every dense-vector path must
+either work without a vector (sampling) or fail with an actionable error
+(search — until sparse query encoding lands).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from benchmax.rag.corpus.pinecone.index_client import PineconeIndexClient
+
+from fakes.pinecone import FakeIndex, make_match, make_source
+
+
+def _make_client(index) -> PineconeIndexClient:
+    client = PineconeIndexClient(
+        api_key="test-key",
+        index_name="test",
+        embed_fn=lambda texts: [[0.1, 0.2, 0.3]] * len(texts),
+    )
+    client._index = index
+    return client
+
+
+class _SparseIndex:
+    """describe_index_stats shape of a sparse serverless index."""
+
+    def __init__(self):
+        self.queries: list[dict] = []
+
+    def describe_index_stats(self):
+        return SimpleNamespace(
+            dimension=None,
+            vector_type="sparse",
+            total_vector_count=15,
+            namespaces={"sample-data": SimpleNamespace(vector_count=15)},
+        )
+
+    def query(self, **kwargs):
+        self.queries.append(kwargs)
+        return SimpleNamespace(matches=[])
+
+
+class TestSparseGuards:
+    def test_query_raises_actionable_error(self):
+        client = _make_client(_SparseIndex())
+        with pytest.raises(ValueError, match="sparse"):
+            client.query(vector=[0.1, 0.2, 0.3])
+
+    def test_query_never_reaches_index(self):
+        index = _SparseIndex()
+        client = _make_client(index)
+        with pytest.raises(ValueError):
+            client.query(vector=[0.1, 0.2, 0.3])
+        assert index.queries == []
+
+    def test_zero_vector_raises_on_missing_dimension(self):
+        client = _make_client(_SparseIndex())
+        with pytest.raises(ValueError, match="sparse"):
+            client.zero_vector()
+
+    def test_dense_index_unaffected(self):
+        client = _make_client(FakeIndex(matches=[make_match("1", "hello")]))
+        result = client.query(vector=[0.1, 0.2, 0.3])
+        assert len(result.matches) == 1
+
+
+class TestVectorType:
+    def test_sparse_detected(self):
+        client = _make_client(_SparseIndex())
+        assert client.vector_type() == "sparse"
+
+    def test_dense_default_when_absent(self):
+        # Older SDK stats objects have no vector_type attribute.
+        client = _make_client(FakeIndex())
+        assert client.vector_type() == "dense"
+
+
+class TestNamespaceHandling:
+    def test_none_namespace_normalizes_to_default(self):
+        client = PineconeIndexClient(
+            api_key="k", index_name="i", namespace=None, embed_fn=lambda t: []
+        )
+        assert client._namespace == ""
+
+    def test_namespace_vector_count_scoped(self):
+        class _Index:
+            def describe_index_stats(self):
+                return SimpleNamespace(
+                    total_vector_count=500,
+                    namespaces={
+                        "__default__": SimpleNamespace(vector_count=480),
+                        "other": SimpleNamespace(vector_count=20),
+                    },
+                )
+
+        client = _make_client(_Index())
+        # Default namespace → "__default__" entry, NOT the index-wide total.
+        assert client.namespace_vector_count() == 480
+
+        named = PineconeIndexClient(
+            api_key="k", index_name="i", namespace="other", embed_fn=lambda t: []
+        )
+        named._index = _Index()
+        assert named.namespace_vector_count() == 20
+
+    def test_namespace_vector_count_empty_namespace(self):
+        class _Index:
+            def describe_index_stats(self):
+                return SimpleNamespace(total_vector_count=15, namespaces={})
+
+        client = _make_client(_Index())
+        assert client.namespace_vector_count() == 0
+
+
+class TestSampleChunksViaIds:
+    def test_samples_without_querying(self):
+        matches = [make_match(f"id-{i}", f"content {i}") for i in range(5)]
+        index = FakeIndex(matches=matches)
+        source = make_source(index)
+        chunks = source.sample_chunks(3)
+        assert len(chunks) == 3
+        # ID-based sampling must not issue any vector query.
+        assert index._call_idx == 0
+
+    def test_min_chars_filtering(self):
+        matches = [
+            make_match("long-1", "x" * 50),
+            make_match("short-1", "x"),
+            make_match("long-2", "y" * 50),
+        ]
+        source = make_source(FakeIndex(matches=matches))
+        chunks = source.sample_chunks(2, min_chars=10)
+        assert len(chunks) == 2
+        assert all(len(c.content) >= 10 for c in chunks)
+
+    def test_empty_index_returns_empty(self):
+        source = make_source(FakeIndex(matches=[]))
+        assert source.sample_chunks(5) == []

--- a/tests/unit/rag/corpus/pinecone/test_sparse_and_sampling.py
+++ b/tests/unit/rag/corpus/pinecone/test_sparse_and_sampling.py
@@ -141,3 +141,86 @@ class TestSampleChunksViaIds:
     def test_empty_index_returns_empty(self):
         source = make_source(FakeIndex(matches=[]))
         assert source.sample_chunks(5) == []
+
+
+class TestContentField:
+    """content_field sugar — BYO indexes whose text isn't under `content`."""
+
+    def _movie_client(self, **kwargs) -> PineconeIndexClient:
+        client = PineconeIndexClient(
+            api_key="k", index_name="movies", embed_fn=lambda t: [], **kwargs
+        )
+        return client
+
+    def test_maps_custom_key_to_content(self):
+        client = self._movie_client(content_field="summary")
+        assert client._pc_field("content") == "summary"
+
+        match = SimpleNamespace(
+            id="0",
+            metadata={"title": "Avatar", "summary": "On the alien world..."},
+            score=0.9,
+        )
+        raw = client.match_to_raw(match)
+        assert raw["content"] == "On the alien world..."
+        assert raw["metadata"]["title"] == "Avatar"
+        assert "summary" not in raw["metadata"]  # consumed as content
+
+    def test_fetch_to_raw_uses_custom_key(self):
+        client = self._movie_client(content_field="summary")
+        raw = client.fetch_to_raw(
+            "0", SimpleNamespace(metadata={"summary": "text here", "year": 2009})
+        )
+        assert raw["content"] == "text here"
+
+    def test_empty_or_default_is_noop(self):
+        for cf in (None, "", "content"):
+            client = self._movie_client(content_field=cf)
+            assert client._pc_field("content") == "content"
+
+    def test_explicit_field_mapping_composes(self):
+        client = self._movie_client(
+            field_mapping={"path": "file_path"}, content_field="summary"
+        )
+        assert client._pc_field("content") == "summary"
+        assert client._pc_field("file_path") == "path"
+
+    def test_conflicting_content_mappings_raise(self):
+        # field_mapping already claims the content column with a different
+        # key — ambiguous, must fail instead of silently picking a winner.
+        with pytest.raises(ValueError, match="conflicts"):
+            self._movie_client(
+                field_mapping={"description": "content"}, content_field="summary"
+            )
+
+    def test_agreeing_content_mappings_pass(self):
+        client = self._movie_client(
+            field_mapping={"summary": "content"}, content_field="summary"
+        )
+        assert client._pc_field("content") == "summary"
+
+
+class TestEmptyContentGuard:
+    def test_all_empty_content_raises_with_field_listing(self):
+        # Records whose text lives under `summary` while the source still
+        # reads `content` — the sample-movies failure mode.
+        matches = [
+            make_match("0", "", title="Avatar", summary="On the alien world..."),
+            make_match("1", "", title="Endgame", summary="In the aftermath..."),
+        ]
+        source = make_source(FakeIndex(matches=matches))
+        with pytest.raises(ValueError) as exc:
+            source.sample_chunks(2)
+        msg = str(exc.value)
+        assert "content" in msg
+        assert "summary" in msg and "title" in msg
+        assert "content_field" in msg
+
+    def test_some_content_passes(self):
+        matches = [
+            make_match("0", "real text"),
+            make_match("1", "", stray="x"),
+        ]
+        source = make_source(FakeIndex(matches=matches))
+        chunks = source.sample_chunks(2)
+        assert len(chunks) == 2

--- a/tests/unit/rag/corpus/test_protocol_conformance.py
+++ b/tests/unit/rag/corpus/test_protocol_conformance.py
@@ -244,6 +244,12 @@ def _fake_pinecone_source() -> PineconeChunkSource:
         def zero_vector(self):
             return [0.0] * self._vector_dim
 
+        def vector_type(self):
+            return "dense"
+
+        def namespace_vector_count(self):
+            return 2
+
         def match_content(self, match):
             return str((getattr(match, "metadata", {}) or {}).get("content", ""))
 

--- a/tests/unit/rag/corpus/tpuf/test_content_field.py
+++ b/tests/unit/rag/corpus/tpuf/test_content_field.py
@@ -1,0 +1,46 @@
+"""content_field sugar on the Turbopuffer source/search — BYO namespaces
+whose text attribute isn't named `content`."""
+
+from __future__ import annotations
+
+import pytest
+
+from benchmax.rag.corpus.turbopuffer.namespace import resolve_content_attr
+from benchmax.rag.corpus.turbopuffer.search import TpufSearch
+
+
+class TestResolveContentAttr:
+    def test_field_becomes_single_attr(self):
+        assert resolve_content_attr(None, "description") == ["description"]
+
+    def test_passthrough_without_field(self):
+        assert resolve_content_attr(["title", "content"], None) == [
+            "title",
+            "content",
+        ]
+        assert resolve_content_attr(None, None) is None
+
+    def test_empty_field_is_noop(self):
+        # Platform codegen passes "" for an unset optional resource field.
+        assert resolve_content_attr(None, "") is None
+
+    def test_agreeing_values_pass(self):
+        assert resolve_content_attr(["description"], "description") == [
+            "description"
+        ]
+
+    def test_conflicting_values_raise(self):
+        with pytest.raises(ValueError, match="conflicts"):
+            resolve_content_attr(["title"], "description")
+
+
+class TestTpufSearchContentField:
+    def test_content_field_sets_content_attr(self):
+        search = TpufSearch(
+            "ns", content_field="body", token_provider=lambda: "k"
+        )
+        assert search._content_attr == ["body"]
+
+    def test_default_unchanged(self):
+        search = TpufSearch("ns", token_provider=lambda: "k")
+        assert search._content_attr is None

--- a/tests/unit/rag/fakes/pinecone.py
+++ b/tests/unit/rag/fakes/pinecone.py
@@ -155,6 +155,23 @@ class FakeClient:
     def zero_vector(self) -> list[float]:
         return [0.0] * self._vector_dim
 
+    def vector_type(self) -> str:
+        return "dense"
+
+    def namespace_vector_count(self) -> int:
+        return sum(len(m) for m in self._index.matches_per_call)
+
+    def _all_matches(self) -> list:
+        return [m for batch in self._index.matches_per_call for m in batch]
+
+    def sample_ids(self, n: int) -> list[str]:
+        ids = [m.id for m in self._all_matches()]
+        return ids[:n]
+
+    def fetch_by_ids_raw(self, ids: list[str]) -> list[dict]:
+        wanted = set(ids)
+        return [self.match_to_raw(m) for m in self._all_matches() if m.id in wanted]
+
     def match_content(self, match) -> str:
         metadata = getattr(match, "metadata", {}) or {}
         content_key = self._pc_field("content")


### PR DESCRIPTION
## Problem

QA generation against a customer-linked sparse Pinecone index crashes:

```
File "benchmax/rag/corpus/pinecone/source.py", line 253, in sample_chunks
    dim = len(self._client.zero_vector())
File "benchmax/rag/corpus/pinecone/index_client.py", line 171, in zero_vector
    return [0.0] * self._vector_dim
TypeError: can't multiply sequence by non-int of type 'NoneType'
```

Sparse indexes have no fixed dimension, and `sample_chunks` built a random **dense** vector for pseudo-random sampling. Separately, `get_chunk_count` reported the index-wide total rather than the configured namespace's count.

## Changes

- **`sample_chunks`**: samples IDs from the paginated listing and hydrates via fetch (batches of 100). No query vector involved, so the draw is genuinely uniform (the old approach was nearest-to-a-random-point) and works on dense and sparse indexes alike.
- **`get_chunk_count`** → new `PineconeIndexClient.namespace_vector_count()`: scoped to the configured namespace (the SDK keys the default namespace as `__default__`), matching what sampling/search can actually see.
- **Sparse guards**: `query()` and `zero_vector()` raise an actionable `ValueError` on sparse indexes instead of TypeError-ing inside the SDK. Interim, until sparse query encoding is added; sampling and counting work on sparse today with this PR.
- **`namespace=None`** normalizes to the default namespace (platform codegen can pass None for an unset field).
- **`test_search.py`**: rewritten against the `token_provider` constructor — it still used the removed `api_key` kwarg and all 8 tests failed on main.

## Companion PR

castform-ai/castform#201 — wizard namespace field + namespace-scoped preview counts + the same sparse gate at the platform layer.

## Testing

- New `test_sparse_and_sampling.py`: sparse gate (raises before reaching the index), zero-vector guard, vector-type detection, namespace normalization + scoped counts, ID-based sampling with min_chars filtering
- `tests/unit/rag/corpus/pinecone/` + protocol conformance: 92 passed (chroma/tpuf failures on main are unrelated)

## Update: content_field

Adds `content_field` to `PineconeIndexClient` / `PineconeChunkSource` / `PineconeSearch` — the canonical way to point at the text column for BYO indexes that don't use `metadata.content` (e.g. Pinecone's `sample-movies` uses `summary`). Implemented over `field_mapping`, which the docs now position as the low-level escape hatch for relocated structural fields; specifying the content column both ways with different keys raises. `sample_chunks` now fails with the index's actual metadata field names when every record decodes to empty content, instead of the pipeline dying later with "No eligible chunks were found."


## Update 2: content_field on Turbopuffer

Same param mirrored onto `TpufChunkSource`/`TpufSearch`, resolving to `content_attr=[content_field]` via a shared `resolve_content_attr` helper; `content_attr` remains the multi-field escape hatch; conflicting double-specification raises.


## Update 3: tpuf mode-validation fix — `tests/unit/rag` fully green

The two `TestModeValidation` failures on main (same `token_provider`-migration vintage as the pinecone `test_search.py` staleness fixed earlier in this PR) are now fixed at the product layer: `TpufSearch.search()` validated mode *after* constructing the client, so an invalid mode surfaced as a missing-`TPUF_API_KEY` RuntimeError instead of the documented ValueError. Pure reorder — validation now runs first, no credentials needed to reject a bad request.

With that, the full `tests/unit/rag` suite passes: **680 passed, 0 failed** (requires `uv sync --extra rag --extra chroma --extra turbopuffer --extra pinecone` — the remaining "failures on main" I'd flagged earlier were just missing optional provider SDK extras in a fresh checkout, not broken code).
