### PR TITLE
fix(rubrics): retry judge auth failures with a fresh token; surface error keys

### DIFF
--- a/src/benchmax/envs/telestich/telestich_env.py
+++ b/src/benchmax/envs/telestich/telestich_env.py
@@ -999,18 +999,22 @@ then stop."""
             return await self._quality_elo(prompt, poems, anchors, band_edges)
 
         async def _score_batch(batch: list[str]) -> list[float]:
-            res = await evaluate_rubric_ranking(
-                rubric=QUALITY_RUBRIC,
-                question=prompt,
-                responses=batch,
-                model_name=JUDGE_MODEL,
-                base_url=self._judge_base_url,
-                timeout=self._judge_timeout,
-                anchors=anchors or None,
-                band_edges=band_edges or None,
-                anchor_labels=anchor_labels or None,
-            )
-            return res["scores"]
+            try:
+                res = await evaluate_rubric_ranking(
+                    rubric=QUALITY_RUBRIC,
+                    question=prompt,
+                    responses=batch,
+                    model_name=JUDGE_MODEL,
+                    base_url=self._judge_base_url,
+                    timeout=self._judge_timeout,
+                    anchors=anchors or None,
+                    band_edges=band_edges or None,
+                    anchor_labels=anchor_labels or None,
+                )
+                return res["scores"]
+            except Exception:
+                logger.exception("[TelestichEnv] quality batch failed; scoring 0s")
+                return [0.0] * len(batch)
 
         batches = [
             poems[i : i + JUDGE_BATCH] for i in range(0, len(poems), JUDGE_BATCH)

--- a/src/benchmax/rubrics/_utils.py
+++ b/src/benchmax/rubrics/_utils.py
@@ -1,8 +1,67 @@
+import asyncio
 import json
+import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar
 
 import json_repair
+from openai import AsyncOpenAI, AuthenticationError, PermissionDeniedError
+
+from benchmax.platform.credentials import resolve_judge_key
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# The OpenAI SDK treats 401/403 as terminal (max_retries does not cover them). A
+# judge bearer can expire mid-run, so on an auth error we rebuild the client —
+# which re-resolves the credential (a fresh platform_bearer, or a token_provider()
+# call) — and retry a few times. This is what turns a silent judge outage into a
+# recoverable blip instead of a run-wide score-0 collapse.
+_AUTH_ERRORS = (AuthenticationError, PermissionDeniedError)
+_MAX_AUTH_ATTEMPTS = 3  # 1 initial + 2 rebuild-and-retry
+_AUTH_BACKOFF_SECONDS = 0.5
+
+
+def _resolve_judge_credential(
+    api_key: str,
+    base_url: Optional[str],
+    token_provider: Optional[Callable[[], str]],
+) -> Optional[str]:
+    """token_provider wins over api_key and is re-invoked per attempt (so a
+    refreshed token is picked up); otherwise fall back to resolve_judge_key."""
+    if token_provider is not None:
+        return token_provider()
+    return resolve_judge_key(api_key, base_url)
+
+
+async def _judge_call_with_retry(
+    base_url: Optional[str],
+    api_key: str,
+    token_provider: Optional[Callable[[], str]],
+    call: Callable[[AsyncOpenAI], Awaitable[T]],
+) -> T:
+    """Run ``call(client)`` against a freshly built AsyncOpenAI, retrying auth
+    failures with a rebuilt (credential-re-resolved) client. The client is closed
+    after every attempt (the per-call construction previously leaked). Non-auth
+    exceptions propagate unchanged to the caller's own error handler."""
+    last_exc: Optional[Exception] = None
+    for attempt in range(_MAX_AUTH_ATTEMPTS):
+        client = AsyncOpenAI(
+            base_url=base_url,
+            api_key=_resolve_judge_credential(api_key, base_url, token_provider),
+            max_retries=3,
+        )
+        try:
+            return await call(client)
+        except _AUTH_ERRORS as e:
+            last_exc = e
+            if attempt + 1 < _MAX_AUTH_ATTEMPTS:
+                await asyncio.sleep(_AUTH_BACKOFF_SECONDS * (attempt + 1))
+        finally:
+            await client.close()
+    assert last_exc is not None
+    raise last_exc
 
 
 def _extract_json(s: str) -> dict:

