### PR TITLE
Revert #47: fall back to full completion when no <answer> block

### DIFF
--- a/src/benchmax/envs/postgres_search/search_env.py
+++ b/src/benchmax/envs/postgres_search/search_env.py
@@ -285,14 +285,8 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
             if not text.strip():
                 return zeros
 
-            # No final <answer> block → no answer to score. Return all-zero
-            # rewards so conciseness / citations / efficiency can't accrue
-            # from reasoning or tool-call text alone.
-            answer = extract_answer_block(text)
-            if not answer:
-                return zeros
-
             t = task or {}
+            answer = extract_answer_block(text)
             prompt = str(t.get("question") or t.get("prompt") or "")
             gt_str = str(t.get("ground_truth") or "")
             reference_chunks = t.get("reference_chunks", [])

--- a/src/benchmax/envs/reward_helpers.py
+++ b/src/benchmax/envs/reward_helpers.py
@@ -82,16 +82,9 @@ def extract_completion_text(completion: str | list[dict[str, Any]]) -> str:
 
 
 def extract_answer_block(text: str) -> str:
-    """Extract content from ``<answer>`` tags.
-
-    Returns the (stripped) tag contents when an ``<answer>…</answer>`` block
-    is present, otherwise ``""``. A missing answer block is treated as "no
-    final answer" rather than silently falling back to the full completion —
-    consumers can gate rewards on a non-empty result. ``<answer></answer>``
-    likewise yields ``""``.
-    """
+    """Extract content from <answer> tags, or return full text."""
     match = _ANSWER_TAG_RE.search(text or "")
-    return match.group(1).strip() if match else ""
+    return (match.group(1) if match else text).strip()
 
 
 def clip01(value: Any) -> float:

--- a/tests/unit/envs/postgres_search/test_search_env.py
+++ b/tests/unit/envs/postgres_search/test_search_env.py
@@ -448,38 +448,6 @@ class TestComputeReward:
         )
         assert all(v == 0.0 for v in result.values())
 
-    @patch(
-        "benchmax.envs.postgres_search.search_env.evaluate_single_rubric",
-        new_callable=AsyncMock,
-    )
-    def test_no_answer_block_returns_zeros(self, mock_eval):
-        # Model never emits <answer> tags. Even though the judge would happily
-        # score the reasoning/citation text, the missing answer block must zero
-        # out every component — conciseness, citations and efficiency included.
-        mock_eval.return_value = {"score": 1.0}
-        env = _make_env(
-            w_correctness=1.0,
-            w_conciseness=0.5,
-            w_citation_recall=1.0,
-            w_citation_precision=1.0,
-        )
-        result = asyncio.run(
-            env.compute_reward(
-                "r1",
-                _msgs("Here is 42, see [Source: doc_a] but I forgot the tags"),
-                {
-                    "question": "What?",
-                    "ground_truth": "42",
-                    "reference_chunks": [
-                        {"content": "...", "metadata": {"file": "doc_a"}}
-                    ],
-                },
-            )
-        )
-        assert all(v == 0.0 for v in result.values())
-        # The judge must never even be consulted without a final answer.
-        mock_eval.assert_not_called()
-
 
 class TestCitationScoring:
     def test_no_reference_chunks_returns_zero(self):

--- a/tests/unit/envs/test_reward_helpers.py
+++ b/tests/unit/envs/test_reward_helpers.py
@@ -35,12 +35,7 @@ class TestExtractAnswerBlock:
         assert extract_answer_block("before <answer>the answer</answer> after") == "the answer"
 
     def test_without_tags(self):
-        # No <answer> block → empty string, not the full text. Consumers
-        # gate rewards on a non-empty answer.
-        assert extract_answer_block("no tags here") == ""
-
-    def test_empty_tags(self):
-        assert extract_answer_block("before <answer></answer> after") == ""
+        assert extract_answer_block("no tags here") == "no tags here"
 
     def test_empty(self):
         assert extract_answer_block("") == ""


### PR DESCRIPTION
## Why

Reverts #47 ("answer tags must be present for scoring").

A customer replaced the default RAG system prompt with their own and dropped the `<answer>…</answer>` instruction. With #47, `extract_answer_block` returns `""` when no block is present, so every text-based reward (judge, citation, exact_match, contains) scored against empty text — the whole run got zeroed even though the model produced perfectly good answers.

## Change

Restores the pre-#47 behavior:
- `extract_answer_block` extracts the `<answer>` block when present, **otherwise returns the full text** (instead of `""`).
- `search_env.compute_reward` drops the `if not answer: return zeros` guard.
- Test expectations reverted to match.

The platform-service codegen calls `extract_answer_block(completion)` in its generated `compute_reward`, so this flows through to the wizard/training path once the benchmax pin is bumped. No platform-service change needed.

## Tradeoff

This reverts #47's deliberate "answer tags must be present" signal globally. A model that *was* instructed to use `<answer>` tags but fails to emit them now gets partial credit on its full reasoning text instead of 0. Accepted: the cost of that is lower than silently zeroing custom-prompt customers.

## Tests

`tests/unit/envs/test_reward_helpers.py` + `tests/unit/envs/postgres_search/test_search_env.py` — 55 passed. ruff clean.