### PR TITLE
feat(envs): make the audited reward the SearchEnv default

### DIFF
--- a/src/benchmax/cli/scaffold/CLAUDE.md
+++ b/src/benchmax/cli/scaffold/CLAUDE.md
@@ -98,11 +98,12 @@ Rewards are the training signal; robust rewards matter more than anything else.
   need tie-breaking resolution.
 <!-- rag:start -->
 - **For RAG, audit the reward before launch** (`castform validate --reward-audit`).
-  Extract only a committed `<answer>...</answer>` block (never score the model's
-  whole reasoning as an answer), match citations by **id-hash OR title-path** across
-  corpus source formats, keep an **ungated** `retrieval_hit` (credit finding gold
-  even on a wrong answer), and prefer a deterministic length term over an LLM
-  conciseness judge.
+  The `SearchEnv` default already implements the audited shape: it extracts only a
+  committed `<answer>...</answer>` block (never scores the model's whole reasoning
+  as an answer), matches citations by **id-hash OR title-path** across corpus
+  source formats, keeps an **ungated** `retrieval_hit` (credit finding gold even
+  on a wrong answer), and uses a deterministic length term instead of an LLM
+  conciseness judge. Verify on real transcripts that it fits your corpus.
 <!-- rag:end -->
 
 ## Dependencies

--- a/src/benchmax/cli/scaffold/CLAUDE.md
+++ b/src/benchmax/cli/scaffold/CLAUDE.md
@@ -101,7 +101,7 @@ Rewards are the training signal; robust rewards matter more than anything else.
   The `SearchEnv` default already implements the audited shape: it extracts only a
   committed `<answer>...</answer>` block (never scores the model's whole reasoning
   as an answer), matches citations by **id-hash OR title-path** across corpus
-  source formats, keeps an **ungated** `retrieval_hit` (credit finding gold even
+  source formats, keeps an **ungated** `retrieval_hit` (credit for citing gold even
   on a wrong answer), and uses a deterministic length term instead of an LLM
   conciseness judge. Verify on real transcripts that it fits your corpus.
 <!-- rag:end -->

--- a/src/benchmax/cli/scaffold/rag_main.py
+++ b/src/benchmax/cli/scaffold/rag_main.py
@@ -8,7 +8,7 @@ buried in the library. The heavy pieces (the correctness judge, the citation
 matcher) stay as named helpers imported from the lib so this file stays short.
 
 The reward is AUDITED (see `compute_reward`): correctness gates every secondary
-component, `retrieval_hit` is UNGATED so finding gold is rewarded even on a wrong
+component, `retrieval_hit` is UNGATED so citing gold is rewarded even on a wrong
 answer, citations match by id-hash OR title-path, and brevity is a deterministic
 length term (no second LLM call). `validate_probe` measures retrieval gold-hit@k
 over the eval rows — a pre-GPU check the cheap rollout can't give you.

--- a/src/benchmax/cli/scaffold/rag_main.py
+++ b/src/benchmax/cli/scaffold/rag_main.py
@@ -42,8 +42,10 @@ from typing import Any
 
 from benchmax import config
 from benchmax.envs.postgres_search.search_env import (
+    ANSWER_LENGTH_CAP,
     CORRECTNESS_RUBRIC,
     SearchEnv,
+    canonicalize_source_id_loose,
     extract_answer_block,
     score_citations,
 )
@@ -76,10 +78,10 @@ MAX_SEARCH_CALLS = 6
 # (~4 chars/token; 6 searches × 8000 ≈ 12k tokens, under a 16384 max_rollout_len).
 MAX_TOOL_OUTPUT_CHARS = 8000
 
-# Deterministic brevity cap: an answer at/above this many chars earns no length
-# bonus; shorter (still-correct) answers earn more. Replaces the LLM conciseness
-# judge (which fired on ~2% of rollouts) with dense signal on every correct rollout.
-ANSWER_LENGTH_CAP = 600
+# Deterministic brevity cap (imported above; lib default 600): an answer at/above
+# ANSWER_LENGTH_CAP chars earns no length bonus; shorter (still-correct) answers earn
+# more. Replaces the LLM conciseness judge (which fired on ~2% of rollouts) with
+# dense signal on every correct rollout.
 
 # validate_probe: retrieval gold-hit@k over eval rows — k, and a cap on live searches.
 PROBE_TOP_K = 10
@@ -151,12 +153,11 @@ class CustomSearchEnv(SearchEnv):
         return SearchEnv._truncate_tool_output(text, max_chars=max_chars)
 
     def _canonicalize_id(self, source_id: str) -> str:
-        """Match citations by id-hash OR title-path: lowercase, drop any directory
-        prefix and file extension, so 'docs/Geography.md', 'geography.md' and a bare
-        'geography' canonicalize alike (dup-heavy Notion/GitLab exports). Applied
-        symmetrically to the cited id and the gold `metadata.file`."""
-        s = str(source_id or "").strip().lower().rsplit("/", 1)[-1]
-        return s.rsplit(".", 1)[0] if "." in s else s
+        """Match citations by id-hash OR title-path (the lib default — lowercase,
+        drop any directory prefix and file extension, so 'docs/Geography.md',
+        'geography.md' and a bare 'geography' canonicalize alike). Kept here as
+        the seam to swap in a corpus-specific matcher."""
+        return canonicalize_source_id_loose(source_id)
 
     def estimate_rollout_tokens(self) -> int:
         # Worst case: system prompt + N searches × the per-result char cap + the

--- a/src/benchmax/cli/scaffold/skills/design-environment/SKILL.md
+++ b/src/benchmax/cli/scaffold/skills/design-environment/SKILL.md
@@ -210,31 +210,39 @@ dataset" means QA pairs generated from their real corpus.
 #### RAG — search a corpus and cite sources
 
 `castform setup --template rag` writes a `SearchEnv` with a search tool and inline
-reward arithmetic in `compute_reward`. Treat it as an auditable starting point, not
-a law. Before a real launch, inspect transcripts with
-`castform validate --reward-audit` and adjust:
+reward arithmetic in `compute_reward` — the audited 4-component shape, which is
+also the `SearchEnv` library default (`answer_correctness` gate, ungated
+`retrieval_hit`, gated `citation_precision` + deterministic `answer_length`).
+Treat it as an auditable starting point, not a law. Before a real launch, inspect
+transcripts with `castform validate --reward-audit` and adjust:
 
-- **Answer extraction:** only score a committed `<answer>` block. Missing tags
-  should score as no answer, and a final answer block should beat an earlier draft.
-- **Citations:** the stock matcher is exact-source oriented (`score_citations`
-  defaults to whitespace-strip). Real corpora often have duplicate titles, page-id
-  hashes, bare-id citations, or several valid pages for the same fact. Pass a custom
-  matcher — `score_citations(answer, chunks, canonicalize=lambda s: ...)` — to match
-  by id/hash/title/path, and credit citations to any valid retrieved source rather
-  than only the single gold label.
+- **Answer extraction:** only score a committed `<answer>` block (the default
+  does). Missing tags score as no answer, and a final answer block beats an
+  earlier draft.
+- **Citations:** the default matcher is **loose** (`canonicalize_source_id_loose`
+  — lowercase, strip directory prefix + extension, so id-hash and title-path
+  variants match alike). Real corpora may still need corpus-specific rules
+  (several valid pages for the same fact, exact-path corpora): pass a custom
+  matcher — `score_citations(answer, chunks, canonicalize=lambda s: ...)` — or
+  use the strict `canonicalize_source_id` for exact-path matching. Note the free
+  helpers (`score_citations` etc.) default to the strict matcher; only the env
+  defaults to loose.
 - **Correctness gate:** multiply citation, brevity, and style bonuses by
-  correctness so a wrong answer cannot bank source-format rewards.
-- **Retrieval signal (ungated):** unlike the format bonuses, keep a small
-  `retrieval_hit` term **ungated** — a gold-chunk retrieval is worth rewarding even
-  when the final answer is wrong, so the model keeps learning to search. `castform
-  validate`'s RAG probe reports retrieval **gold-hit@k**, so you can read retrieval
-  quality apart from answer correctness.
-- **Conciseness:** an LLM conciseness judge may be sparse and expensive. A
-  deterministic prose-length term, excluding citation labels, is often denser and
-  free.
-- **Search shaping:** a "fewer searches is better" bonus can fight multi-hop
-  exploration. Use the hard `MAX_SEARCH_CALLS` cap for safety; keep search
-  efficiency small or disable it when it under-explores.
+  correctness so a wrong answer cannot bank source-format rewards (the default
+  gates `citation_precision` and `answer_length` this way).
+- **Retrieval signal (ungated):** unlike the format bonuses, the small
+  `retrieval_hit` term stays **ungated** — a gold-chunk retrieval is worth
+  rewarding even when the final answer is wrong, so the model keeps learning to
+  search. `castform validate`'s RAG probe reports retrieval **gold-hit@k**, so
+  you can read retrieval quality apart from answer correctness.
+- **Conciseness:** the default brevity term is the deterministic `answer_length`
+  (a prose-length cap, `ANSWER_LENGTH_CAP`) — dense and free. An LLM conciseness
+  judge (`judge_answer_quality` + `CONCISENESS_RUBRIC`) is opt-in and may be
+  sparse and expensive.
+- **Search shaping:** the default reward has **no** search-efficiency bonus — a
+  "fewer searches is better" term can fight multi-hop exploration. The hard
+  `MAX_SEARCH_CALLS` cap covers safety; opt back in with
+  `score_search_efficiency` and keep it small if it under-explores.
 - **Tool-output budget:** large search responses across many turns count toward
   `max_rollout_len`. If you let each search return thousands of characters, lower
   `MAX_SEARCH_CALLS`, trim per-chunk bodies, or raise `max_rollout_len` after

--- a/src/benchmax/cli/scaffold/skills/design-environment/SKILL.md
+++ b/src/benchmax/cli/scaffold/skills/design-environment/SKILL.md
@@ -231,10 +231,11 @@ transcripts with `castform validate --reward-audit` and adjust:
   correctness so a wrong answer cannot bank source-format rewards (the default
   gates `citation_precision` and `answer_length` this way).
 - **Retrieval signal (ungated):** unlike the format bonuses, the small
-  `retrieval_hit` term stays **ungated** — a gold-chunk retrieval is worth
-  rewarding even when the final answer is wrong, so the model keeps learning to
-  search. `castform validate`'s RAG probe reports retrieval **gold-hit@k**, so
-  you can read retrieval quality apart from answer correctness.
+  `retrieval_hit` term stays **ungated** — citing a gold chunk is worth rewarding
+  even when the final answer is wrong, so the model keeps learning to search.
+  It's an answer-side proxy (gold sources cited in `<answer>`, not raw tool
+  traffic); `castform validate`'s RAG probe reports true retrieval **gold-hit@k**,
+  so you can read retrieval quality apart from answer correctness.
 - **Conciseness:** the default brevity term is the deterministic `answer_length`
   (a prose-length cap, `ANSWER_LENGTH_CAP`) — dense and free. An LLM conciseness
   judge (`judge_answer_quality` + `CONCISENESS_RUBRIC`) is opt-in and may be