--- a/src/benchmax/rubrics/adaptive.py
+++ b/src/benchmax/rubrics/adaptive.py
@@ -1,9 +1,10 @@
 import asyncio
-from typing import Dict, List, Literal, Optional, cast
+import logging
+from typing import Callable, Dict, List, Literal, Optional, cast
 
 from openai import AsyncOpenAI
 
-from ._utils import _extract_json
+from ._utils import _extract_json, _judge_call_with_retry
 from .cache import (
     _empty_cache_entry,
     _format_cached_rubrics_for_prompt,
@@ -11,9 +12,10 @@ from .cache import (
     load_rubric_cache,
 )
 from .prompts import INSTANCE_WISE_RUBRIC_GENERATION_PROMPT
-from benchmax.platform.credentials import resolve_judge_key
 
 from .rubric import _cache_dict_to_rubric, evaluate_single_rubric
+
+logger = logging.getLogger(__name__)
 
 
 async def generate_instance_wise_adaptive_rubrics(
@@ -25,6 +27,8 @@ async def generate_instance_wise_adaptive_rubrics(
     base_url: Optional[str] = None,
     api_key: str = "",
     timeout: Optional[float] = None,
+    *,
+    token_provider: Optional[Callable[[], str]] = None,
 ) -> Optional[dict]:
     """
     Generate instance-wise adaptive rubrics using OpenAI async client.
@@ -51,15 +55,9 @@ async def generate_instance_wise_adaptive_rubrics(
 
     prompt = INSTANCE_WISE_RUBRIC_GENERATION_PROMPT + prompt_suffix
 
-    # Explicit api_key wins; otherwise resolve the Castform platform credential
-    # seam (ACT_AS_TOKEN_PATH in training, PLATFORM_API_KEY in playground /
-    # self-serve) — the same surface the search clients use. Falls back to None
-    # (→ OPENAI_API_KEY) when no platform credential is present, for direct use.
-    client = AsyncOpenAI(
-        base_url=base_url, api_key=resolve_judge_key(api_key, base_url), max_retries=3
-    )
-
-    try:
+    # Client built per attempt inside _judge_call_with_retry (re-resolves the
+    # credential on an auth retry); see evaluate_single_rubric.
+    async def _call(client: AsyncOpenAI) -> Optional[dict]:
         response = await client.chat.completions.create(
             model=model_name,
             messages=[{"role": "user", "content": prompt}],
@@ -67,7 +65,9 @@ async def generate_instance_wise_adaptive_rubrics(
             timeout=timeout,
         )
 
-        content = response.choices[0].message.content.strip() if response.choices else ""
+        content = (
+            response.choices[0].message.content.strip() if response.choices else ""
+        )
         if not content:
             print("Empty response from model")
             return None
@@ -76,7 +76,14 @@ async def generate_instance_wise_adaptive_rubrics(
         print(f"Generated instance-wise adaptive rubrics: {obj}")
         return obj
 
+    try:
+        return await _judge_call_with_retry(base_url, api_key, token_provider, _call)
     except Exception as e:
+        logger.error(
+            "adaptive rubric generation failed after retries: %s: %s",
+            type(e).__name__,
+            e,
+        )
         print(f"Prompt: {prompt}")
         print(f"Error generating instance-wise adaptive rubrics: {e}")
         return None

--- a/src/benchmax/rubrics/rubric.py
+++ b/src/benchmax/rubrics/rubric.py
@@ -1,12 +1,10 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Callable, Dict, List, Literal, Optional
 
 from openai import AsyncOpenAI
 
-from benchmax.platform.credentials import resolve_judge_key
-
-from ._utils import _extract_json
+from ._utils import _extract_json, _judge_call_with_retry
 from .prompts import (
     RUBRIC_EVALUATION_PROMPT,
     RUBRIC_RANGED_EVALUATION_PROMPT,
@@ -40,6 +38,8 @@ async def evaluate_single_rubric(
     api_key: str = "",
     timeout: Optional[float] = None,
     enable_logging: bool = True,
+    *,
+    token_provider: Optional[Callable[[], str]] = None,
 ) -> Dict[str, Any]:
     """
     Evaluate a single response against a single rubric.
@@ -91,16 +91,15 @@ async def evaluate_single_rubric(
             response=response,
         )
 
-    # Explicit api_key wins; otherwise resolve the Castform platform credential
+    # The client is built inside _judge_call_with_retry, once per attempt, so its
+    # credential re-resolves on an auth retry. Explicit api_key (or token_provider)
+    # wins; otherwise resolve_judge_key resolves the Castform platform credential
     # seam (ACT_AS_TOKEN_PATH in training, PLATFORM_API_KEY in playground /
-    # self-serve) — the same surface the search clients use. Falls back to None
-    # (→ OPENAI_API_KEY) when no platform credential is present, for direct use.
-    client = AsyncOpenAI(
-        base_url=base_url, api_key=resolve_judge_key(api_key, base_url), max_retries=3
-    )
-
+    # self-serve), falling back to OPENAI_API_KEY for direct use.
     content = ""
-    try:
+
+    async def _call(client: AsyncOpenAI) -> Dict[str, Any]:
+        nonlocal content
         resp = await client.chat.completions.create(
             model=model_name,
             messages=[{"role": "user", "content": prompt}],
@@ -134,11 +133,27 @@ async def evaluate_single_rubric(
             )
         return out
 
+    try:
+        return await _judge_call_with_retry(base_url, api_key, token_provider, _call)
     except Exception as e:
+        # Loud: a judge failure must never masquerade as a low reward. The
+        # error/error_type keys let callers surface a _judge_error metric.
+        logger.error(
+            "rubric '%s' evaluation failed after retries: %s: %s",
+            rubric.title,
+            type(e).__name__,
+            e,
+        )
         print(
             f"Error evaluating rubric '{rubric.title}': {e}\njudge output:\n{content}"
         )
-        return {"score": 0, "reasoning": f"Error: {e}", "llm_output": content}
+        return {
+            "score": 0,
+            "reasoning": f"Error: {e}",
+            "llm_output": content,
+            "error": str(e),
+            "error_type": type(e).__name__,
+        }
 
 
 def _monotonic_seams(seams: List[tuple]) -> List[tuple]:
@@ -201,6 +216,7 @@ async def evaluate_rubric_ranking(
     anchors: Optional[List[str]] = None,
     band_edges: Optional[List[float]] = None,
     anchor_labels: Optional[List[str]] = None,
+    token_provider: Optional[Callable[[], str]] = None,
 ) -> Dict[str, Any]:
     """
     Rank N responses against a single rubric in one judge call and convert the
@@ -294,14 +310,12 @@ async def evaluate_rubric_ranking(
         n_minus_1=max_local,
     )
 
-    # Explicit api_key wins; otherwise resolve the Castform platform credential
-    # seam — see resolve_judge_key / evaluate_single_rubric.
-    client = AsyncOpenAI(
-        base_url=base_url, api_key=resolve_judge_key(api_key, base_url), max_retries=3
-    )
-
+    # Client built per attempt inside _judge_call_with_retry (re-resolves the
+    # credential on an auth retry); see evaluate_single_rubric.
     content = ""
-    try:
+
+    async def _call(client: AsyncOpenAI) -> Dict[str, Any]:
+        nonlocal content
         resp = await client.chat.completions.create(
             model=model_name,
             messages=[{"role": "user", "content": prompt}],
@@ -453,11 +467,22 @@ async def evaluate_rubric_ranking(
                 poems_fmt,
             )
         return out
+
+    try:
+        return await _judge_call_with_retry(base_url, api_key, token_provider, _call)
     except Exception as e:
+        logger.error(
+            "rubric ranking '%s' failed after retries: %s: %s",
+            rubric.title,
+            type(e).__name__,
+            e,
+        )
         print(f"Error ranking rubric '{rubric.title}': {e}\njudge output:\n{content}")
         return {
             "scores": scores,
             "ranking": [],
             "reasoning": f"Error: {e}",
             "llm_output": content,
+            "error": str(e),
+            "error_type": type(e).__name__,
         }

--- a/tests/integration/test_rubric_auth_retry.py
+++ b/tests/integration/test_rubric_auth_retry.py
@@ -1,0 +1,135 @@
+"""Judge auth-retry: the credential is re-resolved *inside* the retry loop.
+
+Marked `integration` because it drives the real ``openai`` SDK HTTP path end to
+end — a 401 has to surface as a genuine ``openai.AuthenticationError`` for the
+retry-with-reconstruction to trigger. Unlike the other integration tests it does
+NOT hit a live API: it stands up a local OpenAI-compatible stub server, the only
+way to script a deterministic ``401 -> fresh-token -> 200`` transition. No
+credentials required (the token is supplied via ``token_provider``).
+
+Run: uv run pytest tests/integration/test_rubric_auth_retry.py -v -m integration
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from benchmax.rubrics.rubric import Rubric, evaluate_single_rubric
+
+_VALID_TOKEN = "fresh-token"
+
+
+def _make_handler(state: dict):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_a):  # keep test output clean
+            pass
+
+        def do_POST(self):
+            auth = self.headers.get("Authorization", "")
+            state["requests"].append(auth)
+            self.rfile.read(int(self.headers.get("Content-Length", 0)))
+
+            if auth != f"Bearer {_VALID_TOKEN}":
+                self._respond(
+                    401,
+                    {
+                        "error": {
+                            "message": "invalid token",
+                            "type": "invalid_request_error",
+                            "code": "invalid_api_key",
+                        }
+                    },
+                )
+                return
+
+            content = json.dumps({"score": 1, "reasoning": "ok"})
+            self._respond(
+                200,
+                {
+                    "id": "chatcmpl-stub",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": "stub",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": content},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                },
+            )
+
+        def _respond(self, status: int, payload: dict):
+            body = json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    return Handler
+
+
+@pytest.fixture
+def stub_server():
+    state: dict = {"requests": []}
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _make_handler(state))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/v1", state
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def _rubric() -> Rubric:
+    return Rubric(title="T", description="D")
+
+
+@pytest.mark.integration
+async def test_auth_retry_refreshes_token_in_loop(stub_server):
+    base_url, state = stub_server
+    # Attempt 1 hands the server a stale token (401); the rebuilt client picks up
+    # a fresh token from token_provider and attempt 2 succeeds.
+    tokens = iter(["stale-token", _VALID_TOKEN])
+    result = await evaluate_single_rubric(
+        rubric=_rubric(),
+        question="q",
+        response="r",
+        model_name="stub",
+        base_url=base_url,
+        token_provider=lambda: next(tokens),
+    )
+    assert result["score"] == 1
+    assert "error" not in result  # success path carries no error keys
+    assert state["requests"] == ["Bearer stale-token", f"Bearer {_VALID_TOKEN}"]
+
+
+@pytest.mark.integration
+async def test_persistent_401_surfaces_error_keys(stub_server):
+    base_url, state = stub_server
+    result = await evaluate_single_rubric(
+        rubric=_rubric(),
+        question="q",
+        response="r",
+        model_name="stub",
+        base_url=base_url,
+        token_provider=lambda: "always-stale",
+    )
+    assert result["score"] == 0
+    assert result["error_type"] in ("AuthenticationError", "PermissionDeniedError")
+    assert "Error:" in result["reasoning"]
+    # 1 initial + 2 rebuild-and-retry attempts, all 401.
+    assert len(state["requests"]) == 3

