### PR TITLE
fix(rag/chroma): never client-side-download an embedding model (degrade to BM25 or error)

### DIFF
--- a/src/benchmax/rag/corpus/chroma/client.py
+++ b/src/benchmax/rag/corpus/chroma/client.py
@@ -16,6 +16,13 @@ from typing import Any
 # Sparse-key name used when setting up BM25 schema
 BM25_KEY = "bm25_embedding"
 
+# Embedding functions that run server-side on Chroma Cloud (embed.trychroma.com)
+# — querying a collection that uses one never downloads a model. Everything else
+# (default all-MiniLM, sentence-transformers / HF / Ollama / ONNX locals,
+# third-party API EFs, or no EF) is treated as unsafe. Add hosted names here as
+# they are verified server-side.
+_SERVER_SIDE_EF_NAMES = frozenset({"chroma-cloud-qwen"})
+
 
 def has_search_api() -> bool:
     """Return True when the chromadb package exposes the Search API."""
@@ -176,25 +183,28 @@ class ChromaClient:
 
         return self._collection
 
-    def dense_requires_local_model(self) -> bool:
-        """True when a dense (vector) query would make chromadb embed locally.
+    def dense_embed_is_safe(self) -> bool:
+        """True when a dense (vector) query embeds WITHOUT downloading a model.
 