--- a/src/benchmax/cli/scaffold/skills/verify-environment/SKILL.md
+++ b/src/benchmax/cli/scaffold/skills/verify-environment/SKILL.md
@@ -188,9 +188,10 @@ weight). Read the completions and answer these questions:
 - **For RAG, inspect retrieved chunks and cited sources.** Confirm search returned
   real chunks, the model cites the identifiers it actually saw, and your citation
   matcher accepts valid id/hash/title/path variants without rewarding hallucinated
-  sources. The audited RAG reward keeps an **ungated `retrieval_hit`** (a gold-chunk
-  retrieval is rewarded even when the answer is wrong); the validate probe reports
-  retrieval **gold-hit@k**, so you can read retrieval quality apart from correctness.
+  sources. The default RAG reward (the audited shape) keeps an **ungated
+  `retrieval_hit`** (a gold-chunk retrieval is rewarded even when the answer is
+  wrong); the validate probe reports retrieval **gold-hit@k**, so you can read
+  retrieval quality apart from correctness.
 <!-- rag:end -->
 - **Gate bonuses on correctness.** Wrong answers should not earn citation,
   conciseness, or style rewards. Partial answers should get only partial secondary

--- a/src/benchmax/cli/scaffold/skills/verify-environment/SKILL.md
+++ b/src/benchmax/cli/scaffold/skills/verify-environment/SKILL.md
@@ -189,9 +189,10 @@ weight). Read the completions and answer these questions:
   real chunks, the model cites the identifiers it actually saw, and your citation
   matcher accepts valid id/hash/title/path variants without rewarding hallucinated
   sources. The default RAG reward (the audited shape) keeps an **ungated
-  `retrieval_hit`** (a gold-chunk retrieval is rewarded even when the answer is
-  wrong); the validate probe reports retrieval **gold-hit@k**, so you can read
-  retrieval quality apart from correctness.
+  `retrieval_hit`** (citing a gold chunk in the final `<answer>` is rewarded even
+  when the answer is wrong — an answer-side proxy; it does not inspect raw tool
+  traffic); the validate probe reports retrieval **gold-hit@k**, so you can read
+  actual retrieval quality apart from correctness.
 <!-- rag:end -->
 - **Gate bonuses on correctness.** Wrong answers should not earn citation,
   conciseness, or style rewards. Partial answers should get only partial secondary

