### PR TITLE
docs(cli): make agents load the verify-environment skill before validate

### DIFF
--- a/src/benchmax/cli/scaffold/CLAUDE.md
+++ b/src/benchmax/cli/scaffold/CLAUDE.md
@@ -20,9 +20,21 @@ the skills, not a scaffolded file). Write your datasets too, then `castform
 validate`. The green baseline is the milestone: when validate passes with sane,
 **varying** rewards, stop and decide **iterate or launch**.
 
-> Skills for each stage live in `.claude/skills/` — `design-environment`,
-> `generate-data`, `verify-environment`, `launch-run`, `view-progress`. Read the
-> matching skill before doing that stage.
+> **Load the skill for every stage — this is mandatory, not optional.** Each
+> stage has a skill in `.claude/skills/` — `design-environment`, `generate-data`,
+> `verify-environment`, `launch-run`, `view-progress`. **Invoke the matching skill
+> (Skill tool) before you run that stage's `castform` command**, every time.
+> Running a `castform` command without its skill loaded means you miss how to read
+> its output and what to do next.
+>
+> **In particular: ALWAYS invoke the `verify-environment` skill before you run
+> `castform validate`.** That skill defines how to read the scorecard and the exact
+> format for reporting the baseline — `castform validate` run without it loaded is
+> how the baseline report drifts. No exceptions: load `verify-environment` first,
+> then validate.
+>
+> The skills chain — each one ends by pointing to the next; follow that handoff and
+> load the skill it names rather than jumping straight to the command.
 
 ## Setup
 

--- a/src/benchmax/cli/scaffold/skills/design-environment/SKILL.md
+++ b/src/benchmax/cli/scaffold/skills/design-environment/SKILL.md
@@ -27,7 +27,12 @@ Write a single-turn `run.py` — a `BaseEnv` subclass — by filling in three th
 Start single-turn with no tools (`list_tools` returns `[]`). That's the right
 default — only reach for tools if the task genuinely needs them.
 
-Next: **generate-data** for the datasets, then **verify-environment** to validate.
+Next, hand off to the next skill — **load it, don't just run its command**:
+**invoke the `generate-data` skill** for the datasets, then **invoke the
+`verify-environment` skill** before you run `castform validate`. Each stage's
+skill is loaded with the Skill tool; `castform validate` without
+verify-environment loaded means you'll miss how to read the scorecard and report
+the baseline.
 
 ## Going deeper
 

--- a/src/benchmax/cli/scaffold/skills/generate-data/SKILL.md
+++ b/src/benchmax/cli/scaffold/skills/generate-data/SKILL.md
@@ -43,7 +43,10 @@ sharing/inspecting a file out of band:
 castform data upload train_dataset.jsonl   # → blobPath: datasets/cli/train_dataset.jsonl
 ```
 
-When the data's in place, go to **verify-environment** and run `castform validate`.
+When the data's in place, **invoke the `verify-environment` skill** (with the
+Skill tool) *before* you run `castform validate` — don't run the command bare. It
+defines how to read the scorecard and the exact format for reporting the baseline;
+running `validate` without it loaded is how the baseline report drifts.
 
 ## Going deeper
 


### PR DESCRIPTION
## Problem

A real agent trace following the setup flow (`design → generate → validate`) produced a baseline report that **ignored the prescribed format** — it led with a bare reward table and skipped *What you built*, the run config, the checks block, and a clearly-labelled verdict.

Root cause: the baseline-report contract lives **only** in the `verify-environment` skill, but the agent **never loaded it**. The handoff in `design-environment` / `generate-data` was soft — *"go to verify-environment and run `castform validate`"* — which the model collapsed into *just running the command*. It ran `validate` bare and free-formed the report. This is a missing-skill-at-the-step bug, not recency/decay: the format text was never in context.

## Fix (docs only — no CLI/output changes)

1. **Mandatory skill-loading in the agent guide.** The scaffold `CLAUDE.md` (also written as `AGENTS.md`) now makes loading each stage's skill mandatory, with an explicit callout to **always invoke the `verify-environment` skill before `castform validate`**.
2. **Skills chain stage to stage.** `design-environment` and `generate-data` now hand off with an explicit *invoke the next skill* (Skill tool) instruction instead of pointing at the command.

Deliberately **not** changed:
- No `castform validate` output change — a human running the command shouldn't see agent-only instructions.
- No edit to `verify-environment` itself — the format spec there is fine; the bug was that the skill never loaded.

## Test

`tests/unit/test_cli_setup.py` + `tests/unit/test_cli_validate.py` — 45 passed.