--- a/tests/unit/rubrics/conftest.py
+++ b/tests/unit/rubrics/conftest.py
@@ -36,6 +36,8 @@ def _stub_client_factory(responses: List[str] | Callable[..., str]):
             return _mk_response(responses(kwargs))
 
         client.chat.completions.create = AsyncMock(side_effect=create)
+        # _judge_call_with_retry closes the client after every attempt.
+        client.close = AsyncMock()
         return client
 
     factory.calls = calls  # type: ignore[attr-defined]
@@ -48,8 +50,8 @@ def stub_openai(monkeypatch):
 
     def install(responses):
         factory = _stub_client_factory(responses)
-        monkeypatch.setattr("benchmax.rubrics.rubric.AsyncOpenAI", factory)
-        monkeypatch.setattr("benchmax.rubrics.adaptive.AsyncOpenAI", factory)
+        # Construction now lives in _utils._judge_call_with_retry, so patch there.
+        monkeypatch.setattr("benchmax.rubrics._utils.AsyncOpenAI", factory)
         # The judge clients resolve their bearer through resolve_judge_key ->
         # platform_bearer. With no platform env that raises by design; stub it
         # so these logic tests don't need credentials.

--- a/tests/unit/rubrics/test_rubric.py
+++ b/tests/unit/rubrics/test_rubric.py
@@ -84,6 +84,9 @@ async def test_evaluate_single_rubric_exception_returns_zero(stub_openai):
     )
     assert result["score"] == 0
     assert "network down" in result["reasoning"]
