### PR TITLE
Add finish-rollout tool result

### DIFF
--- a/src/benchmax/envs/how-to-extend-base-env.md
+++ b/src/benchmax/envs/how-to-extend-base-env.md
@@ -85,3 +85,26 @@ class SimpleMathEnv(BaseEnv):
         return tool_fn(**tool_args)
 ```
 
+### 5. **End the rollout from a tool**
+
+Compare the current `tool_name` with the environment's terminal tools. Execute
+the tool first, then return `finish_rollout()` to end without another model
+turn:
+
+```python
+from benchmax.envs.types import finish_rollout
+
+
+class SubmissionEnv(BaseEnv):
+    terminal_tools = {"submit", "finalize"}
+
+    async def run_tool(self, rollout_id: str, tool_name: str, **tool_args) -> Any:
+        result = await self.tools[tool_name](**tool_args)
+        if tool_name in self.terminal_tools:
+            return finish_rollout()
+        return result
+```
+
+`finish_rollout()` stops dispatch immediately. The terminal tool's work has
+already completed, remaining calls are not dispatched, and buffered tool
+responses from that assistant turn are not added to the transcript.

--- a/src/benchmax/envs/types.py
+++ b/src/benchmax/envs/types.py
@@ -128,6 +128,16 @@ class Example(TypedDict):
 # ---------------------------------------------------------------------------
 
 
+class FinishRollout:
+    """Signal that the current tool call should end the rollout."""
+
+
+def finish_rollout() -> FinishRollout:
+    """Return from ``run_tool`` to end the rollout immediately."""
+
+    return FinishRollout()
+
+
 @dataclass
 class ToolDefinition:
     """Definition of a tool's interface"""

--- a/src/benchmax/platform/validation.py
+++ b/src/benchmax/platform/validation.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, Any
 
 import cloudpickle
 
+from benchmax.envs.types import FinishRollout
+
 if TYPE_CHECKING:
     from .client import ValidationResult
 
@@ -337,7 +339,12 @@ def _run_local_checks(
                             rollout_id="test", tool_name=tool.name, **dummy_args
                         )
                     )
-                    if isinstance(result, str):
+                    if isinstance(result, FinishRollout):
+                        print(
+                            f"  \u2713 run_tool finishes rollout (tested: {tool.name})"
+                        )
+                        passed += 1
+                    elif isinstance(result, str):
                         print(f"  \u2713 run_tool returns string (tested: {tool.name})")
                         passed += 1
                     else:
@@ -453,6 +460,7 @@ def _run_local_checks(
             # ── Call each tool twice (catch stateful bugs) ──────
             transcript: list[dict[str, Any]] = list(prompt_messages)
             tool_call_count = 0
+            finish_after_tool = False
             for tool in tools:
                 tool_args = _build_dummy_args(tool.input_schema, query_text)
                 for _ in range(2):
@@ -464,14 +472,20 @@ def _run_local_checks(
                         )
                     )
                     transcript.append({"role": "assistant", "content": "Calling tool."})
-                    transcript.append({"role": "tool", "content": str(result)[:500]})
                     tool_call_count += 1
+                    if isinstance(result, FinishRollout):
+                        finish_after_tool = True
+                        break
+                    transcript.append({"role": "tool", "content": str(result)[:500]})
+                if finish_after_tool:
+                    break
 
             # Final assistant message echoing ground truth if available.
-            gt = (task or {}).get("ground_truth")
-            transcript.append(
-                {"role": "assistant", "content": str(gt or "test answer")}
-            )
+            if not finish_after_tool:
+                gt = (task or {}).get("ground_truth")
+                transcript.append(
+                    {"role": "assistant", "content": str(gt or "test answer")}
+                )
 
             reward = _run_async(
                 env.compute_reward(


### PR DESCRIPTION
## Summary

- add a stateless `finish_rollout()` marker for `run_tool`
- keep existing raw tool-result returns backward compatible
- teach local environment validation to stop at the marker
- document a terminal-tool set implementation in the environment guide

## Customer example

```python
from benchmax.envs.types import finish_rollout

class SubmissionEnv(BaseEnv):
    terminal_tools = {"submit", "finalize"}

    async def run_tool(self, rollout_id, tool_name, **tool_args):
        result = await self.tools[tool_name](**tool_args)
        if tool_name in self.terminal_tools:
            return finish_rollout()
        return result
```

The comparison uses the singular `tool_name` passed to `run_tool`. The tool executes before the finish signal is returned.

## Semantics

Returning `finish_rollout()` ends the rollout immediately. Remaining tool calls from the same assistant response are not dispatched, no buffered tool responses are simulated, and no subsequent model turn is requested.

## Validation

- targeted Ruff checks
- Python syntax compilation
- marker pickle round-trip
- `git diff --check`