--- a/src/benchmax/envs/postgres_search/search_env.py
+++ b/src/benchmax/envs/postgres_search/search_env.py
@@ -3,8 +3,10 @@
 The default reward is the AUDITED 4-component shape (one LLM judge call, the rest
 deterministic):
 1. **answer_correctness** — LLM judge scores factual accuracy (the GATE)
-2. **retrieval_hit** — fraction of gold sources cited (UNGATED: finding gold is
-   rewarded even on a wrong answer, so the model keeps learning to search)
+2. **retrieval_hit** — fraction of gold sources cited in the final ``<answer>``
+   block (UNGATED: citing gold is rewarded even on a wrong answer, so the model
+   keeps learning to search). An answer-side proxy for retrieval — raw tool
+   traffic is never inspected.
 3. **citation_precision** — fraction of cited sources that are gold (gated on
    correctness)
 4. **answer_length** — deterministic brevity term (gated on correctness; replaces
@@ -318,7 +320,9 @@ class SearchEnv(BaseEnv):
             Defaults to ``platform_bearer`` (the credential seam).
         judge_timeout: Timeout for judge API calls.
         w_correctness: Weight for the correctness component (the gate).
-        w_retrieval_hit: Weight for the UNGATED gold-source recall component.
+        w_retrieval_hit: Weight for the UNGATED retrieval_hit component (recall
+            of gold sources among the final-answer citations — a proxy for
+            retrieval; tool traffic is not inspected).
         w_citation_precision: Weight for citation precision (gated).
         w_length: Weight for the deterministic brevity component (gated).
         max_search_calls: Hard search call budget (advertised in the prompt).
@@ -555,6 +559,8 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
                 correctness = 0.0
 
             # 2. Citations (recall → the UNGATED retrieval_hit; precision gated).
+            # retrieval_hit is an answer-side proxy: gold sources cited in the
+            # final <answer>, NOT what the search tool actually returned.
             recall, precision = self._score_citations(answer, reference_chunks)
             # 3. Deterministic brevity: shorter (still-correct) answers score higher.
             length_score = clip01(1.0 - len(answer) / ANSWER_LENGTH_CAP)

--- a/src/benchmax/envs/postgres_search/search_env.py
+++ b/src/benchmax/envs/postgres_search/search_env.py
@@ -1,11 +1,18 @@
 """SearchEnv — multi-component reward search environment for RL training.
 
-Provides 5 reward components:
-1. **answer_correctness** — LLM judge scores factual accuracy (0, 0.5, 1.0)
-2. **conciseness** — LLM judge scores brevity (gated on correctness)
-3. **citation_recall** — fraction of reference sources cited (gated on correctness)
-4. **citation_precision** — fraction of cited sources that are relevant (gated on correctness)
-5. **search_efficiency** — shaped bonus based on search count vs. gold chunk count
+The default reward is the AUDITED 4-component shape (one LLM judge call, the rest
+deterministic):
+1. **answer_correctness** — LLM judge scores factual accuracy (the GATE)
+2. **retrieval_hit** — fraction of gold sources cited (UNGATED: finding gold is
+   rewarded even on a wrong answer, so the model keeps learning to search)
+3. **citation_precision** — fraction of cited sources that are gold (gated on
+   correctness)
+4. **answer_length** — deterministic brevity term (gated on correctness; replaces
+   the LLM conciseness judge)
+
+The old components stay available as opt-in helpers (:data:`CONCISENESS_RUBRIC`,
+:func:`judge_answer_quality`, :func:`score_search_efficiency`) for subclasses that
+override ``compute_reward``.
 """
 
 from __future__ import annotations
@@ -22,7 +29,6 @@ from benchmax.envs.base_env import BaseEnv
 from benchmax.envs.example_id import make_example
 from benchmax.envs.reward_helpers import (
     clip01,
-    count_search_calls,
     extract_completion_text,
     search_within_budget,
 )
@@ -107,6 +113,8 @@ CORRECTNESS_RUBRIC = Rubric(
     },
 )
 