+    # Exception path carries error metadata so callers can flag a _judge_error.
+    assert result["error"] == "network down"
+    assert result["error_type"] == "RuntimeError"
 
 
 # ---------------------------------------------------------------------------
@@ -338,3 +341,5 @@ async def test_ranking_exception_returns_zero_scores(stub_openai):
     )
     assert out["scores"] == [0.0, 0.0]
     assert "Error:" in out["reasoning"]
+    assert out["error"] == "x"
+    assert out["error_type"] == "RuntimeError"


### PR DESCRIPTION
Fixes the judge-token 401 class from the fake-collapse incident (staging run a6ea5ba1, 2026-07-05): the rubric evaluators built the AsyncOpenAI client outside the try, never closed it, and swallowed every exception into a silent `{"score": 0}` — so an expired judge token (a 401 the SDK does not retry) scored every rollout 0 and looked like a policy collapse.

## Changes
- Shared `_judge_call_with_retry` helper (`rubrics/_utils.py`): rebuilds the client (re-resolving the credential) and retries on `AuthenticationError`/`PermissionDeniedError`, always closing it (the per-call client previously leaked).
- Keyword-only `token_provider` on both evaluators + `adaptive.py`: wins over `api_key`, re-invoked per attempt so a refreshed token is picked up in-loop.
- Exception path logs loudly (`logger.error`) and returns `error`/`error_type` keys (empty-input shapes stay error-free) so callers can flag a `_judge_error` metric.
- Guards the previously-unguarded telestich batch-ranker caller.

## Tests
88 pass: `tests/unit/rubrics` + `tests/unit/envs/telestich` + new `tests/integration/test_rubric_auth_retry.py` (local OpenAI-compatible stub scripting 401→fresh-token→200 and persistent-401→error-keys). Run rubric units with `CASTFORM_CREDENTIALS_PATH=/nonexistent uv run pytest tests/unit/rubrics`; the auth-retry test with `uv run pytest tests/integration/test_rubric_auth_retry.py -m integration`.

The integration test uses a local stub server (not a live API) — the only way to script a deterministic 401→200 transition; justified against the CLAUDE.md integration=real-API convention.

Plan: `docs/plans/judge-401-fix-plan.md` (slice S2). PR 1 of the fix; S3 (SearchEnv/scaffold emission + validate scorecard) follows after S1+S2 merge.