### PR TITLE
Add message content helpers (slice 1)

### DIFF
--- a/src/benchmax/envs/base/content.py
+++ b/src/benchmax/envs/base/content.py
@@ -23,6 +23,7 @@ _MIME_SIGNATURES: tuple[tuple[bytes, str], ...] = (
 )
 
 _IMAGE_PLACEHOLDER = "[image]"
+_ELLIPSIS = "…"
 
 
 def message_text(message: Mapping[str, Any]) -> str:
@@ -41,13 +42,27 @@ def message_text(message: Mapping[str, Any]) -> str:
 
     parts: list[str] = []
     for item in content:
-        if isinstance(item, dict):
-            text = item.get("text") or item.get("content")
-            if text:
-                parts.append(str(text))
-        elif item:
-            parts.append(str(item))
+        if not isinstance(item, dict):
+            continue
+        text = _text_bearing_value(item)
+        if text is not None:
+            parts.append(text)
     return "\n".join(parts)
+
+
+def _text_bearing_value(item: dict) -> str | None:
+    """Return the ``text``/``content`` string value of a part, or ``None``.
+
+    Only string values count — a non-string ``text``/``content`` (or neither
+    key present) means the part isn't text-bearing.
+    """
+    text = item.get("text")
+    if isinstance(text, str):
+        return text
+    content_value = item.get("content")
+    if isinstance(content_value, str):
+        return content_value
+    return None
 
 
 def _is_image_part(part: Any) -> bool:
@@ -67,14 +82,12 @@ def content_preview(content: Any, limit: int) -> str:
     try:
         preview = _render_preview(content)
     except Exception:
-        preview = repr(content)
+        preview = _safe_repr(content)
 
     preview = " ".join(preview.splitlines())
     if len(preview) <= limit:
         return preview
-    if limit <= 3:
-        return preview[:limit]
-    return preview[: limit - 3] + "..."
+    return preview[: limit - 1] + _ELLIPSIS
 
 
 def _render_preview(content: Any) -> str:
@@ -89,11 +102,18 @@ def _render_preview(content: Any) -> str:
                 values.append(_IMAGE_PLACEHOLDER)
             elif isinstance(item, dict):
                 text = item.get("text") or item.get("content")
-                values.append(str(text) if text else repr(item))
+                values.append(str(text) if text else _safe_repr(item))
             elif item:
                 values.append(str(item))
         return " ".join(values)
-    return repr(content)
+    return _safe_repr(content)
+
+
+def _safe_repr(value: Any) -> str:
+    try:
+        return repr(value)
+    except Exception:
+        return "<unrepresentable>"
 
 
 def iter_image_refs(messages: Messages) -> Iterator[str]:

--- a/src/benchmax/envs/base/content.py
+++ b/src/benchmax/envs/base/content.py
@@ -1,0 +1,148 @@
+"""Helpers for inspecting and rendering OpenAI-style message content.
+
+Content on a message can be a plain string or a list of typed parts (text,
+image references, etc.). These helpers give one shared surface for pulling
+text out, previewing arbitrary content for logs/UIs, walking image
+references, and turning raw image bytes into a data URI.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+from benchmax.envs.base.openai_types import Messages
+
+_MIME_SIGNATURES: tuple[tuple[bytes, str], ...] = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+)
+
+_IMAGE_PLACEHOLDER = "[image]"
+
+
+def message_text(message: Mapping[str, Any]) -> str:
+    """Extract the text content of a message.
+
+    Str content is returned unchanged. List content is the string values of
+    text-bearing parts (a dict with a ``text`` or ``content`` key), joined
+    with ``"\\n"`` in part order. Image and other non-text parts contribute
+    nothing. ``None``/missing content returns ``""``.
+    """
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, dict):
+            text = item.get("text") or item.get("content")
+            if text:
+                parts.append(str(text))
+        elif item:
+            parts.append(str(item))
+    return "\n".join(parts)
+
+
+def _is_image_part(part: Any) -> bool:
+    return isinstance(part, dict) and part.get("type") == "image_url"
+
+
+def content_preview(content: Any, limit: int) -> str:
+    """Render a single-line preview of raw message ``content``, at most `limit` chars.
+
+    Image parts render as an ``[image]`` placeholder. Never raises on
+    malformed content shapes — falls back to a truncated ``repr``. Does
+    raise ``ValueError`` if ``limit < 1``.
+    """
+    if limit < 1:
+        raise ValueError(f"limit must be >= 1, got {limit}")
+
+    try:
+        preview = _render_preview(content)
+    except Exception:
+        preview = repr(content)
+
+    preview = " ".join(preview.splitlines())
+    if len(preview) <= limit:
+        return preview
+    if limit <= 3:
+        return preview[:limit]
+    return preview[: limit - 3] + "..."
+
+
+def _render_preview(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if content is None:
+        return ""
+    if isinstance(content, list):
+        values: list[str] = []
+        for item in content:
+            if _is_image_part(item):
+                values.append(_IMAGE_PLACEHOLDER)
+            elif isinstance(item, dict):
+                text = item.get("text") or item.get("content")
+                values.append(str(text) if text else repr(item))
+            elif item:
+                values.append(str(item))
+        return " ".join(values)
+    return repr(content)
+
+
+def iter_image_refs(messages: Messages) -> Iterator[str]:
+    """Yield the ``image_url.url`` string of every image part, in transcript order.
+
+    Iterates messages in order, then parts within each message's content
+    list in order. Messages with str content contribute nothing. Malformed
+    image parts (missing keys, non-string url, etc.) are skipped.
+    """
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not _is_image_part(part):
+                continue
+            image_url = part.get("image_url")
+            if not isinstance(image_url, dict):
+                continue
+            url = image_url.get("url")
+            if isinstance(url, str):
+                yield url
+
+
+def image_to_data_uri(source: str | Path | bytes) -> str:
+    """Turn an image path/bytes into a ``data:`` URI, sniffing MIME from magic numbers.
+
+    Strings already starting with ``data:`` or ``https:`` pass through
+    untouched. Any other string is treated as a filesystem path. Supports
+    PNG, JPEG, GIF, and WEBP signatures; raises ``ValueError`` on
+    unrecognized bytes rather than guessing a MIME type.
+    """
+    if isinstance(source, str) and (source.startswith("data:") or source.startswith("https:")):
+        return source
+
+    data = Path(source).read_bytes() if isinstance(source, (str, Path)) else source
+
+    mime = _sniff_mime(data)
+    if mime is None:
+        raise ValueError("unrecognized image byte signature")
+
+    encoded = base64.b64encode(data).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
+
+
+def _sniff_mime(data: bytes) -> str | None:
+    if data[0:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    for signature, mime in _MIME_SIGNATURES:
+        if data.startswith(signature):
+            return mime
+    return None

--- a/tests/unit/envs/base/test_content.py
+++ b/tests/unit/envs/base/test_content.py
@@ -61,11 +61,23 @@ class TestMessageText:
         }
         assert message_text(message) == "look at this\nwhat is it"
 
+    def test_non_dict_part_skipped(self):
+        message = {"role": "user", "content": [42, {"text": "kept"}]}
+        assert message_text(message) == "kept"
+
+    def test_non_string_text_value_skipped(self):
+        message = {"role": "assistant", "content": [{"text": 42}, {"text": "kept"}]}
+        assert message_text(message) == "kept"
+
+    def test_empty_string_text_value_preserved(self):
+        message = {"role": "assistant", "content": [{"text": ""}, {"text": "kept"}]}
+        assert message_text(message) == "\nkept"
+
 
 class TestContentPreview:
     def test_normal_truncation(self):
         result = content_preview("a" * 50, 10)
-        assert result == "a" * 7 + "..."
+        assert result == "a" * 9 + "…"
         assert len(result) == 10
 
     def test_no_truncation_needed(self):
@@ -74,6 +86,19 @@ class TestContentPreview:
     def test_limit_of_one_accepted(self):
         result = content_preview("hello", 1)
         assert len(result) <= 1
+
+    def test_truncation_marker_present_for_limit_one(self):
+        assert content_preview("hello", 1) == "…"
+
+    def test_truncation_marker_present_for_limit_two(self):
+        result = content_preview("hello", 2)
+        assert result == "h…"
+        assert len(result) == 2
+
+    def test_truncation_marker_present_for_limit_three(self):
+        result = content_preview("hello", 3)
+        assert result == "he…"
+        assert len(result) == 3
 
     def test_limit_zero_raises(self):
         with pytest.raises(ValueError):
@@ -108,6 +133,15 @@ class TestContentPreview:
 
     def test_malformed_list_item_never_raises(self):
         result = content_preview([object(), {"unexpected": "shape"}], 50)
+        assert isinstance(result, str)
+        assert len(result) <= 50
+
+    def test_raising_repr_never_raises(self):
+        class Unrepresentable:
+            def __repr__(self):
+                raise RuntimeError("boom")
+
+        result = content_preview(Unrepresentable(), 50)
         assert isinstance(result, str)
         assert len(result) <= 50
 

--- a/tests/unit/envs/base/test_content.py
+++ b/tests/unit/envs/base/test_content.py
@@ -1,0 +1,200 @@
+"""Tests for message content helpers."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from benchmax.envs.base.content import (
+    content_preview,
+    image_to_data_uri,
+    iter_image_refs,
+    message_text,
+)
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+_JPEG_BYTES = b"\xff\xd8\xff" + b"\x00" * 16
+_GIF_BYTES = b"GIF89a" + b"\x00" * 16
+_WEBP_BYTES = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 16
+
+
+class TestMessageText:
+    def test_str_content(self):
+        assert message_text({"role": "user", "content": "hello"}) == "hello"
+
+    def test_part_list_preserves_order_across_key_styles(self):
+        message = {
+            "role": "assistant",
+            "content": [
+                {"text": "first"},
+                {"content": "second"},
+                {"text": "third"},
+            ],
+        }
+        assert message_text(message) == "first\nsecond\nthird"
+
+    def test_empty_content(self):
+        assert message_text({"role": "user", "content": ""}) == ""
+
+    def test_none_content(self):
+        assert message_text({"role": "user", "content": None}) == ""
+
+    def test_missing_content_key(self):
+        assert message_text({"role": "user"}) == ""
+
+    def test_image_only_content_is_empty(self):
+        message = {
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}],
+        }
+        assert message_text(message) == ""
+
+    def test_mixed_text_and_image_content(self):
+        message = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look at this"},
+                {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+                {"type": "text", "text": "what is it"},
+            ],
+        }
+        assert message_text(message) == "look at this\nwhat is it"
+
+
+class TestContentPreview:
+    def test_normal_truncation(self):
+        result = content_preview("a" * 50, 10)
+        assert result == "a" * 7 + "..."
+        assert len(result) == 10
+
+    def test_no_truncation_needed(self):
+        assert content_preview("short", 10) == "short"
+
+    def test_limit_of_one_accepted(self):
+        result = content_preview("hello", 1)
+        assert len(result) <= 1
+
+    def test_limit_zero_raises(self):
+        with pytest.raises(ValueError):
+            content_preview("hello", 0)
+
+    def test_limit_negative_raises(self):
+        with pytest.raises(ValueError):
+            content_preview("hello", -5)
+
+    def test_image_part_renders_placeholder(self):
+        content = [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}]
+        result = content_preview(content, 50)
+        assert "[image]" in result
+
+    def test_single_line_with_embedded_newlines(self):
+        result = content_preview("line one\nline two\nline three", 100)
+        assert "\n" not in result
+
+    def test_single_line_truncated_still_has_no_newline(self):
+        result = content_preview("line one\nline two\nline three", 10)
+        assert "\n" not in result
+        assert len(result) <= 10
+
+    def test_malformed_content_never_raises(self):
+        class Weird:
+            def __repr__(self):
+                return "<Weird object>"
+
+        result = content_preview(Weird(), 50)
+        assert isinstance(result, str)
+        assert len(result) <= 50
+
+    def test_malformed_list_item_never_raises(self):
+        result = content_preview([object(), {"unexpected": "shape"}], 50)
+        assert isinstance(result, str)
+        assert len(result) <= 50
+
+    def test_none_content(self):
+        assert content_preview(None, 10) == ""
+
+
+class TestIterImageRefs:
+    def test_multiple_messages_multiple_images_order_preserved(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "img1"}},
+                    {"type": "text", "text": "hi"},
+                    {"type": "image_url", "image_url": {"url": "img2"}},
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": "text only, no images",
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "img3"}},
+                ],
+            },
+        ]
+        assert list(iter_image_refs(messages)) == ["img1", "img2", "img3"]
+
+    def test_str_content_message_contributes_nothing(self):
+        messages = [{"role": "user", "content": "just text"}]
+        assert list(iter_image_refs(messages)) == []
+
+    def test_malformed_image_url_parts_skipped(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url"},  # missing image_url dict
+                    {"type": "image_url", "image_url": {}},  # missing url
+                    {"type": "image_url", "image_url": {"url": 123}},  # non-str url
+                    {"type": "image_url", "image_url": "not-a-dict"},
+                    {"type": "image_url", "image_url": {"url": "good"}},
+                ],
+            }
+        ]
+        assert list(iter_image_refs(messages)) == ["good"]
+
+    def test_no_messages(self):
+        assert list(iter_image_refs([])) == []
+
+
+class TestImageToDataUri:
+    def test_real_path(self, tmp_path):
+        path = tmp_path / "tiny.png"
+        path.write_bytes(_PNG_BYTES)
+        result = image_to_data_uri(path)
+        assert result.startswith("data:image/png;base64,")
+        encoded = result.split(",", 1)[1]
+        assert base64.b64decode(encoded) == _PNG_BYTES
+
+    def test_bytes_input_directly(self):
+        result = image_to_data_uri(_PNG_BYTES)
+        assert result.startswith("data:image/png;base64,")
+
+    def test_png_signature(self):
+        assert image_to_data_uri(_PNG_BYTES).startswith("data:image/png;base64,")
+
+    def test_jpeg_signature(self):
+        assert image_to_data_uri(_JPEG_BYTES).startswith("data:image/jpeg;base64,")
+
+    def test_gif_signature(self):
+        assert image_to_data_uri(_GIF_BYTES).startswith("data:image/gif;base64,")
+
+    def test_webp_signature(self):
+        assert image_to_data_uri(_WEBP_BYTES).startswith("data:image/webp;base64,")
+
+    def test_data_uri_passthrough(self):
+        source = "data:image/png;base64,abc123"
+        assert image_to_data_uri(source) == source
+
+    def test_https_passthrough(self):
+        source = "https://example.com/image.png"
+        assert image_to_data_uri(source) == source
+
+    def test_unrecognized_bytes_raises(self):
+        with pytest.raises(ValueError):
+            image_to_data_uri(b"not an image")


### PR DESCRIPTION
## Summary
- Slice 1 of docs/plans/sft-multimodal-interface.md (Revision 4): `src/benchmax/envs/base/content.py` with `message_text`, `content_preview`, `iter_image_refs`, `image_to_data_uri`.
- Stacked on #70 (sft-slice0-baseline), not on main.

## Test plan
- [x] `uv run pytest tests/unit/envs/base/test_content.py -v` (31 passed)
- [x] `uv run pytest tests/unit` (1143 passed, 3 skipped)
- [x] `uv run ruff check src/` clean on new file (3 pre-existing errors elsewhere, unrelated, present on base branch too)