-        With no caller ``embed_fn`` and no hosted embedding function, chromadb
-        falls back to its ``DefaultEmbeddingFunction``, which downloads and runs
-        all-MiniLM on the client — pathologically slow in constrained executors.
-        A hosted EF (e.g. chroma-cloud-qwen, attached by
-        ``_repair_cloud_embedding_function``) embeds server-side, so dense stays
-        cheap there. Callers use this to prefer a lexical index over an
-        expensive local embed. Best-effort: any introspection failure reports
-        False (don't degrade on uncertainty).
+        Safe only when we can produce vectors without a client-side model
+        download: either a caller-supplied ``embed_fn``, or a Chroma-hosted
+        server-side embedding function (embeds at embed.trychroma.com). Every
+        other embedder — chromadb's default all-MiniLM, sentence-transformers /
+        HuggingFace / Ollama / ONNX locals, third-party API EFs we lack keys
+        for, or no EF at all — is treated as UNSAFE, so callers refuse the dense
+        path rather than trigger a model download. Conservative by design: an
+        unknown embedder is unsafe.
         """
         if self.embed_fn is not None:
-            return False
+            return True
         col = self._collection
         if col is None:
             return False
-        ef = getattr(col, "_embedding_function", None)
-        return ef is None or type(ef).__name__ == "DefaultEmbeddingFunction"
+        try:
+            ef = (col._model.configuration_json or {}).get("embedding_function") or {}
+        except Exception:
+            return False
+        return ef.get("name") in _SERVER_SIDE_EF_NAMES
 
     @staticmethod
     def _repair_cloud_embedding_function(collection: Any) -> None:

--- a/src/benchmax/rag/corpus/chroma/client.py
+++ b/src/benchmax/rag/corpus/chroma/client.py
@@ -176,6 +176,26 @@ class ChromaClient:
 
         return self._collection
 
+    def dense_requires_local_model(self) -> bool:
+        """True when a dense (vector) query would make chromadb embed locally.
+
+        With no caller ``embed_fn`` and no hosted embedding function, chromadb
+        falls back to its ``DefaultEmbeddingFunction``, which downloads and runs
+        all-MiniLM on the client — pathologically slow in constrained executors.
+        A hosted EF (e.g. chroma-cloud-qwen, attached by
+        ``_repair_cloud_embedding_function``) embeds server-side, so dense stays
+        cheap there. Callers use this to prefer a lexical index over an
+        expensive local embed. Best-effort: any introspection failure reports
+        False (don't degrade on uncertainty).
+        """
+        if self.embed_fn is not None:
+            return False
+        col = self._collection
+        if col is None:
+            return False
+        ef = getattr(col, "_embedding_function", None)
+        return ef is None or type(ef).__name__ == "DefaultEmbeddingFunction"
+
     @staticmethod
     def _repair_cloud_embedding_function(collection: Any) -> None:
         """Attach a working EF when chromadb can't rebuild a Cloud hosted one.

--- a/src/benchmax/rag/corpus/chroma/search.py
+++ b/src/benchmax/rag/corpus/chroma/search.py
@@ -10,6 +10,9 @@ from collections.abc import Callable
 from typing import Any
 
 from benchmax.platform.credentials import TokenProvider, as_token_provider, env_token
+from benchmax.rag.corpus.search_schema.search_exceptions import (
+    LocalEmbeddingDownloadDisallowedError,
+)
 
 
 class ChromaSearch:
@@ -113,19 +116,33 @@ class ChromaSearch:
     ) -> list[dict[str, Any]]:
         """Search and return structured results."""
         client = self._get_client()
+        # Initialize the collection first so capabilities reflect the real index
+        # (BM25 downgrade) and the embedder config is readable below.
+        client.get_collection()
+        modes = client.modes
+        has_lexical = "lexical" in modes
 
-        if mode == "auto":
-            modes = client.modes
+        # Never download a client-side embedding model at inference/rollout time.
+        # When a dense embed isn't safe — no embed_fn and no Chroma-hosted
+        # server-side embedding function — use the BM25 lexical index if the
+        # collection has one, otherwise refuse rather than fetch all-MiniLM.
+        if not client.dense_embed_is_safe():
+            if not has_lexical:
+                raise LocalEmbeddingDownloadDisallowedError(
+                    "chroma", self._collection_name
+                )
+            mode = "lexical"
+        elif mode == "auto":
             if "hybrid" in modes:
                 mode = "hybrid"
-            elif "lexical" in modes:
+            elif has_lexical:
                 mode = "lexical"
             else:
                 mode = "vector"
-        elif mode not in client.modes:
+        elif mode not in modes:
             raise ValueError(
                 f"ChromaSearch does not support mode '{mode}'. "
-                f"Available modes: {sorted(client.modes)}"
+                f"Available modes: {sorted(modes)}"
             )
 
         if client.search_api and mode in ("lexical", "hybrid"):

--- a/src/benchmax/rag/corpus/chroma/source.py
+++ b/src/benchmax/rag/corpus/chroma/source.py
@@ -17,6 +17,7 @@ from tqdm.auto import tqdm
 from benchmax.rag.chunkers.models import Chunk, ChunkCollection
 from benchmax.rag.corpus.search_schema.search_exceptions import (
     InvalidSearchSpecError,
+    LocalEmbeddingDownloadDisallowedError,
     UnsupportedSearchModeError,
 )
 from benchmax.rag.corpus.search_schema.search_types import (
@@ -642,29 +643,30 @@ class ChromaChunkSource:
         # lack a BM25 index, in which case modes was downgraded to vector-only.
         modes = self._current_modes()
 
-        # Pick mode. "hybrid"/None use the best available strategy and KEEP
-        # lexical enabled as a fallback: hybrid = dense + sparse, and when we
-        # can't produce dense query vectors (no embed_fn, the usual remote case)
-        # the per-query loop below degrades to the sparse/lexical leg — which
-        # needs no embedding.
-        #
-        # An explicit "vector" (e.g. the linker's "inference" reasoning mode)
-        # normally disables lexical. But if the dense embed would be the
-        # chromadb-local fallback (no embed_fn, no hosted EF) we keep lexical
-        # instead: a remote default-EF collection would otherwise download
-        # all-MiniLM to embed every query. Server-side dense (hosted EF) or a
-        # client embed_fn stays on the vector path — semantic search preserved.
-        if mode == "vector":
+        has_lexical = "lexical" in modes
+        has_hybrid = "hybrid" in modes
+
+        # Hard rule: never let chromadb embed a query with a client-side model
+        # (it downloads all-MiniLM and crawls in constrained executors). When a
+        # dense embed isn't safe — no embed_fn and no Chroma-hosted server-side
+        # embedding function — use the BM25 lexical index if the collection has
+        # one, otherwise refuse. This covers every requested mode, including the
+        # linker's "inference" preference for vector.
+        if not self._chroma.dense_embed_is_safe():
+            if not has_lexical:
+                raise LocalEmbeddingDownloadDisallowedError(
+                    "chroma", self._chroma.collection_name
+                )
             use_hybrid = False
-            use_lexical = (
-                "lexical" in modes and self._chroma.dense_requires_local_model()
-            )
+            use_lexical = True
         elif mode == "lexical":
             use_hybrid = False
-            use_lexical = "lexical" in modes
+            use_lexical = has_lexical
+        elif mode == "vector":
+            use_hybrid = use_lexical = False
         else:  # "hybrid", None, or unrecognized -> best available
-            use_hybrid = "hybrid" in modes
-            use_lexical = "lexical" in modes
+            use_hybrid = has_hybrid
+            use_lexical = has_lexical
 
         # Batch-embed all queries when embed_fn available and vectors needed
         vectors: list[list[float]] | None = None

--- a/src/benchmax/rag/corpus/chroma/source.py
+++ b/src/benchmax/rag/corpus/chroma/source.py
@@ -646,13 +646,19 @@ class ChromaChunkSource:
         # lexical enabled as a fallback: hybrid = dense + sparse, and when we
         # can't produce dense query vectors (no embed_fn, the usual remote case)
         # the per-query loop below degrades to the sparse/lexical leg — which
-        # needs no embedding. Only an explicit "vector" disables lexical; that's
-        # the dense-only recovery path a caller uses after a lexical/hybrid
-        # failure. (Disabling lexical for "hybrid" silently forced vector search,
-        # which made remote collections dense-embed every query — slow, and on a
-        # default-EF collection it pulls the all-MiniLM model.)
+        # needs no embedding.
+        #
+        # An explicit "vector" (e.g. the linker's "inference" reasoning mode)
+        # normally disables lexical. But if the dense embed would be the
+        # chromadb-local fallback (no embed_fn, no hosted EF) we keep lexical
+        # instead: a remote default-EF collection would otherwise download
+        # all-MiniLM to embed every query. Server-side dense (hosted EF) or a
+        # client embed_fn stays on the vector path — semantic search preserved.
         if mode == "vector":
-            use_hybrid = use_lexical = False
+            use_hybrid = False
+            use_lexical = (
+                "lexical" in modes and self._chroma.dense_requires_local_model()
+            )
         elif mode == "lexical":
             use_hybrid = False
             use_lexical = "lexical" in modes

--- a/src/benchmax/rag/corpus/search_schema/search_exceptions.py
+++ b/src/benchmax/rag/corpus/search_schema/search_exceptions.py
@@ -43,3 +43,21 @@ class UnsupportedSearchModeError(ValueError):
             f"[{backend}] unsupported search mode '{mode}'. "
             f"Supported modes: {sorted(supported_modes)}"
         )
+
+
+class LocalEmbeddingDownloadDisallowedError(RuntimeError):
+    """Raised when serving a search would download a client-side embedding model.
+
+    The collection has no server-side (hosted) embedding function and no BM25
+    index, and the caller supplied no ``embed_fn`` — so embedding a text query
+    would make chromadb download and run a local model (e.g. all-MiniLM). We
+    refuse rather than trigger that download.
+    """
+
+    def __init__(self, backend: str, collection: str):
+        super().__init__(
+            f"[{backend}] collection {collection!r} has no server-side embedding "
+            "function and no BM25 index, so search would download a local "
+            "embedding model. Re-ingest the corpus with a hosted embedder "
+            "(chroma-cloud-qwen) or a BM25 index, or supply an embed_fn."
+        )

--- a/tests/unit/rag/corpus/chroma/test_configurations.py
+++ b/tests/unit/rag/corpus/chroma/test_configurations.py
@@ -27,6 +27,7 @@ from fakes.chroma import (
 from benchmax.rag.chunkers.models import Chunk
 from benchmax.rag.corpus.chroma.client import BM25_KEY
 from benchmax.rag.corpus.search_schema.search_exceptions import (
+    LocalEmbeddingDownloadDisallowedError,
     UnsupportedSearchModeError,
 )
 from benchmax.rag.corpus.search_schema.search_types import SearchSpec
@@ -587,51 +588,55 @@ class TestCloudQwenEmbeddingRepair:
 # ---------------------------------------------------------------------------
 
 
-class TestDenseLocality:
-    """dense_requires_local_model() — when a vector query embeds locally."""
+def _set_ef_name(source, name):
+    """Set the fake collection's configured embedding-function name.
 
-    def _client(self, *, embed_fn=None, ef="missing"):
-        col = FakeCollection(count=0)
-        source = make_source(col, embed_fn=embed_fn)
-        if ef != "missing":
-            source._chroma._collection._embedding_function = ef
+    ``name=None`` means a collection with no embedding function at all.
+    """
+    cfg = {"embedding_function": {"name": name}} if name is not None else {}
+    source._chroma._collection._model = SimpleNamespace(configuration_json=cfg)
+
+
+class TestDenseSafety:
+    """dense_embed_is_safe() — when a vector query won't download a model."""
+
+    def _chroma(self, *, embed_fn=None, ef_name="missing"):
+        source = make_source(FakeCollection(count=0), embed_fn=embed_fn)
+        if ef_name != "missing":
+            _set_ef_name(source, ef_name)
         return source._chroma
 
-    def test_true_when_no_embed_fn_and_no_ef(self):
-        # FakeCollection has no _embedding_function -> chromadb default fallback.
-        assert self._client().dense_requires_local_model() is True
-
-    def test_true_for_default_embedding_function(self):
-        class DefaultEmbeddingFunction:
-            pass
-
-        assert (
-            self._client(ef=DefaultEmbeddingFunction()).dense_requires_local_model()
-            is True
-        )
-
-    def test_false_with_client_embed_fn(self):
+    def test_true_with_client_embed_fn(self):
         from unittest.mock import MagicMock
 
-        assert self._client(embed_fn=MagicMock()).dense_requires_local_model() is False
+        assert self._chroma(embed_fn=MagicMock()).dense_embed_is_safe() is True
 
-    def test_false_with_hosted_embedding_function(self):
-        # A non-default EF (e.g. chroma-cloud-qwen) embeds server-side.
-        assert self._client(ef=object()).dense_requires_local_model() is False
+    def test_true_for_hosted_server_side_ef(self):
+        assert self._chroma(ef_name="chroma-cloud-qwen").dense_embed_is_safe() is True
+
+    def test_false_for_default_ef(self):
+        # all-MiniLM, client-side download.
+        assert self._chroma(ef_name="default").dense_embed_is_safe() is False
+
+    def test_false_for_third_party_api_ef(self):
+        # No model download, but we lack the provider key -> treat as unsafe.
+        assert self._chroma(ef_name="openai").dense_embed_is_safe() is False
+
+    def test_false_for_no_embedding_function(self):
+        assert self._chroma(ef_name=None).dense_embed_is_safe() is False
 
     def test_false_when_collection_uninitialized(self):
-        chroma = self._client()
+        chroma = self._chroma()
         chroma._collection = None
-        assert chroma.dense_requires_local_model() is False
+        assert chroma.dense_embed_is_safe() is False
 
 
 class TestSearchModeClamp:
-    def test_explicit_vector_mode_uses_vector_when_dense_is_cheap(self):
-        """mode='vector' uses the query() vector path when dense is not local.
+    def test_vector_uses_vector_when_dense_is_safe(self):
+        """mode='vector' uses the query() vector path when dense is safe.
 
-        A server-side embedding function (here a non-default stand-in) means a
-        dense embed is cheap, so the vector preference is honored rather than
-        degraded to lexical.
+        A server-side hosted embedding function (default fake = chroma-cloud-qwen)
+        means a dense embed never downloads a model, so vector is honored.
         """
         col = FakeCollection(
             query_results_per_call=[make_query_result(["v"])],
@@ -640,9 +645,6 @@ class TestSearchModeClamp:
         source = make_source(col, files=NoFileFakeFiles())
         source._chroma.modes = {"vector", "lexical", "hybrid"}
         source._chroma.search_api = True
-        # Hosted/server-side EF (type name != DefaultEmbeddingFunction) -> dense
-        # is cheap, so vector is not degraded.
-        source._chroma._collection._embedding_function = object()
 
         primary = Chunk(content="src", metadata=())
         results = source.search_related(primary, ["q"], top_k=5, mode="vector")
@@ -650,40 +652,48 @@ class TestSearchModeClamp:
         # Vector path went through the legacy query() API, not collection.search().
         assert col._last_query_kwargs["query_texts"] == ["q"]
 
-    def test_vector_degrades_to_lexical_when_dense_is_local(self):
-        """mode='vector' + local-default dense + lexical available -> lexical.
+    def test_unsafe_dense_degrades_to_lexical_when_bm25_present(self):
+        """Unsafe dense (default EF, no embed_fn) + BM25 -> lexical, no download.
 
-        The linker's "inference" reasoning mode requests vector. On a remote
-        default-EF collection (no embed_fn, no hosted EF) honoring it would make
-        chromadb download all-MiniLM to embed every query. With a lexical index
-        present we use that instead — no embedding, no model download.
+        Covers the e2e collection: the linker's "inference" mode requests vector,
+        but honoring it would download all-MiniLM. With a BM25 index present we
+        use that instead — for every requested mode.
         """
-        col = FakeCollection(count=5)
-        source = make_source(col, files=NoFileFakeFiles())  # embed_fn=None
+        source = make_source(FakeCollection(count=5), files=NoFileFakeFiles())
         source._chroma.modes = {"vector", "lexical", "hybrid"}
         source._chroma.search_api = True
-        # FakeCollection has no _embedding_function -> treated as local default.
-        assert source._chroma.dense_requires_local_model() is True
+        _set_ef_name(source, "default")  # client-side all-MiniLM -> unsafe
+        assert source._chroma.dense_embed_is_safe() is False
 
         captured: list[str | None] = []
         source._search_with_scores = lambda spec: captured.append(spec.get("mode")) or []  # type: ignore[method-assign,return-value]
-        source.search_related(
-            Chunk(content="src", metadata=()), ["q"], top_k=3, mode="vector"
-        )
-        assert captured == ["lexical"]
+        for requested in ("vector", "hybrid", None):
+            captured.clear()
+            source.search_related(
+                Chunk(content="src", metadata=()), ["q"], top_k=3, mode=requested
+            )
+            assert captured == ["lexical"], requested
 
-    def test_vector_stays_vector_when_no_lexical_fallback(self):
-        """mode='vector' on a vector-only collection still does vector.
+    def test_unsafe_dense_without_bm25_raises(self):
+        """Unsafe dense + no BM25 index -> error, never a model download."""
+        source = make_source(FakeCollection(count=5), files=NoFileFakeFiles())
+        source._chroma.modes = {"vector"}  # vector-only, no lexical
+        source._chroma.search_api = True
+        _set_ef_name(source, "default")  # unsafe
 
-        No lexical index to fall back to (e.g. a hosted-EF collection downgraded
-        to vector-only), so the dense path is the only option.
-        """
+        with pytest.raises(LocalEmbeddingDownloadDisallowedError):
+            source.search_related(
+                Chunk(content="src", metadata=()), ["q"], top_k=3, mode="vector"
+            )
+
+    def test_vector_stays_vector_when_safe_and_no_lexical(self):
+        """Safe dense (hosted EF) + vector-only collection -> vector."""
         col = FakeCollection(
             query_results_per_call=[make_query_result(["v"])],
             count=5,
         )
         source = make_source(col, files=NoFileFakeFiles())
-        source._chroma.modes = {"vector"}  # no lexical
+        source._chroma.modes = {"vector"}  # no lexical; default fake EF is hosted
         source._chroma.search_api = True
 
         captured: list[str | None] = []

--- a/tests/unit/rag/corpus/chroma/test_configurations.py
+++ b/tests/unit/rag/corpus/chroma/test_configurations.py
@@ -587,12 +587,51 @@ class TestCloudQwenEmbeddingRepair:
 # ---------------------------------------------------------------------------
 
 
-class TestSearchModeClamp:
-    def test_explicit_vector_mode_forces_vector_path(self):
-        """mode='vector' uses the query() vector path even when hybrid is available.
+class TestDenseLocality:
+    """dense_requires_local_model() — when a vector query embeds locally."""
 
-        Lets the QA metadata-linker force vector search to recover from a
-        lexical/hybrid failure without depending on capability state.
+    def _client(self, *, embed_fn=None, ef="missing"):
+        col = FakeCollection(count=0)
+        source = make_source(col, embed_fn=embed_fn)
+        if ef != "missing":
+            source._chroma._collection._embedding_function = ef
+        return source._chroma
+
+    def test_true_when_no_embed_fn_and_no_ef(self):
+        # FakeCollection has no _embedding_function -> chromadb default fallback.
+        assert self._client().dense_requires_local_model() is True
+
+    def test_true_for_default_embedding_function(self):
+        class DefaultEmbeddingFunction:
+            pass
+
+        assert (
+            self._client(ef=DefaultEmbeddingFunction()).dense_requires_local_model()
+            is True
+        )
+
+    def test_false_with_client_embed_fn(self):
+        from unittest.mock import MagicMock
+
+        assert self._client(embed_fn=MagicMock()).dense_requires_local_model() is False
+
+    def test_false_with_hosted_embedding_function(self):
+        # A non-default EF (e.g. chroma-cloud-qwen) embeds server-side.
+        assert self._client(ef=object()).dense_requires_local_model() is False
+
+    def test_false_when_collection_uninitialized(self):
+        chroma = self._client()
+        chroma._collection = None
+        assert chroma.dense_requires_local_model() is False
+
+
+class TestSearchModeClamp:
+    def test_explicit_vector_mode_uses_vector_when_dense_is_cheap(self):
+        """mode='vector' uses the query() vector path when dense is not local.
+
+        A server-side embedding function (here a non-default stand-in) means a
+        dense embed is cheap, so the vector preference is honored rather than
+        degraded to lexical.
         """
         col = FakeCollection(
             query_results_per_call=[make_query_result(["v"])],
@@ -601,12 +640,59 @@ class TestSearchModeClamp:
         source = make_source(col, files=NoFileFakeFiles())
         source._chroma.modes = {"vector", "lexical", "hybrid"}
         source._chroma.search_api = True
+        # Hosted/server-side EF (type name != DefaultEmbeddingFunction) -> dense
+        # is cheap, so vector is not degraded.
+        source._chroma._collection._embedding_function = object()
 
         primary = Chunk(content="src", metadata=())
         results = source.search_related(primary, ["q"], top_k=5, mode="vector")
         assert results[0]["chunk"].content == "v"
         # Vector path went through the legacy query() API, not collection.search().
         assert col._last_query_kwargs["query_texts"] == ["q"]
+
+    def test_vector_degrades_to_lexical_when_dense_is_local(self):
+        """mode='vector' + local-default dense + lexical available -> lexical.
+
+        The linker's "inference" reasoning mode requests vector. On a remote
+        default-EF collection (no embed_fn, no hosted EF) honoring it would make
+        chromadb download all-MiniLM to embed every query. With a lexical index
+        present we use that instead — no embedding, no model download.
+        """
+        col = FakeCollection(count=5)
+        source = make_source(col, files=NoFileFakeFiles())  # embed_fn=None
+        source._chroma.modes = {"vector", "lexical", "hybrid"}
+        source._chroma.search_api = True
+        # FakeCollection has no _embedding_function -> treated as local default.
+        assert source._chroma.dense_requires_local_model() is True
+
+        captured: list[str | None] = []
+        source._search_with_scores = lambda spec: captured.append(spec.get("mode")) or []  # type: ignore[method-assign,return-value]
+        source.search_related(
+            Chunk(content="src", metadata=()), ["q"], top_k=3, mode="vector"
+        )
+        assert captured == ["lexical"]
+
+    def test_vector_stays_vector_when_no_lexical_fallback(self):
+        """mode='vector' on a vector-only collection still does vector.
+
+        No lexical index to fall back to (e.g. a hosted-EF collection downgraded
+        to vector-only), so the dense path is the only option.
+        """
+        col = FakeCollection(
+            query_results_per_call=[make_query_result(["v"])],
+            count=5,
+        )
+        source = make_source(col, files=NoFileFakeFiles())
+        source._chroma.modes = {"vector"}  # no lexical
+        source._chroma.search_api = True
+
+        captured: list[str | None] = []
+        orig = source._search_with_scores
+        source._search_with_scores = lambda spec: (captured.append(spec.get("mode")), orig(spec))[1]  # type: ignore[method-assign]
+        source.search_related(
+            Chunk(content="src", metadata=()), ["q"], top_k=3, mode="vector"
+        )
+        assert captured == ["vector"]
 
     def test_downgraded_modes_clamp_stale_hybrid_request_to_vector(self):
         """A stale mode='hybrid' is clamped to vector when the index is gone.

--- a/tests/unit/rag/corpus/chroma/test_search.py
+++ b/tests/unit/rag/corpus/chroma/test_search.py
@@ -8,10 +8,20 @@ import cloudpickle
 import pytest
 
 from benchmax.rag.corpus.chroma.search import ChromaSearch
+from benchmax.rag.corpus.search_schema.search_exceptions import (
+    LocalEmbeddingDownloadDisallowedError,
+)
 
 
-def _make_search(modes=None, embed_fn=None) -> ChromaSearch:
-    """Build a ChromaSearch with a fake ChromaClient injected."""
+def _make_search(modes=None, embed_fn=None, ef_name="chroma-cloud-qwen") -> ChromaSearch:
+    """Build a ChromaSearch with a fake ChromaClient injected.
+
+    ``ef_name`` is the collection's configured embedding function: defaults to a
+    hosted server-side EF (dense-safe). Pass ``"default"`` (all-MiniLM, would
+    download) or ``None`` (no EF) to exercise the unsafe path.
+    """
+    from types import SimpleNamespace
+
     from benchmax.rag.corpus.chroma.client import ChromaClient
 
     cs = ChromaSearch(
@@ -37,7 +47,11 @@ def _make_search(modes=None, embed_fn=None) -> ChromaSearch:
     client.rrf_oversample = 20
     client.rrf_max_candidates = 200
     client._raw_client = None
-    client._collection = None
+    cfg = {"embedding_function": {"name": ef_name}} if ef_name is not None else {}
+    client._collection = SimpleNamespace(
+        _model=SimpleNamespace(configuration_json=cfg)
+    )
+    client.get_collection = lambda: client._collection
     client._embed_dim = None
     client._total_count = None
     client.search_api = False
@@ -91,6 +105,37 @@ class TestSearch:
         cs = _make_search(modes={"vector"})
         with pytest.raises(ValueError, match="does not support mode 'hybrid'"):
             cs.search("query", mode="hybrid")
+
+    def test_unsafe_dense_uses_lexical_at_inference(self):
+        """Default-EF collection + BM25: the search tool uses BM25, no download.
+
+        Mirrors a rollout/inference search against a default (all-MiniLM)
+        collection — embedding would download a model, so we use lexical instead.
+        """
+        cs = _make_search(modes={"vector", "lexical", "hybrid"}, ef_name="default")
+        cs._client.search_api = True
+        seen = {}
+        cs._client.search_api_raw = lambda **kw: seen.update(kw) or [
+            {"id": "1", "content": "bm25 result", "metadata": {}, "score": 0.9},
+        ]
+        results = cs.search("query", mode="auto")
+        assert results[0]["content"] == "bm25 result"
+        assert seen["mode"] == "lexical"  # never vector/hybrid -> no embed
+
+    def test_unsafe_dense_without_bm25_raises_at_inference(self):
+        """Default-EF, vector-only collection: refuse rather than download."""
+        cs = _make_search(modes={"vector"}, ef_name="default")
+        with pytest.raises(LocalEmbeddingDownloadDisallowedError):
+            cs.search("query", mode="auto")
+
+    def test_explicit_vector_on_unsafe_collection_degrades(self):
+        """Even an explicit vector request degrades to BM25 when unsafe."""
+        cs = _make_search(modes={"vector", "lexical"}, ef_name="default")
+        cs._client.search_api = True
+        seen = {}
+        cs._client.search_api_raw = lambda **kw: seen.update(kw) or []
+        cs.search("query", mode="vector")
+        assert seen["mode"] == "lexical"
 
 
 class TestEmbed:

--- a/tests/unit/rag/fakes/chroma.py
+++ b/tests/unit/rag/fakes/chroma.py
@@ -5,6 +5,7 @@ One place to update when the real ChromaChunkSource interface changes.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 from benchmax.rag.chunkers.models import Chunk
@@ -182,6 +183,13 @@ def make_source(
     # Inject the fake collection so no real Chroma connection is made
     chroma._collection = collection
     chroma._total_count = collection.count() if collection else None
+    # Default fake collection embeds server-side (hosted EF) so dense queries are
+    # "safe" by default. Tests covering the local-download / error policy override
+    # collection._model.configuration_json with a default/third-party/no EF.
+    if collection is not None and not hasattr(collection, "_model"):
+        collection._model = SimpleNamespace(
+            configuration_json={"embedding_function": {"name": "chroma-cloud-qwen"}}
+        )
 
     source = ChromaChunkSource.__new__(ChromaChunkSource)
     source._chroma = chroma

--- a/uv.lock
+++ b/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "benchmax"
-version = "0.1.2.dev30"
+version = "0.1.2.dev31"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1052,9 +1052,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
     { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
     { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
     { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
     { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
     { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },


### PR DESCRIPTION
## Summary
Launch-safe rule: **a dense (vector) query is allowed only when it won't download a model.** Otherwise we use BM25 if the collection has it, else error — chromadb never pulls all-MiniLM. Applied to **both** code paths that embed a query:
- **QA generation** — `ChromaChunkSource.search_related` (the metadata-linker)
- **Inference / training** — `ChromaSearch.search` (the tool `SearchEnv` calls per rollout)

### Why
A Chroma Cloud collection whose embedder is the **default (all-MiniLM)** embeds **client-side in the executor**, downloading the ~80MB ONNX model over a throttled link → hang. QA-gen surfaced it first (the linker's "inference" reasoning mode forces `vector`); the same path exists at rollout time, where it would download on every worker. Verifying against Chroma's docs also showed the embedder space is broader than "default": third-party API EFs (OpenAI/Cohere/…), other local-model EFs (sentence-transformers/HF/Ollama/ONNX), hosted server-side EFs (chroma-cloud-qwen/splade), and no-EF collections.

### Policy (`ChromaClient.dense_embed_is_safe()`, keyed off the collection's configured EF name)
| Dense embedder | BM25 | Behavior (QA-gen + inference) |
|---|---|---|
| Hosted server-side (chroma-cloud-qwen) | any | **vector/hybrid server-side** — no download |
| caller `embed_fn` | any | vector via embed_fn |
| default / sentence-transformers / HF / Ollama / ONNX / third-party API / no EF | **yes** | **BM25 lexical** (every mode) — no download |
| same, unsafe | **no** | **raise `LocalEmbeddingDownloadDisallowedError`** |

`_SERVER_SIDE_EF_NAMES` is a conservative allowlist (currently `chroma-cloud-qwen`); unknown embedders are unsafe by design.

## Validation
- `pytest tests/unit/rag/{corpus/chroma,qa_generation}` — 101 pass (new `TestDenseSafety`; QA-gen + inference unsafe→BM25 / unsafe+no-BM25→raise / hosted→vector)
- `ruff` clean
- **Live Chroma Cloud:** `cgft-cloud-e2e-test` (default EF + BM25) → QA-gen and inference both resolve to **lexical**, no download; `customer-support-messages` (chroma-cloud-qwen) → **vector server-side**, no download.

## Follow-ups (not blocking launch)
- Optional low-level safety net in `query_raw`/`search_api_raw` (raise before any dense embed) to also cover the lower-level `search()`/`search_content()` helpers.
- Broaden sparse detection beyond the hardcoded `bm25_embedding` key; add more hosted EF names as verified.