+# Opt-in rubric — NOT part of the default reward (brevity is the deterministic
+# answer_length term). Pass it to `judge_answer_quality` from a custom reward.
 CONCISENESS_RUBRIC = Rubric(
     title="Answer conciseness",
     description=(
@@ -119,6 +127,11 @@ CONCISENESS_RUBRIC = Rubric(
 MAX_TOOL_OUTPUT_CHARS = 10000
 TOOL_OUTPUT_TRUNCATION_SUFFIX = "\n...[truncated due to character limit]"
 SEARCH_EFFICIENCY_DECAY_RATE = 0.2
+
+# Deterministic brevity cap: an answer at/above this many chars earns no length
+# bonus; shorter (still-correct) answers earn more. Dense signal on every correct
+# rollout, no second LLM call.
+ANSWER_LENGTH_CAP = 600
 
 
 # ----------------------------------------------------------------------------
@@ -143,10 +156,13 @@ async def judge_answer_quality(
 ) -> tuple[float, float]:
     """LLM judge → ``(correctness, conciseness)``, both in [0, 1].
 
-    Empty response → ``(0.0, 0.0)``. The two rubric calls run concurrently. This
-    is the heavy HTTP leg of the reward — a scaffold ``main.py`` calls it as a
-    one-liner and does the weighting/gating arithmetic itself. Pass custom
-    rubrics to change what "correct"/"concise" mean.
+    Opt-in helper — NOT called by the default reward, which makes ONE
+    ``evaluate_single_rubric`` call (correctness only) and scores brevity
+    deterministically. Use this from a custom ``compute_reward`` when you want
+    a judged conciseness component too.
+
+    Empty response → ``(0.0, 0.0)``. The two rubric calls run concurrently.
+    Pass custom rubrics to change what "correct"/"concise" mean.
     """
     if not response.strip():
         return (0.0, 0.0)
@@ -183,12 +199,25 @@ async def judge_answer_quality(
 
 
 def canonicalize_source_id(source_id: str) -> str:
-    """Normalize a citation/source id (default: whitespace-strip → exact match).
+    """Normalize a citation/source id by whitespace-strip → exact match.
 
-    Pass a custom callable to :func:`score_citations` for corpus-specific,
-    robust matching (id-hash / title / path). The default is exact-path *by
-    design* — the design-environment skill covers when to override it."""
+    This is the strict matcher and the default for the free citation helpers
+    (:func:`parse_citations` / :func:`extract_reference_ids` /
+    :func:`score_citations`). :class:`SearchEnv` itself defaults to the loose
+    :func:`canonicalize_source_id_loose`; pass ``canonicalize=`` (or override
+    ``_canonicalize_id``) to choose per corpus."""
     return str(source_id or "").strip()
+
+
+def canonicalize_source_id_loose(source_id: str) -> str:
+    """Match citations by id-hash OR title-path: lowercase, drop any directory
+    prefix and file extension, so ``docs/Geography.md``, ``geography.md`` and a
+    bare ``geography`` canonicalize alike (dup-heavy Notion/GitLab exports).
+    Apply symmetrically to the cited id and the gold ``metadata.file``.
+
+    The :class:`SearchEnv` default canonicalizer."""
+    s = str(source_id or "").strip().lower().rsplit("/", 1)[-1]
+    return s.rsplit(".", 1)[0] if "." in s else s
 
 
 def parse_citations(
@@ -253,6 +282,10 @@ def score_search_efficiency(
 ) -> float:
     """Bonus for a CORRECT answer that doesn't over-search past ~``ref_chunks + 2``.
 
+    Opt-in helper — NOT part of the default reward (a "fewer searches" bonus can
+    fight multi-hop exploration; the hard ``max_search_calls`` cap covers safety).
+    Call it from a custom ``compute_reward`` to re-enable search shaping.
+
     ``0`` when the answer is incorrect (``correctness <= 0``) or the run is over
     the hard ``max_search_calls`` budget. ``correctness`` is the raw judge score
     (it both gates and scales)."""
@@ -267,9 +300,15 @@ def score_search_efficiency(
 
 
 class SearchEnv(BaseEnv):
-    """Backend-agnostic search environment with multi-component rewards.
+    """Backend-agnostic search environment with the audited 4-component reward.
 
-    Requires an LLM judge for correctness and conciseness scoring.
+    ``answer_correctness`` (one LLM judge call) is the GATE: every component
+    EXCEPT ``retrieval_hit`` is × correctness, so brevity/precision can't be
+    earned on a wrong answer. ``retrieval_hit`` is UNGATED — citing a gold
+    source is rewarded even when the answer is wrong. ``answer_length`` is a
+    deterministic brevity term (no second judge call).
+
+    Requires an LLM judge for correctness scoring.
 
     Args:
         search: A :class:`SearchClient` instance (pickle-safe).
@@ -278,13 +317,16 @@ class SearchEnv(BaseEnv):
         judge_token_provider: Optional; resolves the judge bearer per call.
             Defaults to ``platform_bearer`` (the credential seam).
         judge_timeout: Timeout for judge API calls.
-        w_correctness: Weight for correctness reward component.
-        w_conciseness: Weight for conciseness reward component.
-        w_citation_recall: Weight for citation recall component.
-        w_citation_precision: Weight for citation precision component.
-        w_search_efficiency: Weight for search efficiency reward component.
-        max_search_calls: Hard search call budget (0 reward if exceeded).
+        w_correctness: Weight for the correctness component (the gate).
+        w_retrieval_hit: Weight for the UNGATED gold-source recall component.
+        w_citation_precision: Weight for citation precision (gated).
+        w_length: Weight for the deterministic brevity component (gated).
+        max_search_calls: Hard search call budget (advertised in the prompt).
     """
+
+    # The gate component — `castform validate --reward-audit` judges the
+    # secondary components for redundancy against this key.
+    PRIMARY_REWARD_KEY = "answer_correctness"
 
     SYSTEM_PROMPT_TEMPLATE = """\
 Answer the given question by searching over {corpus_description}.
@@ -342,13 +384,25 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         judge_token_provider: str | TokenProvider | None = None,
         judge_timeout: float = 30.0,
         w_correctness: float = 1.0,
-        w_conciseness: float = 0.5,
-        w_citation_recall: float = 0.5,
-        w_citation_precision: float = 0.5,
-        w_search_efficiency: float = 0.1,
+        w_retrieval_hit: float = 0.3,
+        w_citation_precision: float = 0.3,
+        w_length: float = 0.2,
         max_search_calls: int = 10,
         **kwargs: Any,
     ) -> None:
+        # Fail loudly on the pre-audit weight kwargs (**kwargs would otherwise
+        # swallow them silently and the caller's weights would be no-ops).
+        removed = {"w_conciseness", "w_citation_recall", "w_search_efficiency"} & set(
+            kwargs
+        )
+        if removed:
+            raise TypeError(
+                f"SearchEnv no longer accepts {sorted(removed)}; the default reward "
+                "is the audited 4-component shape (answer_correctness / "
+                "retrieval_hit / citation_precision / answer_length). Use "
+                "w_retrieval_hit / w_length, or override compute_reward with the "
+                "opt-in helpers (judge_answer_quality, score_search_efficiency)."
+            )
         if not judge_base_url or not judge_model:
             raise ValueError(
                 "SearchEnv requires judge_base_url and judge_model; both must be "
@@ -367,10 +421,9 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         )
         self._judge_timeout = judge_timeout
         self._w_correctness = w_correctness
-        self._w_conciseness = w_conciseness
-        self._w_citation_recall = w_citation_recall
+        self._w_retrieval_hit = w_retrieval_hit
         self._w_citation_precision = w_citation_precision
-        self._w_search_efficiency = w_search_efficiency
+        self._w_length = w_length
         self._max_search_calls = max_search_calls
 
         # Determine default search mode.
@@ -455,19 +508,25 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         task: dict[str, Any] | None,
         **kwargs: Any,
     ) -> dict[str, float]:
-        """Compute 5-component reward."""
+        """The audited 4-component reward.
+
+        ``answer_correctness`` (from the judge rubric) is the GATE: every
+        component EXCEPT ``retrieval_hit`` is × correctness, so brevity/precision
+        can't be earned on a wrong answer. ``retrieval_hit`` is UNGATED — citing
+        a gold source is rewarded even when the answer is wrong.
+        """
         zeros = self._zero_rewards()
         try:
-            text = extract_completion_text(messages)
-            if not text.strip():
+            # Strict extraction: no committed <answer> → "" → scores 0 (the
+            # model's reasoning is never scored as the answer).
+            answer = _extract_answer_block(extract_completion_text(messages))
+            if not answer.strip():
                 return zeros
 
             t = task or {}
-            answer = _extract_answer_block(text)
             prompt = str(t.get("question") or t.get("prompt") or "")
             gt_str = str(t.get("ground_truth") or "")
             reference_chunks = t.get("reference_chunks", [])
-            reference_chunk_count = len(reference_chunks)
 
             logger.info(
                 "[SearchEnv] Q: %s\n  GT: %s\n  A: %s",
@@ -476,46 +535,46 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
                 answer[:200],
             )
 
-            # 1. Correctness + Conciseness (concurrent judge calls)
-            correctness_raw, conciseness_raw = await self._judge_answer_quality(
-                question=prompt,
-                ground_truth=gt_str,
-                response=answer,
-            )
+            # 1. Correctness judge — ONE rubric call. A judge failure means "not
+            # verified correct" (0) and must NOT zero the ungated retrieval
+            # signal below, so it's caught locally.
+            try:
+                result = await evaluate_single_rubric(
+                    rubric=CORRECTNESS_RUBRIC,
+                    question=prompt,
+                    ground_truth=gt_str,
+                    response=answer,
+                    model_name=self._judge_model,
+                    base_url=self._judge_base_url,
+                    api_key=self._judge_token_provider(),
+                    timeout=self._judge_timeout,
+                )
+                correctness = clip01(result.get("score", 0.0))
+            except Exception:
+                logger.warning("[SearchEnv] correctness judge failed; scoring 0")
+                correctness = 0.0
 
-            # Gate every secondary bonus on correctness (0 / 0.5 / 1.0): a wrong
-            # or missing answer earns no citation/brevity reward, and a partial
-            # answer earns only partial bonuses — so brevity/citations can't
-            # trade off against being right. (search_efficiency already scales
-            # this way.)
-            correctness = clip01(correctness_raw)
+            # 2. Citations (recall → the UNGATED retrieval_hit; precision gated).
+            recall, precision = self._score_citations(answer, reference_chunks)
+            # 3. Deterministic brevity: shorter (still-correct) answers score higher.
+            length_score = clip01(1.0 - len(answer) / ANSWER_LENGTH_CAP)
+
             rewards: dict[str, float] = {
                 "answer_correctness": self._w_correctness * correctness,
-                "conciseness": self._w_conciseness
-                * clip01(conciseness_raw)
+                "retrieval_hit": self._w_retrieval_hit * recall,  # UNGATED
+                "citation_precision": self._w_citation_precision
+                * precision
                 * correctness,
+                "answer_length": self._w_length * length_score * correctness,
             }
-
-            # 2. Citation recall / precision (gated on correctness)
-            recall, precision = self._score_citations(answer, reference_chunks)
-            rewards["citation_recall"] = self._w_citation_recall * recall * correctness
-            rewards["citation_precision"] = (
-                self._w_citation_precision * precision * correctness
-            )
-
-            # 3. Search efficiency (shaped by search count vs. gold chunk baseline)
-            calls = count_search_calls(messages)
-            rewards["search_efficiency"] = self._score_search_efficiency(
-                calls=calls,
-                correctness_raw=correctness_raw,
-                reference_chunk_count=reference_chunk_count,
-            )
 
             logger.info("[SearchEnv] rewards=%s", rewards)
             return rewards
 
-        except (KeyError, ValueError, TypeError, AttributeError) as exc:
-            logger.exception("[SearchEnv] compute_reward failed: %s", exc)
+        except Exception:
+            # A reward bug must not crash the rollout — score 0, but LOG it: a
+            # silent all-zero reward is the hardest reward bug to diagnose.
+            logger.exception("[SearchEnv] compute_reward failed")
             return zeros
 
     # ------------------------------------------------------------------
@@ -597,7 +656,10 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         response: str,
     ) -> tuple[float, float]:
         """Evaluate correctness + conciseness — delegates to the free
-        :func:`judge_answer_quality` helper with this env's judge config."""
+        :func:`judge_answer_quality` helper with this env's judge config.
+
+        Opt-in: the default reward makes ONE correctness rubric call instead;
+        call this from a custom ``compute_reward`` for a judged conciseness."""
         return await judge_answer_quality(
             question=question,
             ground_truth=ground_truth,
@@ -611,23 +673,6 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
     # ------------------------------------------------------------------
     # Citation scoring
     # ------------------------------------------------------------------
-
-    def _score_search_efficiency(
-        self,
-        *,
-        calls: int,
-        correctness_raw: float,
-        reference_chunk_count: int,
-    ) -> float:
-        """Reward correct answers that don't search past the gold-chunk baseline —
-        delegates to the free :func:`score_search_efficiency` helper."""
-        return score_search_efficiency(
-            calls=calls,
-            correctness=correctness_raw,
-            reference_chunk_count=reference_chunk_count,
-            max_search_calls=self._max_search_calls,
-            weight=self._w_search_efficiency,
-        )
 
     def _score_citations(
         self,
@@ -654,8 +699,11 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         return parse_citations(text, canonicalize=self._canonicalize_id)
 
     def _canonicalize_id(self, source_id: str) -> str:
-        """Normalize a source ID. Override for corpus-specific rules."""
-        return canonicalize_source_id(source_id)
+        """Normalize a source ID (default: the loose id-hash OR title-path
+        matcher, :func:`canonicalize_source_id_loose`). Override for
+        corpus-specific rules — e.g. return :func:`canonicalize_source_id`
+        for strict exact-path matching."""
+        return canonicalize_source_id_loose(source_id)
 
     # ------------------------------------------------------------------
     # Helpers
@@ -664,8 +712,7 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
     def _zero_rewards(self) -> dict[str, float]:
         return {
             "answer_correctness": 0.0,
-            "conciseness": 0.0,
-            "citation_recall": 0.0,
+            "retrieval_hit": 0.0,
             "citation_precision": 0.0,
-            "search_efficiency": 0.0,
+            "answer_length": 0.0,
         }

--- a/tests/unit/envs/postgres_search/test_search_env.py
+++ b/tests/unit/envs/postgres_search/test_search_env.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import math
 import pickle
 from unittest.mock import AsyncMock, patch
 
@@ -116,9 +115,23 @@ class TestInit:
         env = _make_env()
         assert env._max_search_calls == 10
 
-    def test_w_search_efficiency_defaults_to_point_one(self):
+    def test_default_weights_are_the_audited_shape(self):
         env = _make_env()
-        assert env._w_search_efficiency == pytest.approx(0.1)
+        assert env._w_correctness == pytest.approx(1.0)
+        assert env._w_retrieval_hit == pytest.approx(0.3)
+        assert env._w_citation_precision == pytest.approx(0.3)
+        assert env._w_length == pytest.approx(0.2)
+
+    def test_removed_weight_kwargs_fail_loudly(self):
+        # The pre-audit weights are GONE, not aliased. **kwargs would swallow
+        # them silently (caller's weights become no-ops), so __init__ rejects
+        # them explicitly.
+        for kwarg in ("w_conciseness", "w_citation_recall", "w_search_efficiency"):
+            with pytest.raises(TypeError, match="no longer accepts"):
+                _make_env(**{kwarg: 0.5})
+
+    def test_primary_reward_key_is_answer_correctness(self):
+        assert SearchEnv.PRIMARY_REWARD_KEY == "answer_correctness"
 
     def test_subclass_can_set_plain_system_prompt(self):
         class CustomEnv(SearchEnv):
@@ -233,7 +246,7 @@ class TestComputeReward:
     )
     def test_all_components_returned(self, mock_eval):
         mock_eval.return_value = {"score": 0.8}
-        env = _make_env(w_correctness=1.0, w_conciseness=0.5)
+        env = _make_env()
         result = asyncio.run(
             env.compute_reward(
                 "r1",
@@ -247,11 +260,14 @@ class TestComputeReward:
                 },
             )
         )
-        assert "answer_correctness" in result
-        assert "conciseness" in result
-        assert "citation_recall" in result
-        assert "citation_precision" in result
-        assert "search_efficiency" in result
+        # Exactly the audited 4-component shape — no conciseness/recall/
+        # search_efficiency keys in the default reward.
+        assert set(result) == {
+            "answer_correctness",
+            "retrieval_hit",
+            "citation_precision",
+            "answer_length",
+        }
 
     @patch(
         "benchmax.envs.postgres_search.search_env.evaluate_single_rubric",
@@ -273,8 +289,8 @@ class TestComputeReward:
         "benchmax.envs.postgres_search.search_env.evaluate_single_rubric",
         new_callable=AsyncMock,
     )
-    def test_conciseness_gated_on_correctness(self, mock_eval):
-        # Correctness=0, conciseness should also be 0
+    def test_answer_length_gated_on_correctness(self, mock_eval):
+        # Correctness=0 → the brevity term is 0 (short-but-wrong earns nothing).
         mock_eval.return_value = {"score": 0.0}
         env = _make_env()
         result = asyncio.run(
@@ -284,7 +300,54 @@ class TestComputeReward:
                 {"question": "Q?", "ground_truth": "right"},
             )
         )
-        assert result["conciseness"] == 0.0
+        assert result["answer_length"] == 0.0
+
+    @patch(
+        "benchmax.envs.postgres_search.search_env.evaluate_single_rubric",
+        new_callable=AsyncMock,
+    )
+    def test_answer_length_is_deterministic_brevity(self, mock_eval):
+        # Correct + short → w_length * (1 - len/ANSWER_LENGTH_CAP); correct +
+        # over the cap → clamps to 0. No second judge call is ever made.
+        mock_eval.return_value = {"score": 1.0}
+        env = _make_env(w_length=1.0)
+        short = "42"
+        result = asyncio.run(
+            env.compute_reward(
+                "r1",
+                _msgs(f"<answer>{short}</answer>"),
+                {"question": "Q?", "ground_truth": "42"},
+            )
+        )
+        assert result["answer_length"] == pytest.approx(1.0 - len(short) / 600)
+        assert mock_eval.await_count == 1  # ONE judge call (correctness only)
+
+        long = "x" * 700  # >= ANSWER_LENGTH_CAP
+        result = asyncio.run(
+            env.compute_reward(
+                "r1",
+                _msgs(f"<answer>{long}</answer>"),
+                {"question": "Q?", "ground_truth": "42"},
+            )
+        )
+        assert result["answer_length"] == 0.0
+
+    @patch(
+        "benchmax.envs.postgres_search.search_env.evaluate_single_rubric",
+        new_callable=AsyncMock,
+    )
+    def test_no_answer_tag_short_circuits_before_judge(self, mock_eval):
+        # Strict extraction: no committed <answer> → zeros, judge never called.
+        env = _make_env()
+        result = asyncio.run(
+            env.compute_reward(
+                "r1",
+                _msgs("I think it's 42 but I never commit an answer tag"),
+                {"question": "Q?", "ground_truth": "42"},
+            )
+        )
+        assert all(v == 0.0 for v in result.values())
+        mock_eval.assert_not_awaited()
 
     @patch(
         "benchmax.envs.postgres_search.search_env.evaluate_single_rubric",
@@ -292,7 +355,7 @@ class TestComputeReward:
     )
     def test_citation_exact_match(self, mock_eval):
         mock_eval.return_value = {"score": 1.0}
-        env = _make_env(w_citation_recall=1.0, w_citation_precision=1.0)
+        env = _make_env(w_retrieval_hit=1.0, w_citation_precision=1.0)
         result = asyncio.run(
             env.compute_reward(
                 "r1",
@@ -309,7 +372,32 @@ class TestComputeReward:
                 },
             )
         )
-        assert result["citation_recall"] == pytest.approx(1.0)
+        assert result["retrieval_hit"] == pytest.approx(1.0)
+        assert result["citation_precision"] == pytest.approx(1.0)
+
+    @patch(
+        "benchmax.envs.postgres_search.search_env.evaluate_single_rubric",
+        new_callable=AsyncMock,
+    )
+    def test_citation_matches_title_path_variant_by_default(self, mock_eval):
+        # The default canonicalizer is LOOSE (id-hash OR title-path): a cited
+        # 'docs/Statute_A.md' matches a bare 'statute_a' gold file id.
+        mock_eval.return_value = {"score": 1.0}
+        env = _make_env(w_retrieval_hit=1.0, w_citation_precision=1.0)
+        result = asyncio.run(
+            env.compute_reward(
+                "r1",
+                _msgs("<answer>Found it [Source: docs/Statute_A.md]</answer>"),
+                {
+                    "question": "Q?",
+                    "ground_truth": "answer",
+                    "reference_chunks": [
+                        {"content": "...", "metadata": {"file": "statute_a"}},
+                    ],
+                },
+            )
+        )
+        assert result["retrieval_hit"] == pytest.approx(1.0)
         assert result["citation_precision"] == pytest.approx(1.0)
 
     @patch(
@@ -318,7 +406,7 @@ class TestComputeReward:
     )
     def test_citation_partial_recall(self, mock_eval):
         mock_eval.return_value = {"score": 1.0}
-        env = _make_env(w_citation_recall=1.0, w_citation_precision=1.0)
+        env = _make_env(w_retrieval_hit=1.0, w_citation_precision=1.0)
         result = asyncio.run(
             env.compute_reward(
                 "r1",
@@ -333,28 +421,28 @@ class TestComputeReward:
                 },
             )
         )
-        assert result["citation_recall"] == pytest.approx(0.5)
+        assert result["retrieval_hit"] == pytest.approx(0.5)
         assert result["citation_precision"] == pytest.approx(1.0)
 
     @patch(
         "benchmax.envs.postgres_search.search_env.evaluate_single_rubric",
         new_callable=AsyncMock,
     )
-    def test_secondary_rewards_scaled_by_partial_correctness(self, mock_eval):
-        # correctness=conciseness=0.5 (same judge mock). Every secondary bonus
-        # multiplies by correctness, so a half-right answer earns half its
-        # citation/brevity reward — they can't trade off against being right.
+    def test_gated_rewards_scaled_by_partial_correctness(self, mock_eval):
+        # correctness=0.5. The GATED components (precision, length) scale by
+        # correctness; retrieval_hit does NOT (it's ungated by design).
         mock_eval.return_value = {"score": 0.5}
         env = _make_env(
             w_correctness=1.0,
-            w_conciseness=0.5,
-            w_citation_recall=1.0,
+            w_retrieval_hit=1.0,
             w_citation_precision=1.0,
+            w_length=1.0,
         )
+        answer = "partial [Source: doc_a]"
         result = asyncio.run(
             env.compute_reward(
                 "r1",
-                _msgs("<answer>partial [Source: doc_a]</answer>"),
+                _msgs(f"<answer>{answer}</answer>"),
                 {
                     "question": "Q?",
                     "ground_truth": "full",
@@ -365,18 +453,19 @@ class TestComputeReward:
             )
         )
         assert result["answer_correctness"] == pytest.approx(0.5)  # not gated
-        assert result["conciseness"] == pytest.approx(0.125)  # 0.5 * 0.5 * 0.5
-        assert result["citation_recall"] == pytest.approx(0.5)  # 1.0 * 1.0 * 0.5
+        assert result["retrieval_hit"] == pytest.approx(1.0)  # UNGATED: full recall
         assert result["citation_precision"] == pytest.approx(0.5)  # 1.0 * 1.0 * 0.5
+        assert result["answer_length"] == pytest.approx((1.0 - len(answer) / 600) * 0.5)
 
     @patch(
         "benchmax.envs.postgres_search.search_env.evaluate_single_rubric",
         new_callable=AsyncMock,
     )
-    def test_citations_zeroed_when_answer_wrong(self, mock_eval):
-        # correctness=0 → perfect citations still earn 0 (gated on correctness).
+    def test_retrieval_hit_survives_wrong_answer(self, mock_eval):
+        # The core audit fix: correctness=0 → the GATED precision is zeroed, but
+        # the UNGATED retrieval_hit still credits citing the gold source.
         mock_eval.return_value = {"score": 0.0}
-        env = _make_env(w_citation_recall=1.0, w_citation_precision=1.0)
+        env = _make_env(w_retrieval_hit=1.0, w_citation_precision=1.0)
         result = asyncio.run(
             env.compute_reward(
                 "r1",
@@ -390,111 +479,34 @@ class TestComputeReward:
                 },
             )
         )
-        assert result["citation_recall"] == 0.0
-        assert result["citation_precision"] == 0.0
+        assert result["answer_correctness"] == 0.0
+        assert result["retrieval_hit"] == pytest.approx(1.0)  # UNGATED
+        assert result["citation_precision"] == 0.0  # gated → 0
 
     @patch(
         "benchmax.envs.postgres_search.search_env.evaluate_single_rubric",
         new_callable=AsyncMock,
     )
-    def test_search_efficiency_within_chunk_baseline(self, mock_eval):
-        mock_eval.return_value = {"score": 1.0}
-        env = _make_env(max_search_calls=3)
-        # Baseline is len(reference_chunks) + 2 = 3, so full reward at 2 calls.
-        messages = [
-            {"role": "assistant", "content": "<tool_call>search1</tool_call>"},
-            {"role": "assistant", "content": "<tool_call>search2</tool_call>"},
-            {"role": "assistant", "content": "<answer>answer</answer>"},
-        ]
+    def test_judge_failure_scores_zero_but_keeps_retrieval_hit(self, mock_eval):
+        # A judge exception is caught LOCALLY: correctness scores 0, but the
+        # ungated retrieval signal (and the rest of the reward) still computes.
+        mock_eval.side_effect = RuntimeError("judge down")
+        env = _make_env(w_retrieval_hit=1.0)
         result = asyncio.run(
             env.compute_reward(
                 "r1",
-                messages,
+                _msgs("<answer>42 [Source: doc_a]</answer>"),
                 {
                     "question": "Q?",
-                    "ground_truth": "answer",
+                    "ground_truth": "42",
                     "reference_chunks": [
                         {"content": "...", "metadata": {"file": "doc_a"}}
                     ],
                 },
             )
         )
-        assert result["search_efficiency"] == 0.1
-
-    @patch(
-        "benchmax.envs.postgres_search.search_env.evaluate_single_rubric",
-        new_callable=AsyncMock,
-    )
-    def test_search_efficiency_over_budget(self, mock_eval):
-        mock_eval.return_value = {"score": 1.0}
-        env = _make_env(max_search_calls=2)
-        # 3 tool calls — over budget
-        messages = [
-            {"role": "assistant", "content": "<tool_call>s1</tool_call>"},
-            {"role": "assistant", "content": "<tool_call>s2</tool_call>"},
-            {
-                "role": "assistant",
-                "content": "<tool_call>s3</tool_call> <answer>a</answer>",
-            },
-        ]
-        result = asyncio.run(
-            env.compute_reward(
-                "r1",
-                messages,
-                {"question": "Q?", "ground_truth": "a"},
-            )
-        )
-        assert result["search_efficiency"] == 0.0
-
-    @patch(
-        "benchmax.envs.postgres_search.search_env.evaluate_single_rubric",
-        new_callable=AsyncMock,
-    )
-    def test_search_efficiency_decays_past_baseline(self, mock_eval):
-        mock_eval.return_value = {"score": 1.0}
-        env = _make_env(max_search_calls=10)
-        messages = [
-            {"role": "assistant", "content": "<tool_call>search1</tool_call>"},
-            {"role": "assistant", "content": "<tool_call>search2</tool_call>"},
-            {"role": "assistant", "content": "<tool_call>search3</tool_call>"},
-            {"role": "assistant", "content": "<tool_call>search4</tool_call>"},
-            {"role": "assistant", "content": "<tool_call>search5</tool_call>"},
-            {"role": "assistant", "content": "<answer>answer</answer>"},
-        ]
-        result = asyncio.run(
-            env.compute_reward(
-                "r1",
-                messages,
-                {
-                    "question": "Q?",
-                    "ground_truth": "answer",
-                    "reference_chunks": [
-                        {"content": "...", "metadata": {"file": "doc_a"}}
-                    ],
-                },
-            )
-        )
-        assert result["search_efficiency"] == pytest.approx(0.1 * math.exp(-0.4))
-
-    @patch(
-        "benchmax.envs.postgres_search.search_env.evaluate_single_rubric",
-        new_callable=AsyncMock,
-    )
-    def test_search_efficiency_uses_weight_and_correctness_scale(self, mock_eval):
-        mock_eval.return_value = {"score": 0.5}
-        env = _make_env(max_search_calls=10, w_search_efficiency=0.25)
-        messages = [
-            {"role": "assistant", "content": "<tool_call>search1</tool_call>"},
-            {"role": "assistant", "content": "<answer>answer</answer>"},
-        ]
-        result = asyncio.run(
-            env.compute_reward(
-                "r1",
-                messages,
-                {"question": "Q?", "ground_truth": "answer"},
-            )
-        )
-        assert result["search_efficiency"] == pytest.approx(0.125)
+        assert result["answer_correctness"] == 0.0
+        assert result["retrieval_hit"] == pytest.approx(1.0)  # not zeroed
 
     def test_empty_completion_returns_zeros(self):
         env = _make_env()
@@ -527,6 +539,22 @@ class TestCitationScoring:
     def test_canonicalize_id_strips_whitespace(self):
         env = _make_env()
         assert env._canonicalize_id("  doc_a  ") == "doc_a"
+
+    def test_default_canonicalizer_is_loose(self):
+        # SearchEnv now defaults to id-hash OR title-path matching.
+        env = _make_env()
+        assert env._canonicalize_id("docs/Geography.md") == "geography"
+        assert env._canonicalize_id("Geography.md") == "geography"
+        assert env._canonicalize_id("geography") == "geography"
+
+    def test_score_citations_matches_title_path_to_bare_id(self):
+        env = _make_env()
+        recall, precision = env._score_citations(
+            "answer [Source: docs/Geography.md]",
+            [{"content": "...", "metadata": {"file": "geography"}}],
+        )
+        assert recall == pytest.approx(1.0)
+        assert precision == pytest.approx(1.0)
 
     def test_email_style_thread_ids_work_via_metadata_file(self):
         env = _make_env()
@@ -647,7 +675,9 @@ class TestPickle:
 # --- free reward helpers (imported by a scaffold main.py) --------------------
 
 from benchmax.envs.postgres_search.search_env import (  # noqa: E402
+    ANSWER_LENGTH_CAP,
     canonicalize_source_id,
+    canonicalize_source_id_loose,
     extract_answer_block,
     extract_reference_ids,
     judge_answer_quality,
@@ -688,6 +718,23 @@ class TestFreeRewardHelpers:
         assert parse_citations("x [Source: p ] y") == {"p"}
         assert extract_reference_ids([{"metadata": {"file_path": " q "}}]) == {"q"}
         assert canonicalize_source_id("  z  ") == "z"
+
+    def test_canonicalize_source_id_loose(self):
+        # id-hash OR title-path: lowercase, strip dir prefix + extension.
+        assert canonicalize_source_id_loose("docs/Geography.md") == "geography"
+        assert canonicalize_source_id_loose("Geography.md") == "geography"
+        assert canonicalize_source_id_loose("geography") == "geography"
+        assert canonicalize_source_id_loose("  AbC123  ") == "abc123"
+        assert canonicalize_source_id_loose("a/b/Notes.2024.txt") == "notes.2024"
+        assert canonicalize_source_id_loose("") == ""
+
+    def test_canonicalize_source_id_stays_exact(self):
+        # The strict matcher is still exported and still exact-path.
+        assert canonicalize_source_id("docs/Geography.md") == "docs/Geography.md"
+        # ...and remains the default for the free citation helpers.
+        assert score_citations(
+            "[Source: docs/Geography.md]", [{"metadata": {"file": "geography"}}]
+        ) == (0.0, 0.0)
 
     def test_score_search_efficiency_gates_and_decays(self):
         # incorrect → 0; within baseline → full weight; over budget → 0
@@ -749,3 +796,44 @@ class TestFreeRewardHelpers:
             )
         )
         assert (c, con) == (0.0, 0.0)
+
+
+# --- seed <-> lib sync guard --------------------------------------------------
+
+
+class TestSeedLibSync:
+    """The RAG seed spells the reward out inline (pedagogy); its semantics must
+    stay IDENTICAL to the lib default it mirrors."""
+
+    @pytest.fixture
+    def rag_mod(self):
+        from pathlib import Path
+
+        import benchmax.cli.scaffold as scaffold_pkg
+        from benchmax.cli._project import _load_module_from_file
+
+        return _load_module_from_file(
+            Path(scaffold_pkg.__file__).parent / "rag_main.py"
+        )
+
+    def test_reward_keys_match_lib_default(self, rag_mod):
+        env = _make_env()
+        assert set(rag_mod.REWARD_KEYS) == set(env._zero_rewards())
+
+    def test_weights_and_length_cap_match_lib_defaults(self, rag_mod):
+        env = _make_env()
+        assert rag_mod.W_CORRECTNESS == env._w_correctness
+        assert rag_mod.W_RETRIEVAL_HIT == env._w_retrieval_hit
+        assert rag_mod.W_CITATION_PRECISION == env._w_citation_precision
+        assert rag_mod.W_LENGTH == env._w_length
+        # The seed imports the lib constant, so the caps can't drift.
+        assert rag_mod.ANSWER_LENGTH_CAP == ANSWER_LENGTH_CAP == 600
+
+    def test_seed_primary_reward_key_matches_lib(self, rag_mod):
+        from benchmax.cli._project import discover_env_class
+
+        assert (
+            discover_env_class(rag_mod).PRIMARY_REWARD_KEY
+            == SearchEnv.PRIMARY_REWARD_KEY
+            == "answer_correctness"
+        )


### PR DESCRIPTION
## What

Folds the audited reward shape — until now only in the RAG seed template — into the library default `SearchEnv.compute_reward`, so envs that don't override it inherit the good reward (backlog §1 of the main.py redesign).

New default (seed and lib are identical, enforced by a sync test):

| component | gating |
|---|---|
| `answer_correctness` (w 1.0) | the gate — ONE `CORRECTNESS_RUBRIC` judge call, locally try/excepted |
| `retrieval_hit` (w 0.3) | **UNGATED** — gold retrieval is credited even on a wrong answer |
| `citation_precision` (w 0.3) | × correctness |
| `answer_length` (w 0.2) | × correctness, deterministic (`clip01(1 − len/600)`) |

## ⚠ Wire-visible changes for existing SearchEnv users

- Component keys change: `citation_recall` → `retrieval_hit` (now ungated); `conciseness` and `search_efficiency` **removed from the default** (helpers stay public as opt-in).
- One judge call per rollout instead of two (conciseness judge dropped for the deterministic length term).
- Default citation canonicalizer is now the loose id-hash OR title-path matcher (`canonicalize_source_id_loose`) — the audit found exact-path matching broken on dup-heavy exports; strict `canonicalize_source_id` stays exported and the `canonicalize=`/`_canonicalize_id` seams are unchanged.
- Removed weight kwargs (`w_conciseness`, `w_citation_recall`, `w_search_efficiency`) raise an explicit `TypeError` rather than being silently swallowed.
- `SearchEnv.PRIMARY_REWARD_KEY = "answer_correctness"` declared for the validate reward-audit gate.

Only one SearchEnv subclass exists in-tree (the rag seed) and it overrides `compute_reward`, so blast radius is direct `SearchEnv(...)` instantiations + future subclasses.

## Tests

Targeted suites (search_env + rag scaffold + cli setup): **101 passed**. Full `tests/unit` failures verified identical on a pristine baseline (optional-dep collection errors + 2 stale traces tests fixed separately in #63).