### PR TITLE
Add benchmax/sft package: dataset boundary, schema, validation

### DIFF
--- a/src/benchmax/sft/__init__.py
+++ b/src/benchmax/sft/__init__.py
@@ -1,0 +1,17 @@
+"""The SFT dataset boundary: load, canonicalize, and validate OpenAI-format
+fine-tuning rows (``{"messages": [...]}``, with optional ``tools`` and
+per-assistant-message ``weight``). :func:`load_sft_dataset` is the only
+JSONL reader for SFT data; validation and upload both consume its output.
+"""
+
+from __future__ import annotations
+
+from benchmax.sft.dataset import SftDataset, load_sft_dataset
+from benchmax.sft.validate import SftValidationReport, validate_sft_dataset
+
+__all__ = [
+    "load_sft_dataset",
+    "validate_sft_dataset",
+    "SftDataset",
+    "SftValidationReport",
+]

--- a/src/benchmax/sft/dataset.py
+++ b/src/benchmax/sft/dataset.py
@@ -108,13 +108,21 @@ def load_sft_dataset(path: str | Path) -> SftDataset:
     return SftDataset(path=source_path, rows=rows, load_issues=load_issues)
 
 
-def canonical_jsonl(dataset: SftDataset) -> bytes:
-    """Render ``dataset``'s rows as canonical JSONL bytes — the only shape the upload path accepts.
+def canonical_row_bytes(row_data: dict[str, Any]) -> bytes:
+    """The exact bytes ``canonical_jsonl`` produces for one row.
 
-    ``allow_nan=False`` so a non-finite value that somehow reaches this
-    point (load-time already rejects it) raises loudly instead of emitting
-    a ``NaN``/``Infinity`` token that isn't valid JSON.
+    Shared with :func:`benchmax.sft.schema.validate_row` and
+    :func:`benchmax.sft.validate.validate_sft_dataset` so "is this row
+    serializable" is answered by the same code path that actually
+    canonicalizes it — ``ensure_ascii=True`` (json.dumps' default) never
+    attempts the UTF-8 encode step, so a schema check that only called
+    ``json.dumps`` could pass a row containing a lone surrogate that then
+    raises ``UnicodeEncodeError`` here. ``allow_nan=False`` rejects
+    ``NaN``/``Infinity`` tokens that aren't valid JSON.
     """
-    return "".join(
-        json.dumps(row.data, ensure_ascii=False, allow_nan=False) + "\n" for row in dataset.rows
-    ).encode("utf-8")
+    return json.dumps(row_data, ensure_ascii=False, allow_nan=False).encode("utf-8")
+
+
+def canonical_jsonl(dataset: SftDataset) -> bytes:
+    """Render ``dataset``'s rows as canonical JSONL bytes — the only shape the upload path accepts."""
+    return b"".join(canonical_row_bytes(row.data) + b"\n" for row in dataset.rows)

--- a/src/benchmax/sft/dataset.py
+++ b/src/benchmax/sft/dataset.py
@@ -1,0 +1,100 @@
+"""The SFT dataset canonicalization boundary.
+
+:func:`load_sft_dataset` is the only JSONL reader for SFT data — it reads
+raw lines itself (not ``cli/_project.py``'s ``_load_jsonl``, which drops
+blank lines, reindexes, and raises before any report could exist), retains
+per-row ``(source_path, physical_line)`` provenance, and normalizes every
+row on load so callers never see a legacy shape.
+:func:`canonical_jsonl` is the only serializer for the upload path — no path
+exists where un-normalized rows reach storage.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from benchmax.sft.normalize import normalize_row
+
+Severity = Literal["error", "notice"]
+
+
+@dataclass(frozen=True)
+class SftIssue:
+    """A single dataset-loading or validation issue.
+
+    ``physical_line`` is 1-indexed and counts blank lines, matching the
+    on-disk file exactly. ``physical_line == 0`` marks a dataset-level
+    issue with no single source line (e.g. an empty dataset).
+    """
+
+    source_path: str
+    physical_line: int
+    severity: Severity
+    message: str
+
+
+@dataclass(frozen=True)
+class SftRow:
+    """One canonicalized dataset row plus its on-disk provenance."""
+
+    source_path: str
+    physical_line: int
+    data: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class SftDataset:
+    """A loaded, canonicalized SFT dataset: rows plus per-line load issues."""
+
+    path: str
+    rows: list[SftRow]
+    load_issues: list[SftIssue]
+
+
+def load_sft_dataset(path: str | Path) -> SftDataset:
+    """Read raw JSONL at ``path``, normalize every row, and retain provenance.
+
+    Blank lines are skipped but still counted toward ``physical_line``. A
+    line that isn't valid JSON, or whose top-level value isn't a JSON
+    object, becomes an error :class:`SftIssue` instead of raising —
+    :func:`benchmax.sft.validate.validate_sft_dataset` is where a malformed
+    dataset surfaces to the caller.
+    """
+    file_path = Path(path)
+    source_path = str(file_path)
+    rows: list[SftRow] = []
+    load_issues: list[SftIssue] = []
+
+    text = file_path.read_text(encoding="utf-8")
+    for physical_line, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError as exc:
+            load_issues.append(SftIssue(source_path, physical_line, "error", f"invalid JSON: {exc}"))
+            continue
+        if not isinstance(parsed, dict):
+            load_issues.append(
+                SftIssue(
+                    source_path,
+                    physical_line,
+                    "error",
+                    f"row must be a JSON object, got {type(parsed).__name__}",
+                )
+            )
+            continue
+        rows.append(SftRow(source_path, physical_line, normalize_row(parsed)))
+
+    return SftDataset(path=source_path, rows=rows, load_issues=load_issues)
+
+
+def canonical_jsonl(dataset: SftDataset) -> bytes:
+    """Render ``dataset``'s rows as canonical JSONL bytes — the only shape the upload path accepts."""
+    return "".join(
+        json.dumps(row.data, ensure_ascii=False) + "\n" for row in dataset.rows
+    ).encode("utf-8")

--- a/src/benchmax/sft/dataset.py
+++ b/src/benchmax/sft/dataset.py
@@ -12,6 +12,7 @@ exists where un-normalized rows reach storage.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -19,6 +20,12 @@ from typing import Any, Literal
 from benchmax.sft.normalize import normalize_row
 
 Severity = Literal["error", "notice"]
+
+# str.splitlines() also breaks on U+2028/U+2029 (and other unicode line
+# separators), which are legal unescaped inside a JSON string value and can
+# round-trip straight through canonical_jsonl's ensure_ascii=False. Split
+# strictly on the actual on-disk line terminators instead.
+_LINE_BOUNDARY = re.compile(r"\r\n|\n")
 
 
 @dataclass(frozen=True)
@@ -54,12 +61,20 @@ class SftDataset:
     load_issues: list[SftIssue]
 
 
+def _reject_non_finite(constant: str) -> Any:
+    # json.loads accepts the non-standard NaN/Infinity/-Infinity tokens by
+    # default (not valid JSON per RFC 8259); treat them as a decode failure
+    # instead of silently admitting a value canonical_jsonl can't round-trip.
+    raise ValueError(f"non-finite JSON constant {constant!r} is not allowed")
+
+
 def load_sft_dataset(path: str | Path) -> SftDataset:
     """Read raw JSONL at ``path``, normalize every row, and retain provenance.
 
     Blank lines are skipped but still counted toward ``physical_line``. A
-    line that isn't valid JSON, or whose top-level value isn't a JSON
-    object, becomes an error :class:`SftIssue` instead of raising —
+    line that isn't valid JSON, whose top-level value isn't a JSON object,
+    or that contains a ``NaN``/``Infinity``/``-Infinity`` constant becomes
+    an error :class:`SftIssue` instead of raising —
     :func:`benchmax.sft.validate.validate_sft_dataset` is where a malformed
     dataset surfaces to the caller.
     """
@@ -69,13 +84,13 @@ def load_sft_dataset(path: str | Path) -> SftDataset:
     load_issues: list[SftIssue] = []
 
     text = file_path.read_text(encoding="utf-8")
-    for physical_line, raw_line in enumerate(text.splitlines(), start=1):
+    for physical_line, raw_line in enumerate(_LINE_BOUNDARY.split(text), start=1):
         line = raw_line.strip()
         if not line:
             continue
         try:
-            parsed = json.loads(line)
-        except json.JSONDecodeError as exc:
+            parsed = json.loads(line, parse_constant=_reject_non_finite)
+        except ValueError as exc:
             load_issues.append(SftIssue(source_path, physical_line, "error", f"invalid JSON: {exc}"))
             continue
         if not isinstance(parsed, dict):
@@ -94,7 +109,12 @@ def load_sft_dataset(path: str | Path) -> SftDataset:
 
 
 def canonical_jsonl(dataset: SftDataset) -> bytes:
-    """Render ``dataset``'s rows as canonical JSONL bytes — the only shape the upload path accepts."""
+    """Render ``dataset``'s rows as canonical JSONL bytes — the only shape the upload path accepts.
+
+    ``allow_nan=False`` so a non-finite value that somehow reaches this
+    point (load-time already rejects it) raises loudly instead of emitting
+    a ``NaN``/``Infinity`` token that isn't valid JSON.
+    """
     return "".join(
-        json.dumps(row.data, ensure_ascii=False) + "\n" for row in dataset.rows
+        json.dumps(row.data, ensure_ascii=False, allow_nan=False) + "\n" for row in dataset.rows
     ).encode("utf-8")

--- a/src/benchmax/sft/normalize.py
+++ b/src/benchmax/sft/normalize.py
@@ -6,6 +6,14 @@ Invoked only by :func:`benchmax.sft.dataset.load_sft_dataset` — callers
 never see a raw row. Never raises: a row that matches no recognized legacy
 shape passes through unchanged for :func:`benchmax.sft.schema.validate_row`
 to reject with a clear message.
+
+Copy-on-write: only the specific legacy keys actually consumed into
+``messages`` (``prompt_messages``/``prompt``/``completion_messages``/
+``completion``) are removed. Every other top-level field — recognized or
+not — survives to the canonical row, and every field on a tool-call/
+function dict beyond the ones being reshaped survives too, so an
+unsupported field becomes an explicit schema issue rather than silent
+data loss.
 """
 
 from __future__ import annotations
@@ -20,45 +28,47 @@ def normalize_row(row: dict[str, Any]) -> dict[str, Any]:
     Recognizes an already-canonical ``messages`` row, the
     ``prompt_messages``/``completion_messages`` split, a bare ``prompt``
     and/or ``completion`` string, and flat (un-nested) tool-call entries —
-    combinable in any mix. ``tools`` and per-message ``weight``/content
-    parts are preserved verbatim; only legacy shapes are rewritten.
+    combinable in any mix. ``tools``, per-message ``weight``/content parts,
+    and any other field are preserved verbatim; only legacy shapes are
+    rewritten.
     """
-    canonical: dict[str, Any] = {}
-    messages = _extract_messages(row)
-    if messages is not None:
-        canonical["messages"] = (
-            [_normalize_message(m) for m in messages] if isinstance(messages, list) else messages
-        )
-    if "tools" in row:
-        canonical["tools"] = row["tools"]
+    if "messages" in row:
+        canonical = dict(row)
+        messages = canonical["messages"]
+        if isinstance(messages, list):
+            canonical["messages"] = [_normalize_message(m) for m in messages]
+        return canonical
+
+    consumed_keys: set[str] = set()
+    prompt_part = _extract_prompt_part(row, consumed_keys)
+    completion_part = _extract_completion_part(row, consumed_keys)
+    if prompt_part is None and completion_part is None:
+        return dict(row)
+
+    canonical = {k: v for k, v in row.items() if k not in consumed_keys}
+    messages = (prompt_part or []) + (completion_part or [])
+    canonical["messages"] = [_normalize_message(m) for m in messages]
     return canonical
 
 
-def _extract_messages(row: dict[str, Any]) -> Any:
-    if "messages" in row:
-        return row["messages"]
-
-    prompt_part = _extract_prompt_part(row)
-    completion_part = _extract_completion_part(row)
-    if prompt_part is None and completion_part is None:
-        return None
-    return (prompt_part or []) + (completion_part or [])
-
-
-def _extract_prompt_part(row: dict[str, Any]) -> list[Any] | None:
+def _extract_prompt_part(row: dict[str, Any], consumed_keys: set[str]) -> list[Any] | None:
     if "prompt_messages" in row:
+        consumed_keys.add("prompt_messages")
         value = row["prompt_messages"]
         return value if isinstance(value, list) else [value]
     if "prompt" in row and isinstance(row["prompt"], str):
+        consumed_keys.add("prompt")
         return [{"role": "user", "content": row["prompt"]}]
     return None
 
 
-def _extract_completion_part(row: dict[str, Any]) -> list[Any] | None:
+def _extract_completion_part(row: dict[str, Any], consumed_keys: set[str]) -> list[Any] | None:
     if "completion_messages" in row:
+        consumed_keys.add("completion_messages")
         value = row["completion_messages"]
         return value if isinstance(value, list) else [value]
     if "completion" in row and isinstance(row["completion"], str):
+        consumed_keys.add("completion")
         return [{"role": "assistant", "content": row["completion"]}]
     return None
 
@@ -76,25 +86,28 @@ def _normalize_message(message: Any) -> Any:
 def _normalize_tool_call(tool_call: Any) -> Any:
     if not isinstance(tool_call, dict):
         return tool_call
+
     function = tool_call.get("function")
     if isinstance(function, dict):
-        return {
-            "id": tool_call.get("id", ""),
-            "type": tool_call.get("type", "function"),
-            "function": {
-                "name": function.get("name", ""),
-                "arguments": _stringify_arguments(function.get("arguments", "{}")),
-            },
-        }
+        # Already nested — copy every field on both dicts, only touching
+        # `arguments` so id/type/extra keys on either level survive intact.
+        normalized = dict(tool_call)
+        normalized_function = dict(function)
+        normalized_function["arguments"] = _stringify_arguments(function.get("arguments", "{}"))
+        normalized["function"] = normalized_function
+        return normalized
+
     if "name" in tool_call:
-        return {
-            "id": tool_call.get("id", ""),
-            "type": "function",
-            "function": {
-                "name": tool_call["name"],
-                "arguments": _stringify_arguments(tool_call.get("arguments", "{}")),
-            },
+        # Flat shape: name/arguments live directly on the tool-call dict —
+        # lift them into `function`, keep every other field as-is.
+        normalized = {k: v for k, v in tool_call.items() if k not in {"name", "arguments"}}
+        normalized.setdefault("type", "function")
+        normalized["function"] = {
+            "name": tool_call["name"],
+            "arguments": _stringify_arguments(tool_call.get("arguments", "{}")),
         }
+        return normalized
+
     return tool_call
 
 

--- a/src/benchmax/sft/normalize.py
+++ b/src/benchmax/sft/normalize.py
@@ -1,0 +1,108 @@
+"""Legacy SFT row shapes -> the canonical ``{"messages": [...], "tools"?: [...]}`` shape.
+
+Self-contained (no shared normalizer with ``traces/adapter.py``, which is
+lossy for multimodal content and is rewritten by harbor-proper's merge).
+Invoked only by :func:`benchmax.sft.dataset.load_sft_dataset` — callers
+never see a raw row. Never raises: a row that matches no recognized legacy
+shape passes through unchanged for :func:`benchmax.sft.schema.validate_row`
+to reject with a clear message.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def normalize_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Normalize one parsed JSON row into the canonical SFT row shape.
+
+    Recognizes an already-canonical ``messages`` row, the
+    ``prompt_messages``/``completion_messages`` split, a bare ``prompt``
+    and/or ``completion`` string, and flat (un-nested) tool-call entries —
+    combinable in any mix. ``tools`` and per-message ``weight``/content
+    parts are preserved verbatim; only legacy shapes are rewritten.
+    """
+    canonical: dict[str, Any] = {}
+    messages = _extract_messages(row)
+    if messages is not None:
+        canonical["messages"] = (
+            [_normalize_message(m) for m in messages] if isinstance(messages, list) else messages
+        )
+    if "tools" in row:
+        canonical["tools"] = row["tools"]
+    return canonical
+
+
+def _extract_messages(row: dict[str, Any]) -> Any:
+    if "messages" in row:
+        return row["messages"]
+
+    prompt_part = _extract_prompt_part(row)
+    completion_part = _extract_completion_part(row)
+    if prompt_part is None and completion_part is None:
+        return None
+    return (prompt_part or []) + (completion_part or [])
+
+
+def _extract_prompt_part(row: dict[str, Any]) -> list[Any] | None:
+    if "prompt_messages" in row:
+        value = row["prompt_messages"]
+        return value if isinstance(value, list) else [value]
+    if "prompt" in row and isinstance(row["prompt"], str):
+        return [{"role": "user", "content": row["prompt"]}]
+    return None
+
+
+def _extract_completion_part(row: dict[str, Any]) -> list[Any] | None:
+    if "completion_messages" in row:
+        value = row["completion_messages"]
+        return value if isinstance(value, list) else [value]
+    if "completion" in row and isinstance(row["completion"], str):
+        return [{"role": "assistant", "content": row["completion"]}]
+    return None
+
+
+def _normalize_message(message: Any) -> Any:
+    if not isinstance(message, dict):
+        return message
+    normalized = dict(message)
+    tool_calls = normalized.get("tool_calls")
+    if isinstance(tool_calls, list):
+        normalized["tool_calls"] = [_normalize_tool_call(tc) for tc in tool_calls]
+    return normalized
+
+
+def _normalize_tool_call(tool_call: Any) -> Any:
+    if not isinstance(tool_call, dict):
+        return tool_call
+    function = tool_call.get("function")
+    if isinstance(function, dict):
+        return {
+            "id": tool_call.get("id", ""),
+            "type": tool_call.get("type", "function"),
+            "function": {
+                "name": function.get("name", ""),
+                "arguments": _stringify_arguments(function.get("arguments", "{}")),
+            },
+        }
+    if "name" in tool_call:
+        return {
+            "id": tool_call.get("id", ""),
+            "type": "function",
+            "function": {
+                "name": tool_call["name"],
+                "arguments": _stringify_arguments(tool_call.get("arguments", "{}")),
+            },
+        }
+    return tool_call
+
+
+def _stringify_arguments(arguments: Any) -> Any:
+    """OpenAI tool-call ``arguments`` is a JSON-encoded string; coerce a dict, pass a string through."""
+    if isinstance(arguments, str):
+        return arguments
+    try:
+        return json.dumps(arguments)
+    except TypeError:
+        return arguments

--- a/src/benchmax/sft/schema.py
+++ b/src/benchmax/sft/schema.py
@@ -1,0 +1,144 @@
+"""The SFT row contract: ``{"messages": [...]}`` plus optional ``tools`` and
+per-assistant-message ``weight``.
+
+:func:`validate_row` is pure structural validation — role shape, tool-call
+well-formedness, content-part well-formedness, at least one trained
+assistant turn, and JSON-serializability. It has no notion of on-disk
+provenance (that's :mod:`benchmax.sft.dataset`'s job) or severity tiers
+(that's :mod:`benchmax.sft.validate`'s) — it just returns a flat list of
+human-readable error messages, empty when the row is well-formed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+VALID_ROLES = frozenset({"system", "user", "assistant", "tool"})
+VALID_CONTENT_PART_TYPES = frozenset({"text", "image_url"})
+VALID_WEIGHTS = frozenset({0, 1})
+
+
+def validate_row(row: Any) -> list[str]:
+    """Structural errors in one canonical SFT row. Empty list means well-formed."""
+    if not isinstance(row, dict):
+        return [f"row must be a JSON object, got {type(row).__name__}"]
+
+    messages = row.get("messages")
+    if messages is None:
+        return ["'messages' is required"]
+    if not isinstance(messages, list) or not messages:
+        return ["'messages' must be a non-empty list"]
+
+    errors: list[str] = []
+    trained_assistant_turns = 0
+    for i, message in enumerate(messages):
+        if not isinstance(message, dict):
+            errors.append(f"messages[{i}] must be an object")
+            continue
+
+        role = message.get("role")
+        if role not in VALID_ROLES:
+            errors.append(
+                f"messages[{i}].role must be one of {sorted(VALID_ROLES)}, got {role!r}"
+            )
+        if role == "tool" and not isinstance(message.get("tool_call_id"), str):
+            errors.append(f"messages[{i}] (tool) must have a string 'tool_call_id'")
+
+        errors.extend(_validate_content(message.get("content"), i))
+
+        if role == "assistant":
+            weight = message.get("weight")
+            if "weight" in message and weight not in VALID_WEIGHTS:
+                errors.append(f"messages[{i}].weight must be 0 or 1, got {weight!r}")
+            elif weight != 0:
+                trained_assistant_turns += 1
+
+            tool_calls = message.get("tool_calls")
+            if tool_calls is not None:
+                errors.extend(_validate_tool_calls(tool_calls, i))
+
+    if trained_assistant_turns == 0:
+        errors.append(
+            "row has no trained assistant turn (all assistant messages have "
+            "weight=0, or none are present)"
+        )
+
+    tools = row.get("tools")
+    if tools is not None and not isinstance(tools, list):
+        errors.append("'tools' must be a list")
+
+    if not errors:
+        try:
+            json.dumps(row)
+        except (TypeError, ValueError) as exc:
+            errors.append(f"row is not JSON-serializable: {exc}")
+
+    return errors
+
+
+def _validate_content(content: Any, index: int) -> list[str]:
+    if content is None or isinstance(content, str):
+        return []
+    if not isinstance(content, list):
+        return [f"messages[{index}].content must be a string or a list of content parts"]
+
+    errors: list[str] = []
+    for j, part in enumerate(content):
+        if not isinstance(part, dict):
+            errors.append(f"messages[{index}].content[{j}] must be an object")
+            continue
+        part_type = part.get("type")
+        if part_type not in VALID_CONTENT_PART_TYPES:
+            errors.append(
+                f"messages[{index}].content[{j}].type must be one of "
+                f"{sorted(VALID_CONTENT_PART_TYPES)}, got {part_type!r}"
+            )
+            continue
+        if part_type == "text" and not isinstance(part.get("text"), str):
+            errors.append(f"messages[{index}].content[{j}] (text) must have a string 'text'")
+        elif part_type == "image_url":
+            image_url = part.get("image_url")
+            url = image_url.get("url") if isinstance(image_url, dict) else None
+            if not isinstance(url, str) or not (url.startswith("data:") or url.startswith("https:")):
+                errors.append(
+                    f"messages[{index}].content[{j}] (image_url) must have image_url.url "
+                    "starting with 'data:' or 'https:'"
+                )
+    return errors
+
+
+def _validate_tool_calls(tool_calls: Any, index: int) -> list[str]:
+    if not isinstance(tool_calls, list):
+        return [f"messages[{index}].tool_calls must be a list"]
+
+    errors: list[str] = []
+    for j, tc in enumerate(tool_calls):
+        if not isinstance(tc, dict):
+            errors.append(f"messages[{index}].tool_calls[{j}] must be an object")
+            continue
+        if tc.get("type") != "function":
+            errors.append(f"messages[{index}].tool_calls[{j}].type must be 'function'")
+        function = tc.get("function")
+        if not isinstance(function, dict):
+            errors.append(f"messages[{index}].tool_calls[{j}].function must be an object")
+            continue
+        name = function.get("name")
+        if not isinstance(name, str) or not name:
+            errors.append(
+                f"messages[{index}].tool_calls[{j}].function.name must be a non-empty string"
+            )
+        arguments = function.get("arguments")
+        if not isinstance(arguments, str):
+            errors.append(
+                f"messages[{index}].tool_calls[{j}].function.arguments must be a "
+                "JSON-encoded string"
+            )
+        else:
+            try:
+                json.loads(arguments)
+            except json.JSONDecodeError:
+                errors.append(
+                    f"messages[{index}].tool_calls[{j}].function.arguments must be valid JSON"
+                )
+    return errors

--- a/src/benchmax/sft/schema.py
+++ b/src/benchmax/sft/schema.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from benchmax.sft.dataset import canonical_row_bytes
+
 ALLOWED_TOP_LEVEL_KEYS = frozenset({"messages", "tools"})
 VALID_ROLES = frozenset({"system", "user", "assistant", "tool"})
 VALID_CONTENT_PART_TYPES = frozenset({"text", "image_url"})
@@ -58,8 +60,11 @@ def validate_row(row: Any) -> list[str]:
         errors.append("'tools' must be a list")
 
     try:
-        json.dumps(row, allow_nan=False)
+        canonical_row_bytes(row)
     except (TypeError, ValueError) as exc:
+        # UnicodeEncodeError (e.g. a lone surrogate) is a ValueError subclass,
+        # so this also catches a row that would only fail once canonical_jsonl
+        # actually UTF-8-encodes it.
         errors.append(f"row is not JSON-serializable: {exc}")
 
     return errors
@@ -129,8 +134,19 @@ def _has_meaningful_content(content: Any) -> bool:
     if isinstance(content, str):
         return content != ""
     if isinstance(content, list):
-        return len(content) > 0
+        return any(_part_has_meaningful_content(part) for part in content)
     return False
+
+
+def _part_has_meaningful_content(part: Any) -> bool:
+    if not isinstance(part, dict):
+        return False
+    if part.get("type") == "image_url":
+        image_url = part.get("image_url")
+        url = image_url.get("url") if isinstance(image_url, dict) else None
+        return isinstance(url, str) and (url.startswith("data:") or url.startswith("https:"))
+    text = part.get("text") or part.get("content")
+    return isinstance(text, str) and text != ""
 
 
 def _validate_content(content: Any, index: int) -> list[str]:
@@ -198,9 +214,16 @@ def _validate_tool_calls(tool_calls: Any, index: int) -> list[str]:
             )
         else:
             try:
-                json.loads(arguments)
-            except json.JSONDecodeError:
+                json.loads(arguments, parse_constant=_reject_non_finite_constant)
+            except ValueError:
                 errors.append(
                     f"messages[{index}].tool_calls[{j}].function.arguments must be valid JSON"
                 )
     return errors
+
+
+def _reject_non_finite_constant(constant: str) -> Any:
+    # json.loads accepts NaN/Infinity/-Infinity by default (not valid JSON
+    # per RFC 8259); mirrors dataset.py's top-level row parse so a tool
+    # call's arguments string can't sneak one through as "valid JSON".
+    raise ValueError(f"non-finite JSON constant {constant!r} is not allowed")

--- a/src/benchmax/sft/schema.py
+++ b/src/benchmax/sft/schema.py
@@ -7,6 +7,12 @@ assistant turn, and JSON-serializability. It has no notion of on-disk
 provenance (that's :mod:`benchmax.sft.dataset`'s job) or severity tiers
 (that's :mod:`benchmax.sft.validate`'s) — it just returns a flat list of
 human-readable error messages, empty when the row is well-formed.
+
+Every check that compares a user-supplied value against a fixed set
+type-checks first: raw JSONL can put anything JSON-shaped (a list, a
+dict, a bool) where a string or int is expected, and an unhashable value
+in a set-membership test raises ``TypeError`` instead of producing a
+clean issue.
 """
 
 from __future__ import annotations
@@ -14,67 +20,117 @@ from __future__ import annotations
 import json
 from typing import Any
 
+ALLOWED_TOP_LEVEL_KEYS = frozenset({"messages", "tools"})
 VALID_ROLES = frozenset({"system", "user", "assistant", "tool"})
 VALID_CONTENT_PART_TYPES = frozenset({"text", "image_url"})
 VALID_WEIGHTS = frozenset({0, 1})
 
 
 def validate_row(row: Any) -> list[str]:
-    """Structural errors in one canonical SFT row. Empty list means well-formed."""
+    """Structural errors in one canonical SFT row. Empty list means well-formed.
+
+    Every check below runs unconditionally — including JSON-serializability
+    — rather than short-circuiting on the first error, so a row with
+    several independent problems reports all of them.
+    """
     if not isinstance(row, dict):
         return [f"row must be a JSON object, got {type(row).__name__}"]
 
+    errors: list[str] = []
+
+    unexpected = set(row) - ALLOWED_TOP_LEVEL_KEYS
+    if unexpected:
+        errors.append(
+            f"unexpected field(s) {sorted(unexpected)}; only "
+            f"{sorted(ALLOWED_TOP_LEVEL_KEYS)} are accepted top-level keys"
+        )
+
     messages = row.get("messages")
     if messages is None:
-        return ["'messages' is required"]
-    if not isinstance(messages, list) or not messages:
-        return ["'messages' must be a non-empty list"]
+        errors.append("'messages' is required")
+    elif not isinstance(messages, list) or not messages:
+        errors.append("'messages' must be a non-empty list")
+    else:
+        errors.extend(_validate_messages(messages))
 
+    tools = row.get("tools")
+    if tools is not None and not isinstance(tools, list):
+        errors.append("'tools' must be a list")
+
+    try:
+        json.dumps(row, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        errors.append(f"row is not JSON-serializable: {exc}")
+
+    return errors
+
+
+def _validate_messages(messages: list[Any]) -> list[str]:
     errors: list[str] = []
     trained_assistant_turns = 0
+
     for i, message in enumerate(messages):
         if not isinstance(message, dict):
             errors.append(f"messages[{i}] must be an object")
             continue
 
         role = message.get("role")
-        if role not in VALID_ROLES:
+        if not isinstance(role, str) or role not in VALID_ROLES:
             errors.append(
                 f"messages[{i}].role must be one of {sorted(VALID_ROLES)}, got {role!r}"
             )
-        if role == "tool" and not isinstance(message.get("tool_call_id"), str):
-            errors.append(f"messages[{i}] (tool) must have a string 'tool_call_id'")
+
+        if role == "tool":
+            tool_call_id = message.get("tool_call_id")
+            if not isinstance(tool_call_id, str) or not tool_call_id:
+                errors.append(f"messages[{i}] (tool) must have a non-empty string 'tool_call_id'")
 
         errors.extend(_validate_content(message.get("content"), i))
 
+        has_weight = "weight" in message
+        weight = message.get("weight")
+        if has_weight and role != "assistant":
+            errors.append(f"messages[{i}].weight is only valid on assistant messages")
+
         if role == "assistant":
-            weight = message.get("weight")
-            if "weight" in message and weight not in VALID_WEIGHTS:
-                errors.append(f"messages[{i}].weight must be 0 or 1, got {weight!r}")
-            elif weight != 0:
-                trained_assistant_turns += 1
+            weight_valid = True
+            if has_weight:
+                # bool is a subclass of int (isinstance(True, int) is True) and
+                # 1.0 == 1, so an exact `type(...) is int` check is required to
+                # reject True/1.0 rather than silently accepting them as 0/1.
+                if type(weight) is not int or weight not in VALID_WEIGHTS:
+                    errors.append(f"messages[{i}].weight must be 0 or 1, got {weight!r}")
+                    weight_valid = False
 
             tool_calls = message.get("tool_calls")
+            has_valid_tool_calls = False
             if tool_calls is not None:
-                errors.extend(_validate_tool_calls(tool_calls, i))
+                tool_call_errors = _validate_tool_calls(tool_calls, i)
+                errors.extend(tool_call_errors)
+                has_valid_tool_calls = (
+                    isinstance(tool_calls, list) and len(tool_calls) > 0 and not tool_call_errors
+                )
+
+            is_masked = has_weight and weight_valid and weight == 0
+            has_content = _has_meaningful_content(message.get("content"))
+            if not is_masked and (has_content or has_valid_tool_calls):
+                trained_assistant_turns += 1
 
     if trained_assistant_turns == 0:
         errors.append(
-            "row has no trained assistant turn (all assistant messages have "
-            "weight=0, or none are present)"
+            "row has no trained assistant turn (need an assistant message with content "
+            "or tool calls, and weight != 0)"
         )
 
-    tools = row.get("tools")
-    if tools is not None and not isinstance(tools, list):
-        errors.append("'tools' must be a list")
-
-    if not errors:
-        try:
-            json.dumps(row)
-        except (TypeError, ValueError) as exc:
-            errors.append(f"row is not JSON-serializable: {exc}")
-
     return errors
+
+
+def _has_meaningful_content(content: Any) -> bool:
+    if isinstance(content, str):
+        return content != ""
+    if isinstance(content, list):
+        return len(content) > 0
+    return False
 
 
 def _validate_content(content: Any, index: int) -> list[str]:
@@ -89,7 +145,7 @@ def _validate_content(content: Any, index: int) -> list[str]:
             errors.append(f"messages[{index}].content[{j}] must be an object")
             continue
         part_type = part.get("type")
-        if part_type not in VALID_CONTENT_PART_TYPES:
+        if not isinstance(part_type, str) or part_type not in VALID_CONTENT_PART_TYPES:
             errors.append(
                 f"messages[{index}].content[{j}].type must be one of "
                 f"{sorted(VALID_CONTENT_PART_TYPES)}, got {part_type!r}"
@@ -117,8 +173,14 @@ def _validate_tool_calls(tool_calls: Any, index: int) -> list[str]:
         if not isinstance(tc, dict):
             errors.append(f"messages[{index}].tool_calls[{j}] must be an object")
             continue
+
+        tool_call_id = tc.get("id")
+        if not isinstance(tool_call_id, str) or not tool_call_id:
+            errors.append(f"messages[{index}].tool_calls[{j}].id must be a non-empty string")
+
         if tc.get("type") != "function":
             errors.append(f"messages[{index}].tool_calls[{j}].type must be 'function'")
+
         function = tc.get("function")
         if not isinstance(function, dict):
             errors.append(f"messages[{index}].tool_calls[{j}].function must be an object")

--- a/src/benchmax/sft/schema.py
+++ b/src/benchmax/sft/schema.py
@@ -145,7 +145,10 @@ def _part_has_meaningful_content(part: Any) -> bool:
         image_url = part.get("image_url")
         url = image_url.get("url") if isinstance(image_url, dict) else None
         return isinstance(url, str) and (url.startswith("data:") or url.startswith("https:"))
-    text = part.get("text") or part.get("content")
+    # Canonical text parts (openai.types.chat.ChatCompletionContentPartTextParam)
+    # carry only `text` — no `content` fallback here, unlike the deliberately
+    # forgiving benchmax.envs.base.content.message_text display helper.
+    text = part.get("text")
     return isinstance(text, str) and text != ""
 
 

--- a/src/benchmax/sft/validate.py
+++ b/src/benchmax/sft/validate.py
@@ -5,11 +5,10 @@ validated is not a pass" rule for the SFT pathway.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 
 from benchmax.envs.base.content import message_text
-from benchmax.sft.dataset import SftDataset, SftIssue
+from benchmax.sft.dataset import SftDataset, SftIssue, canonical_row_bytes
 from benchmax.sft.schema import validate_row
 
 DEFAULT_MAX_SEQ_LEN = 8192
@@ -154,14 +153,15 @@ def validate_sft_dataset(
 
 
 def _safe_serialized_len(row_data: dict) -> int | None:
-    """Byte length of ``row_data`` as canonical JSON, or ``None`` if it can't serialize.
+    """Byte length of ``row_data`` via the same encoding ``canonical_jsonl`` uses,
+    or ``None`` if it can't serialize.
 
     A non-serializable row already gets a "not JSON-serializable" error
     from :func:`benchmax.sft.schema.validate_row` above — this guard just
     keeps a bad row from crashing the rest of the report.
     """
     try:
-        return len(json.dumps(row_data, ensure_ascii=False, allow_nan=False).encode("utf-8"))
+        return len(canonical_row_bytes(row_data))
     except (TypeError, ValueError):
         return None
 

--- a/src/benchmax/sft/validate.py
+++ b/src/benchmax/sft/validate.py
@@ -1,0 +1,194 @@
+"""Dataset-level SFT validation: :func:`validate_sft_dataset` gates a
+train/eval pair before upload, mirroring ``ValidationReport``'s "nothing
+validated is not a pass" rule for the SFT pathway.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+from benchmax.envs.base.content import message_text
+from benchmax.sft.dataset import SftDataset, SftIssue
+from benchmax.sft.schema import validate_row
+
+DEFAULT_MAX_SEQ_LEN = 8192
+DEFAULT_MAX_ROW_BYTES = 1024 * 1024  # 1 MiB
+
+
+@dataclass(frozen=True)
+class TokenLengthStats:
+    """Char/4 heuristic token-length stats across every row in the pair."""
+
+    min_tokens: int
+    max_tokens: int
+    mean_tokens: float
+    rows_over_max_seq_len: int
+
+
+@dataclass(frozen=True)
+class MaskingSummary:
+    """Usage of per-assistant-message ``weight`` across the pair."""
+
+    rows_with_weight: int
+    trained_assistant_messages: int
+    masked_assistant_messages: int
+
+
+@dataclass(frozen=True)
+class SftValidationReport:
+    """Combined outcome of :func:`validate_sft_dataset`.
+
+    Bool-castable so gate code reads identically to ``ValidationReport``::
+
+        if not validate_sft_dataset(train, eval_dataset):
+            raise SystemExit("Fix the dataset before launching.")
+    """
+
+    issues: list[SftIssue] = field(default_factory=list)
+    train_row_count: int = 0
+    eval_row_count: int = 0
+    token_length_stats: TokenLengthStats = field(
+        default_factory=lambda: TokenLengthStats(0, 0, 0.0, 0)
+    )
+    masking_summary: MaskingSummary = field(default_factory=lambda: MaskingSummary(0, 0, 0))
+
+    @property
+    def ok(self) -> bool:
+        # An empty/absent train set is failure, matching ValidationReport's
+        # "nothing validated is not a pass" — even with zero error issues.
+        has_errors = any(issue.severity == "error" for issue in self.issues)
+        return not has_errors and self.train_row_count >= 1
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
+def validate_sft_dataset(
+    train: SftDataset,
+    eval: SftDataset | None = None,
+    max_seq_len: int = DEFAULT_MAX_SEQ_LEN,
+    max_row_bytes: int = DEFAULT_MAX_ROW_BYTES,
+) -> SftValidationReport:
+    """Validate a train (+ optional eval) :class:`SftDataset` pair.
+
+    Every row is checked against :func:`benchmax.sft.schema.validate_row`
+    (error-severity issues); rows serializing at/above ``max_row_bytes`` or
+    estimated (char/4) over ``max_seq_len`` tokens, and rows carrying a
+    per-message ``weight``, get informational notice-severity issues. An
+    empty train dataset is an error; an empty eval dataset is a notice.
+    """
+    issues: list[SftIssue] = list(train.load_issues)
+    if eval is not None:
+        issues.extend(eval.load_issues)
+
+    token_counts: list[int] = []
+    rows_over_max_seq_len = 0
+    rows_with_weight = 0
+    trained_assistant_messages = 0
+    masked_assistant_messages = 0
+
+    for dataset in (train, eval) if eval is not None else (train,):
+        for row in dataset.rows:
+            for message in validate_row(row.data):
+                issues.append(SftIssue(row.source_path, row.physical_line, "error", message))
+
+            serialized_len = len(json.dumps(row.data, ensure_ascii=False).encode("utf-8"))
+            if serialized_len >= max_row_bytes:
+                issues.append(
+                    SftIssue(
+                        row.source_path,
+                        row.physical_line,
+                        "notice",
+                        f"row is {serialized_len} bytes, at/above max_row_bytes ({max_row_bytes})",
+                    )
+                )
+
+            token_count = _estimate_tokens(row.data)
+            token_counts.append(token_count)
+            if token_count > max_seq_len:
+                rows_over_max_seq_len += 1
+                issues.append(
+                    SftIssue(
+                        row.source_path,
+                        row.physical_line,
+                        "notice",
+                        f"estimated token length ~{token_count} exceeds max_seq_len "
+                        f"({max_seq_len}, char/4 heuristic)",
+                    )
+                )
+
+            row_has_weight, trained, masked = _weight_counts(row.data)
+            trained_assistant_messages += trained
+            masked_assistant_messages += masked
+            if row_has_weight:
+                rows_with_weight += 1
+                issues.append(
+                    SftIssue(
+                        row.source_path,
+                        row.physical_line,
+                        "notice",
+                        "row has per-message 'weight' set (experimental — masking support "
+                        "unconfirmed)",
+                    )
+                )
+
+    if len(train.rows) == 0:
+        issues.append(SftIssue(train.path, 0, "error", "train dataset is empty"))
+    if eval is None:
+        issues.append(SftIssue("", 0, "notice", "no eval dataset provided"))
+    elif len(eval.rows) == 0:
+        issues.append(SftIssue(eval.path, 0, "notice", "eval dataset is empty"))
+
+    return SftValidationReport(
+        issues=issues,
+        train_row_count=len(train.rows),
+        eval_row_count=len(eval.rows) if eval is not None else 0,
+        token_length_stats=_token_stats(token_counts, rows_over_max_seq_len),
+        masking_summary=MaskingSummary(
+            rows_with_weight=rows_with_weight,
+            trained_assistant_messages=trained_assistant_messages,
+            masked_assistant_messages=masked_assistant_messages,
+        ),
+    )
+
+
+def _estimate_tokens(row_data: dict) -> int:
+    messages = row_data.get("messages")
+    if not isinstance(messages, list):
+        return 0
+    total_chars = sum(len(message_text(m)) for m in messages if isinstance(m, dict))
+    return total_chars // 4
+
+
+def _weight_counts(row_data: dict) -> tuple[bool, int, int]:
+    messages = row_data.get("messages")
+    if not isinstance(messages, list):
+        return False, 0, 0
+
+    row_has_weight = False
+    trained = 0
+    masked = 0
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        if "weight" in message:
+            row_has_weight = True
+            if message.get("weight") == 0:
+                masked += 1
+            else:
+                trained += 1
+        else:
+            trained += 1
+    return row_has_weight, trained, masked
+
+
+def _token_stats(token_counts: list[int], rows_over_max_seq_len: int) -> TokenLengthStats:
+    if not token_counts:
+        return TokenLengthStats(min_tokens=0, max_tokens=0, mean_tokens=0.0, rows_over_max_seq_len=0)
+    return TokenLengthStats(
+        min_tokens=min(token_counts),
+        max_tokens=max(token_counts),
+        mean_tokens=sum(token_counts) / len(token_counts),
+        rows_over_max_seq_len=rows_over_max_seq_len,
+    )

--- a/src/benchmax/sft/validate.py
+++ b/src/benchmax/sft/validate.py
@@ -93,8 +93,8 @@ def validate_sft_dataset(
             for message in validate_row(row.data):
                 issues.append(SftIssue(row.source_path, row.physical_line, "error", message))
 
-            serialized_len = len(json.dumps(row.data, ensure_ascii=False).encode("utf-8"))
-            if serialized_len >= max_row_bytes:
+            serialized_len = _safe_serialized_len(row.data)
+            if serialized_len is not None and serialized_len >= max_row_bytes:
                 issues.append(
                     SftIssue(
                         row.source_path,
@@ -151,6 +151,19 @@ def validate_sft_dataset(
             masked_assistant_messages=masked_assistant_messages,
         ),
     )
+
+
+def _safe_serialized_len(row_data: dict) -> int | None:
+    """Byte length of ``row_data`` as canonical JSON, or ``None`` if it can't serialize.
+
+    A non-serializable row already gets a "not JSON-serializable" error
+    from :func:`benchmax.sft.schema.validate_row` above — this guard just
+    keeps a bad row from crashing the rest of the report.
+    """
+    try:
+        return len(json.dumps(row_data, ensure_ascii=False, allow_nan=False).encode("utf-8"))
+    except (TypeError, ValueError):
+        return None
 
 
 def _estimate_tokens(row_data: dict) -> int:

--- a/tests/unit/sft/test_dataset.py
+++ b/tests/unit/sft/test_dataset.py
@@ -185,6 +185,26 @@ class TestCanonicalJsonl:
         assert len(lines) == 2
         assert [json.loads(line) for line in lines] == [row.data for row in dataset.rows]
 
+    def test_ordinary_non_ascii_round_trips(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "train.jsonl",
+            '{"messages": [{"role": "assistant", "content": "héllo \\u2014 日本語"}]}\n',
+        )
+        dataset = load_sft_dataset(path)
+        rendered = _canonical_jsonl(dataset).decode("utf-8")
+        assert json.loads(rendered)["messages"][0]["content"] == "héllo — 日本語"
+
+    def test_lone_surrogate_raises_instead_of_producing_broken_bytes(self, tmp_path):
+        # A row with a lone surrogate should never reach canonical_jsonl in
+        # practice — schema.validate_row rejects it first — but this documents
+        # canonical_jsonl's own contract: it fails loudly rather than silently
+        # emitting undecodable bytes if ever called on unvalidated data.
+        path = _write(tmp_path, "train.jsonl", '{"messages": [{"role": "assistant", "content": "\\ud800"}]}\n')
+        dataset = load_sft_dataset(path)
+        with pytest.raises(UnicodeEncodeError):
+            _canonical_jsonl(dataset)
+
     def test_legacy_split_file_canonicalization_preserves_everything(self, tmp_path):
         legacy_row = {
             "prompt_messages": [

--- a/tests/unit/sft/test_dataset.py
+++ b/tests/unit/sft/test_dataset.py
@@ -1,0 +1,162 @@
+"""Tests for the SFT canonicalization boundary: load_sft_dataset + canonical_jsonl."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from benchmax.sft.dataset import load_sft_dataset
+from benchmax.sft.dataset import canonical_jsonl as _canonical_jsonl
+
+
+def _write(tmp_path, name, text):
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class TestValidRows:
+    def test_loads_rows_with_provenance(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "train.jsonl",
+            '{"messages": [{"role": "user", "content": "hi"}, '
+            '{"role": "assistant", "content": "yo"}]}\n',
+        )
+        dataset = load_sft_dataset(path)
+        assert len(dataset.rows) == 1
+        assert dataset.rows[0].source_path == str(path)
+        assert dataset.rows[0].physical_line == 1
+        assert dataset.load_issues == []
+
+    def test_normalization_applied_on_load(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "train.jsonl",
+            '{"prompt": "hi", "completion": "yo"}\n',
+        )
+        dataset = load_sft_dataset(path)
+        assert dataset.rows[0].data == {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "yo"},
+            ]
+        }
+
+
+class TestPhysicalLineNumbers:
+    def test_blank_lines_counted_but_skipped(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "train.jsonl",
+            '{"messages": [{"role": "assistant", "content": "a"}]}\n'
+            "\n"
+            "\n"
+            '{"messages": [{"role": "assistant", "content": "b"}]}\n',
+        )
+        dataset = load_sft_dataset(path)
+        assert [r.physical_line for r in dataset.rows] == [1, 4]
+        assert dataset.load_issues == []
+
+    def test_malformed_json_line_becomes_issue_not_exception(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "train.jsonl",
+            '{"messages": [{"role": "assistant", "content": "a"}]}\n'
+            "\n"
+            "{not valid json\n"
+            '{"messages": [{"role": "assistant", "content": "b"}]}\n',
+        )
+        dataset = load_sft_dataset(path)  # must not raise
+        assert [r.physical_line for r in dataset.rows] == [1, 4]
+        assert len(dataset.load_issues) == 1
+        issue = dataset.load_issues[0]
+        assert issue.physical_line == 3
+        assert issue.severity == "error"
+        assert "invalid JSON" in issue.message
+
+    def test_non_object_json_line_becomes_issue(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "train.jsonl",
+            "[1, 2, 3]\n"
+            '{"messages": [{"role": "assistant", "content": "b"}]}\n',
+        )
+        dataset = load_sft_dataset(path)
+        assert len(dataset.rows) == 1
+        assert dataset.rows[0].physical_line == 2
+        assert dataset.load_issues[0].physical_line == 1
+        assert "JSON object" in dataset.load_issues[0].message
+
+
+class TestMissingFile:
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_sft_dataset(tmp_path / "does_not_exist.jsonl")
+
+
+class TestCanonicalJsonl:
+    def test_empty_dataset_renders_empty_bytes(self, tmp_path):
+        path = _write(tmp_path, "train.jsonl", "\n")
+        dataset = load_sft_dataset(path)
+        assert _canonical_jsonl(dataset) == b""
+
+    def test_round_trips_to_valid_jsonl(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "train.jsonl",
+            '{"messages": [{"role": "assistant", "content": "a"}]}\n'
+            '{"messages": [{"role": "assistant", "content": "b"}]}\n',
+        )
+        dataset = load_sft_dataset(path)
+        rendered = _canonical_jsonl(dataset).decode("utf-8")
+        lines = rendered.splitlines()
+        assert len(lines) == 2
+        assert [json.loads(line) for line in lines] == [row.data for row in dataset.rows]
+
+    def test_legacy_split_file_canonicalization_preserves_everything(self, tmp_path):
+        legacy_row = {
+            "prompt_messages": [
+                {"role": "system", "content": "sys"},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                        {"type": "text", "text": "what is this"},
+                    ],
+                },
+            ],
+            "completion_messages": [
+                {
+                    "role": "assistant",
+                    "content": "it is a cat",
+                    "weight": 1,
+                    "tool_calls": [{"id": "call_1", "name": "lookup", "arguments": {"q": "cat"}}],
+                }
+            ],
+            "tools": [{"type": "function", "function": {"name": "lookup", "parameters": {}}}],
+        }
+        path = _write(tmp_path, "legacy.jsonl", json.dumps(legacy_row) + "\n")
+
+        dataset = load_sft_dataset(path)
+        canon_rows = [json.loads(line) for line in _canonical_jsonl(dataset).decode().splitlines()]
+        assert len(canon_rows) == 1
+        row = canon_rows[0]
+
+        assert set(row.keys()) == {"messages", "tools"}
+        assert row["messages"][0] == {"role": "system", "content": "sys"}
+
+        user_msg = row["messages"][1]
+        assert user_msg["content"][0]["type"] == "image_url"
+        assert user_msg["content"][0]["image_url"]["url"] == "data:image/png;base64,AAAA"
+        assert user_msg["content"][1] == {"type": "text", "text": "what is this"}
+
+        assistant_msg = row["messages"][2]
+        assert assistant_msg["weight"] == 1
+        tool_call = assistant_msg["tool_calls"][0]
+        assert tool_call["type"] == "function"
+        assert tool_call["function"]["name"] == "lookup"
+        assert json.loads(tool_call["function"]["arguments"]) == {"q": "cat"}
+
+        assert row["tools"] == legacy_row["tools"]

--- a/tests/unit/sft/test_dataset.py
+++ b/tests/unit/sft/test_dataset.py
@@ -90,6 +90,76 @@ class TestPhysicalLineNumbers:
         assert "JSON object" in dataset.load_issues[0].message
 
 
+class TestNonFiniteConstants:
+    def test_nan_becomes_load_issue_not_exception(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "train.jsonl",
+            '{"messages": [{"role": "assistant", "content": "a"}]}\n'
+            '{"messages": [{"role": "assistant", "content": NaN}]}\n',
+        )
+        dataset = load_sft_dataset(path)  # must not raise
+        assert [r.physical_line for r in dataset.rows] == [1]
+        assert len(dataset.load_issues) == 1
+        assert dataset.load_issues[0].physical_line == 2
+        assert dataset.load_issues[0].severity == "error"
+
+    def test_infinity_becomes_load_issue_not_exception(self, tmp_path):
+        path = _write(tmp_path, "train.jsonl", '{"messages": [{"role": "a", "weight": Infinity}]}\n')
+        dataset = load_sft_dataset(path)  # must not raise
+        assert dataset.rows == []
+        assert len(dataset.load_issues) == 1
+        assert dataset.load_issues[0].severity == "error"
+
+    def test_negative_infinity_becomes_load_issue_not_exception(self, tmp_path):
+        path = _write(
+            tmp_path, "train.jsonl", '{"messages": [{"role": "a", "weight": -Infinity}]}\n'
+        )
+        dataset = load_sft_dataset(path)  # must not raise
+        assert dataset.rows == []
+        assert len(dataset.load_issues) == 1
+        assert dataset.load_issues[0].severity == "error"
+
+
+class TestUnicodeLineSeparators:
+    def test_u2028_inside_content_does_not_split_physical_lines(self, tmp_path):
+        separator_text = "before after"
+        row1 = {
+            "messages": [
+                {"role": "user", "content": separator_text},
+                {"role": "assistant", "content": "ok"},
+            ]
+        }
+        row2 = {"messages": [{"role": "assistant", "content": "b"}]}
+        text = json.dumps(row1, ensure_ascii=False) + "\n" + json.dumps(row2) + "\n"
+        path = _write(tmp_path, "u2028.jsonl", text)
+
+        dataset = load_sft_dataset(path)
+        assert dataset.load_issues == []
+        assert [r.physical_line for r in dataset.rows] == [1, 2]
+        assert dataset.rows[0].data["messages"][0]["content"] == separator_text
+
+    def test_u2028_round_trips_through_canonical_jsonl(self, tmp_path):
+        separator_text = "before after"
+        row1 = {
+            "messages": [
+                {"role": "user", "content": separator_text},
+                {"role": "assistant", "content": "ok"},
+            ]
+        }
+        row2 = {"messages": [{"role": "assistant", "content": "b"}]}
+        text = json.dumps(row1, ensure_ascii=False) + "\n" + json.dumps(row2) + "\n"
+        path = _write(tmp_path, "u2028.jsonl", text)
+
+        dataset = load_sft_dataset(path)
+        canon_path = _write(tmp_path, "u2028_canon.jsonl", _canonical_jsonl(dataset).decode("utf-8"))
+        reloaded = load_sft_dataset(canon_path)
+
+        assert reloaded.load_issues == []
+        assert [r.physical_line for r in reloaded.rows] == [1, 2]
+        assert reloaded.rows[0].data["messages"][0]["content"] == separator_text
+
+
 class TestMissingFile:
     def test_missing_file_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):

--- a/tests/unit/sft/test_normalize.py
+++ b/tests/unit/sft/test_normalize.py
@@ -1,0 +1,150 @@
+"""Tests for legacy SFT row shape normalization."""
+
+from __future__ import annotations
+
+import json
+
+from benchmax.sft.normalize import normalize_row
+
+
+class TestCanonicalPassthrough:
+    def test_messages_and_tools_preserved_verbatim(self):
+        row = {
+            "messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}],
+            "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        }
+        assert normalize_row(row) == row
+
+    def test_weight_preserved(self):
+        row = {"messages": [{"role": "assistant", "content": "x", "weight": 0}]}
+        assert normalize_row(row)["messages"][0]["weight"] == 0
+
+    def test_multimodal_content_preserved_untouched(self):
+        content = [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            {"type": "text", "text": "what is this"},
+        ]
+        row = {"messages": [{"role": "user", "content": content}]}
+        assert normalize_row(row)["messages"][0]["content"] == content
+
+    def test_unrecognized_shape_drops_no_tools(self):
+        row = {"tools": [{"type": "function", "function": {"name": "f"}}], "random_field": 1}
+        result = normalize_row(row)
+        assert "messages" not in result
+        assert result["tools"] == row["tools"]
+
+
+class TestSplitFormat:
+    def test_prompt_messages_plus_completion_messages(self):
+        row = {
+            "prompt_messages": [{"role": "user", "content": "hi"}],
+            "completion_messages": [{"role": "assistant", "content": "yo"}],
+        }
+        result = normalize_row(row)
+        assert result["messages"] == [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "yo"},
+        ]
+
+    def test_bare_prompt_string_with_completion_messages(self):
+        row = {
+            "prompt": "hi",
+            "completion_messages": [{"role": "assistant", "content": "yo"}],
+        }
+        result = normalize_row(row)
+        assert result["messages"] == [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "yo"},
+        ]
+
+    def test_bare_prompt_and_bare_completion_strings(self):
+        row = {"prompt": "hi", "completion": "yo"}
+        result = normalize_row(row)
+        assert result["messages"] == [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "yo"},
+        ]
+
+    def test_prompt_messages_single_dict_wrapped_in_list(self):
+        row = {
+            "prompt_messages": {"role": "user", "content": "hi"},
+            "completion": "yo",
+        }
+        result = normalize_row(row)
+        assert result["messages"][0] == {"role": "user", "content": "hi"}
+
+
+class TestFlatToolCallFormat:
+    def test_flat_tool_call_normalized_to_nested(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{"id": "call_1", "name": "lookup", "arguments": {"q": "cat"}}],
+                }
+            ]
+        }
+        result = normalize_row(row)
+        tc = result["messages"][0]["tool_calls"][0]
+        assert tc == {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": json.dumps({"q": "cat"})},
+        }
+
+    def test_nested_tool_call_arguments_dict_stringified(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": {"q": "cat"}},
+                        }
+                    ],
+                }
+            ]
+        }
+        result = normalize_row(row)
+        arguments = result["messages"][0]["tool_calls"][0]["function"]["arguments"]
+        assert isinstance(arguments, str)
+        assert json.loads(arguments) == {"q": "cat"}
+
+    def test_nested_tool_call_string_arguments_untouched(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": '{"q": "cat"}'},
+                        }
+                    ],
+                }
+            ]
+        }
+        result = normalize_row(row)
+        assert result["messages"][0]["tool_calls"][0]["function"]["arguments"] == '{"q": "cat"}'
+
+    def test_split_format_with_flat_tool_calls_in_completion(self):
+        row = {
+            "prompt_messages": [{"role": "user", "content": "find a cat"}],
+            "completion_messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{"id": "call_1", "name": "lookup", "arguments": "{}"}],
+                }
+            ],
+        }
+        result = normalize_row(row)
+        tc = result["messages"][1]["tool_calls"][0]
+        assert tc["function"]["name"] == "lookup"
+        assert tc["type"] == "function"

--- a/tests/unit/sft/test_normalize.py
+++ b/tests/unit/sft/test_normalize.py
@@ -27,11 +27,30 @@ class TestCanonicalPassthrough:
         row = {"messages": [{"role": "user", "content": content}]}
         assert normalize_row(row)["messages"][0]["content"] == content
 
-    def test_unrecognized_shape_drops_no_tools(self):
+    def test_unrecognized_shape_preserves_every_field(self):
         row = {"tools": [{"type": "function", "function": {"name": "f"}}], "random_field": 1}
         result = normalize_row(row)
         assert "messages" not in result
         assert result["tools"] == row["tools"]
+        assert result["random_field"] == 1
+
+    def test_unexpected_top_level_field_survives_when_already_canonical(self):
+        row = {"messages": [{"role": "assistant", "content": "hi"}], "extra_metadata": {"foo": "bar"}}
+        result = normalize_row(row)
+        assert result["extra_metadata"] == {"foo": "bar"}
+
+    def test_unexpected_top_level_field_survives_split_format(self):
+        row = {
+            "prompt_messages": [{"role": "user", "content": "hi"}],
+            "completion": "yo",
+            "extra_metadata": {"foo": "bar"},
+        }
+        result = normalize_row(row)
+        assert result["extra_metadata"] == {"foo": "bar"}
+        # the legacy keys actually consumed into `messages` are gone, but
+        # nothing else is
+        assert "prompt_messages" not in result
+        assert "completion" not in result
 
 
 class TestSplitFormat:
@@ -148,3 +167,48 @@ class TestFlatToolCallFormat:
         tc = result["messages"][1]["tool_calls"][0]
         assert tc["function"]["name"] == "lookup"
         assert tc["type"] == "function"
+
+    def test_flat_tool_call_preserves_extra_fields_on_the_call(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {"id": "call_1", "name": "lookup", "arguments": "{}", "index": 0}
+                    ],
+                }
+            ]
+        }
+        result = normalize_row(row)
+        tc = result["messages"][0]["tool_calls"][0]
+        assert tc["index"] == 0
+        assert tc["id"] == "call_1"
+
+    def test_nested_tool_call_preserves_full_fidelity_extra_fields(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "index": 0,
+                            "function": {
+                                "name": "lookup",
+                                "arguments": {"q": "cat"},
+                                "description": "custom",
+                            },
+                        }
+                    ],
+                }
+            ]
+        }
+        result = normalize_row(row)
+        tc = result["messages"][0]["tool_calls"][0]
+        assert tc["index"] == 0
+        assert tc["function"]["name"] == "lookup"
+        assert tc["function"]["description"] == "custom"
+        assert json.loads(tc["function"]["arguments"]) == {"q": "cat"}

--- a/tests/unit/sft/test_schema.py
+++ b/tests/unit/sft/test_schema.py
@@ -193,6 +193,21 @@ class TestWeightErrors:
         row = {"messages": [{"role": "assistant", "content": [{"type": "text", "text": "hi"}]}]}
         assert validate_row(row) == []
 
+    def test_empty_text_part_with_non_canonical_content_key_not_trained(self):
+        # a `content` key on a text part isn't part of the canonical
+        # ChatCompletionContentPartTextParam shape (text-only) — must not be
+        # used as a fallback to smuggle a trained turn past an empty `text`.
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "", "content": "fallback"}],
+                }
+            ]
+        }
+        errors = validate_row(row)
+        assert any("no trained assistant turn" in e for e in errors)
+
     def test_assistant_with_only_image_part_is_trained(self):
         row = {
             "messages": [

--- a/tests/unit/sft/test_schema.py
+++ b/tests/unit/sft/test_schema.py
@@ -170,6 +170,56 @@ class TestWeightErrors:
         errors = validate_row(row)
         assert any("no trained assistant turn" in e for e in errors)
 
+    def test_assistant_with_empty_text_part_not_trained(self):
+        # a content-part list whose only part carries "" is semantically the
+        # same as bare content: "" — must not count as a trained turn either.
+        row = {"messages": [{"role": "assistant", "content": [{"type": "text", "text": ""}]}]}
+        errors = validate_row(row)
+        assert any("no trained assistant turn" in e for e in errors)
+
+    def test_assistant_with_multiple_empty_text_parts_not_trained(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": ""}, {"type": "text", "text": ""}],
+                }
+            ]
+        }
+        errors = validate_row(row)
+        assert any("no trained assistant turn" in e for e in errors)
+
+    def test_assistant_with_non_empty_text_part_is_trained(self):
+        row = {"messages": [{"role": "assistant", "content": [{"type": "text", "text": "hi"}]}]}
+        assert validate_row(row) == []
+
+    def test_assistant_with_only_image_part_is_trained(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+                    ],
+                }
+            ]
+        }
+        assert validate_row(row) == []
+
+    def test_assistant_with_empty_text_plus_valid_image_is_trained(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": ""},
+                        {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+                    ],
+                }
+            ]
+        }
+        assert validate_row(row) == []
+
     def test_assistant_with_valid_tool_calls_and_no_content_is_trained(self):
         row = {
             "messages": [
@@ -333,6 +383,47 @@ class TestToolCallErrors:
         errors = validate_row(row)
         assert any("tool_call_id" in e for e in errors)
 
+    def test_tool_call_arguments_with_nan_is_rejected(self):
+        # json.loads accepts the non-standard NaN/Infinity/-Infinity tokens
+        # by default; a tool-call's arguments string must reject them too,
+        # not just the top-level row parse.
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": '{"score": NaN}'},
+                        }
+                    ],
+                }
+            ]
+        }
+        errors = validate_row(row)
+        assert any("must be valid JSON" in e for e in errors)
+
+    def test_tool_call_arguments_with_infinity_is_rejected(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": '{"score": Infinity}'},
+                        }
+                    ],
+                }
+            ]
+        }
+        errors = validate_row(row)
+        assert any("must be valid JSON" in e for e in errors)
+
 
 class TestContentPartErrors:
     def test_content_not_str_or_list(self):
@@ -389,6 +480,19 @@ class TestJsonSerializability:
         errors = validate_row(row)
         assert any("role must be one of" in e for e in errors)
         assert any("not JSON-serializable" in e for e in errors)
+
+    def test_lone_surrogate_content_is_rejected(self):
+        # ensure_ascii=True (json.dumps' default) never attempts the UTF-8
+        # encode step, so a naive check would pass this row right up until
+        # canonical_jsonl's ensure_ascii=False encode blew up on it.
+        row = {"messages": [{"role": "assistant", "content": "before\ud800after"}]}
+        errors = validate_row(row)
+        assert any("not JSON-serializable" in e for e in errors)
+
+    def test_ordinary_non_ascii_content_is_fine(self):
+        # the fix must not start rejecting legitimate non-ASCII text.
+        row = {"messages": [{"role": "assistant", "content": "héllo — 日本語"}]}
+        assert validate_row(row) == []
 
 
 class TestUnexpectedTopLevelFields:

--- a/tests/unit/sft/test_schema.py
+++ b/tests/unit/sft/test_schema.py
@@ -121,6 +121,73 @@ class TestWeightErrors:
         errors = validate_row(row)
         assert any("weight must be 0 or 1" in e for e in errors)
 
+    def test_boolean_weight_rejected(self):
+        # isinstance(True, int) is True and True == 1, so a naive
+        # membership/equality check would silently accept a bool.
+        row = {"messages": [{"role": "assistant", "content": "x", "weight": True}]}
+        errors = validate_row(row)
+        assert any("weight must be 0 or 1" in e for e in errors)
+
+    def test_float_weight_rejected(self):
+        # 1.0 == 1, so this must be rejected by an exact int type check.
+        row = {"messages": [{"role": "assistant", "content": "x", "weight": 1.0}]}
+        errors = validate_row(row)
+        assert any("weight must be 0 or 1" in e for e in errors)
+
+    def test_weight_on_user_message_is_error(self):
+        row = {
+            "messages": [
+                {"role": "user", "content": "hi", "weight": 1},
+                {"role": "assistant", "content": "yo"},
+            ]
+        }
+        errors = validate_row(row)
+        assert any("weight is only valid on assistant messages" in e for e in errors)
+
+    def test_weight_on_system_message_is_error(self):
+        row = {
+            "messages": [
+                {"role": "system", "content": "sys", "weight": 0},
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "yo"},
+            ]
+        }
+        errors = validate_row(row)
+        assert any("weight is only valid on assistant messages" in e for e in errors)
+
+    def test_assistant_with_no_content_and_no_tool_calls_not_trained(self):
+        row = {"messages": [{"role": "assistant"}]}
+        errors = validate_row(row)
+        assert any("no trained assistant turn" in e for e in errors)
+
+    def test_assistant_with_empty_string_content_not_trained(self):
+        row = {"messages": [{"role": "assistant", "content": ""}]}
+        errors = validate_row(row)
+        assert any("no trained assistant turn" in e for e in errors)
+
+    def test_assistant_with_empty_content_list_not_trained(self):
+        row = {"messages": [{"role": "assistant", "content": []}]}
+        errors = validate_row(row)
+        assert any("no trained assistant turn" in e for e in errors)
+
+    def test_assistant_with_valid_tool_calls_and_no_content_is_trained(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                }
+            ]
+        }
+        assert validate_row(row) == []
+
     def test_all_assistant_turns_masked_is_error(self):
         row = {
             "messages": [
@@ -227,6 +294,45 @@ class TestToolCallErrors:
         errors = validate_row(row)
         assert any("tool_calls must be a list" in e for e in errors)
 
+    def test_tool_call_missing_id(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{"type": "function", "function": {"name": "f", "arguments": "{}"}}],
+                }
+            ]
+        }
+        errors = validate_row(row)
+        assert any("tool_calls[0].id" in e for e in errors)
+
+    def test_tool_call_empty_id(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {"id": "", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+                    ],
+                }
+            ]
+        }
+        errors = validate_row(row)
+        assert any("tool_calls[0].id" in e for e in errors)
+
+    def test_tool_response_empty_tool_call_id_is_error(self):
+        row = {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "ok"},
+                {"role": "tool", "tool_call_id": "", "content": "result"},
+            ]
+        }
+        errors = validate_row(row)
+        assert any("tool_call_id" in e for e in errors)
+
 
 class TestContentPartErrors:
     def test_content_not_str_or_list(self):
@@ -272,3 +378,56 @@ class TestJsonSerializability:
         row = {**_VALID_ROW, "tools": [{"unserializable": {1, 2, 3}}]}
         errors = validate_row(row)
         assert any("not JSON-serializable" in e for e in errors)
+
+    def test_serialization_check_runs_even_with_structural_errors(self):
+        # Previously the JSON-serializability check was skipped once any
+        # other structural error was found; both must surface now.
+        row = {
+            "messages": [{"role": "not-a-real-role", "content": "hi"}],
+            "extra_metadata": {1, 2, 3},  # a set is not JSON-serializable
+        }
+        errors = validate_row(row)
+        assert any("role must be one of" in e for e in errors)
+        assert any("not JSON-serializable" in e for e in errors)
+
+
+class TestUnexpectedTopLevelFields:
+    def test_unexpected_field_is_a_clear_issue(self):
+        row = {**_VALID_ROW, "extra_metadata": {"foo": "bar"}}
+        errors = validate_row(row)
+        assert any("unexpected field" in e and "extra_metadata" in e for e in errors)
+        # the rest of the row is otherwise valid — no unrelated errors
+        assert len(errors) == 1
+
+
+class TestCrashSafety:
+    """Malformed JSON-shaped values (lists/dicts where a string/int is
+    expected) must produce a clean issue, never raise — set-membership and
+    equality checks against user-supplied values can otherwise TypeError on
+    unhashable types."""
+
+    def test_list_role_does_not_raise(self):
+        errors = validate_row({"messages": [{"role": [], "content": "hi"}]})
+        assert any("role must be one of" in e for e in errors)
+
+    def test_dict_role_does_not_raise(self):
+        errors = validate_row({"messages": [{"role": {}, "content": "hi"}]})
+        assert any("role must be one of" in e for e in errors)
+
+    def test_dict_weight_does_not_raise(self):
+        errors = validate_row({"messages": [{"role": "assistant", "content": "hi", "weight": {}}]})
+        assert any("weight must be 0 or 1" in e for e in errors)
+
+    def test_list_weight_does_not_raise(self):
+        errors = validate_row({"messages": [{"role": "assistant", "content": "hi", "weight": []}]})
+        assert any("weight must be 0 or 1" in e for e in errors)
+
+    def test_list_content_part_type_does_not_raise(self):
+        row = {"messages": [{"role": "user", "content": [{"type": []}]}]}
+        errors = validate_row(row)
+        assert any("type must be one of" in e for e in errors)
+
+    def test_dict_content_part_type_does_not_raise(self):
+        row = {"messages": [{"role": "user", "content": [{"type": {}}]}]}
+        errors = validate_row(row)
+        assert any("type must be one of" in e for e in errors)

--- a/tests/unit/sft/test_schema.py
+++ b/tests/unit/sft/test_schema.py
@@ -1,0 +1,274 @@
+"""Tests for per-row SFT schema validation."""
+
+from __future__ import annotations
+
+from benchmax.sft.schema import validate_row
+
+_VALID_ROW = {
+    "messages": [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "yo"},
+    ]
+}
+
+
+class TestValidRows:
+    def test_minimal_valid_row(self):
+        assert validate_row(_VALID_ROW) == []
+
+    def test_valid_row_with_tools_and_weight(self):
+        row = {
+            "messages": [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "yo", "weight": 1},
+            ],
+            "tools": [{"type": "function", "function": {"name": "f", "parameters": {}}}],
+        }
+        assert validate_row(row) == []
+
+    def test_valid_row_with_tool_call_and_tool_response(self):
+        row = {
+            "messages": [
+                {"role": "user", "content": "weather?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": '{"city": "NYC"}'},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "sunny"},
+            ]
+        }
+        assert validate_row(row) == []
+
+    def test_valid_multimodal_row(self):
+        row = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                        {"type": "text", "text": "what is this"},
+                    ],
+                },
+                {"role": "assistant", "content": "a cat"},
+            ]
+        }
+        assert validate_row(row) == []
+
+    def test_multimodal_image_url_https(self):
+        row = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}],
+                },
+                {"role": "assistant", "content": "a cat"},
+            ]
+        }
+        assert validate_row(row) == []
+
+
+class TestRowShapeErrors:
+    def test_not_a_dict(self):
+        assert validate_row([1, 2, 3]) != []
+
+    def test_missing_messages(self):
+        errors = validate_row({})
+        assert any("'messages' is required" in e for e in errors)
+
+    def test_messages_not_a_list(self):
+        errors = validate_row({"messages": "oops"})
+        assert any("non-empty list" in e for e in errors)
+
+    def test_messages_empty_list(self):
+        errors = validate_row({"messages": []})
+        assert any("non-empty list" in e for e in errors)
+
+    def test_tools_not_a_list(self):
+        row = {**_VALID_ROW, "tools": {"not": "a list"}}
+        errors = validate_row(row)
+        assert any("'tools' must be a list" in e for e in errors)
+
+
+class TestRoleErrors:
+    def test_invalid_role(self):
+        row = {"messages": [{"role": "narrator", "content": "hi"}]}
+        errors = validate_row(row)
+        assert any("role must be one of" in e for e in errors)
+
+    def test_tool_role_missing_tool_call_id(self):
+        row = {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "ok"},
+                {"role": "tool", "content": "result"},
+            ]
+        }
+        errors = validate_row(row)
+        assert any("tool_call_id" in e for e in errors)
+
+
+class TestWeightErrors:
+    def test_invalid_weight_value(self):
+        row = {"messages": [{"role": "assistant", "content": "x", "weight": 0.5}]}
+        errors = validate_row(row)
+        assert any("weight must be 0 or 1" in e for e in errors)
+
+    def test_all_assistant_turns_masked_is_error(self):
+        row = {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "yo", "weight": 0},
+            ]
+        }
+        errors = validate_row(row)
+        assert any("no trained assistant turn" in e for e in errors)
+
+    def test_no_assistant_message_is_error(self):
+        row = {"messages": [{"role": "user", "content": "hi"}]}
+        errors = validate_row(row)
+        assert any("no trained assistant turn" in e for e in errors)
+
+    def test_default_weight_counts_as_trained(self):
+        row = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]}
+        assert validate_row(row) == []
+
+    def test_one_trained_one_masked_is_valid(self):
+        row = {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "a", "weight": 0},
+                {"role": "user", "content": "again"},
+                {"role": "assistant", "content": "b", "weight": 1},
+            ]
+        }
+        assert validate_row(row) == []
+
+
+class TestToolCallErrors:
+    def test_tool_call_wrong_type(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {"id": "1", "type": "oops", "function": {"name": "f", "arguments": "{}"}}
+                    ],
+                }
+            ]
+        }
+        errors = validate_row(row)
+        assert any("type must be 'function'" in e for e in errors)
+
+    def test_tool_call_missing_function(self):
+        row = {
+            "messages": [
+                {"role": "assistant", "content": None, "tool_calls": [{"id": "1", "type": "function"}]}
+            ]
+        }
+        errors = validate_row(row)
+        assert any("function must be an object" in e for e in errors)
+
+    def test_tool_call_empty_name(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {"id": "1", "type": "function", "function": {"name": "", "arguments": "{}"}}
+                    ],
+                }
+            ]
+        }
+        errors = validate_row(row)
+        assert any("non-empty string" in e for e in errors)
+
+    def test_tool_call_arguments_not_string(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {"id": "1", "type": "function", "function": {"name": "f", "arguments": {}}}
+                    ],
+                }
+            ]
+        }
+        errors = validate_row(row)
+        assert any("JSON-encoded string" in e for e in errors)
+
+    def test_tool_call_arguments_invalid_json(self):
+        row = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {"id": "1", "type": "function", "function": {"name": "f", "arguments": "{not json"}}
+                    ],
+                }
+            ]
+        }
+        errors = validate_row(row)
+        assert any("must be valid JSON" in e for e in errors)
+
+    def test_tool_calls_not_a_list(self):
+        row = {"messages": [{"role": "assistant", "content": None, "tool_calls": "oops"}]}
+        errors = validate_row(row)
+        assert any("tool_calls must be a list" in e for e in errors)
+
+
+class TestContentPartErrors:
+    def test_content_not_str_or_list(self):
+        row = {"messages": [{"role": "user", "content": 5}]}
+        errors = validate_row(row)
+        assert any("string or a list of content parts" in e for e in errors)
+
+    def test_content_part_not_dict(self):
+        row = {"messages": [{"role": "user", "content": ["oops"]}]}
+        errors = validate_row(row)
+        assert any("content[0] must be an object" in e for e in errors)
+
+    def test_content_part_unknown_type(self):
+        row = {"messages": [{"role": "user", "content": [{"type": "audio"}]}]}
+        errors = validate_row(row)
+        assert any("type must be one of" in e for e in errors)
+
+    def test_text_part_missing_text(self):
+        row = {"messages": [{"role": "user", "content": [{"type": "text"}]}]}
+        errors = validate_row(row)
+        assert any("must have a string 'text'" in e for e in errors)
+
+    def test_image_part_missing_url(self):
+        row = {"messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {}}]}]}
+        errors = validate_row(row)
+        assert any("image_url.url" in e for e in errors)
+
+    def test_image_part_bad_scheme(self):
+        row = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "image_url", "image_url": {"url": "file:///etc/passwd"}}],
+                }
+            ]
+        }
+        errors = validate_row(row)
+        assert any("image_url.url" in e for e in errors)
+
+
+class TestJsonSerializability:
+    def test_non_serializable_tool_spec_is_error(self):
+        row = {**_VALID_ROW, "tools": [{"unserializable": {1, 2, 3}}]}
+        errors = validate_row(row)
+        assert any("not JSON-serializable" in e for e in errors)

--- a/tests/unit/sft/test_validate.py
+++ b/tests/unit/sft/test_validate.py
@@ -219,3 +219,70 @@ class TestErrorClassesWithPhysicalLines:
 
         assert 1 not in by_line
         assert report.ok is False
+
+
+class TestSchemaCrashSafetyThroughFullPipeline:
+    """Malformed-but-JSON-shaped rows (list role, dict weight, etc.) must
+    survive load_sft_dataset -> validate_sft_dataset as ordinary error
+    issues, never as an uncaught exception."""
+
+    def test_list_role_produces_report_not_exception(self, tmp_path):
+        path = _write(tmp_path, "train.jsonl", '{"messages": [{"role": [], "content": "hi"}]}\n')
+        train = load_sft_dataset(path)
+        report = validate_sft_dataset(train)  # must not raise
+        assert any(i.severity == "error" for i in report.issues)
+        assert report.ok is False
+
+    def test_dict_weight_produces_report_not_exception(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "train.jsonl",
+            '{"messages": [{"role": "assistant", "content": "hi", "weight": {}}]}\n',
+        )
+        train = load_sft_dataset(path)
+        report = validate_sft_dataset(train)  # must not raise
+        assert any(i.severity == "error" for i in report.issues)
+
+    def test_list_content_part_type_produces_report_not_exception(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "train.jsonl",
+            '{"messages": [{"role": "user", "content": [{"type": []}]}, '
+            '{"role": "assistant", "content": "hi"}]}\n',
+        )
+        train = load_sft_dataset(path)
+        report = validate_sft_dataset(train)  # must not raise
+        assert any(i.severity == "error" for i in report.issues)
+
+
+class TestSerializationGuard:
+    def test_unserializable_row_reports_error_without_crashing_row_size_check(self):
+        # A row built directly (bypassing the loader's NaN/type guards) with
+        # a non-serializable value must not crash validate_sft_dataset's
+        # row-size measurement — it should surface as an issue instead.
+        row_with_set = {**_TRAINED_ROW, "tools": [{"bad": {1, 2, 3}}]}
+        train = _dataset("train.jsonl", [row_with_set])
+        report = validate_sft_dataset(train)  # must not raise
+        assert any("not JSON-serializable" in i.message for i in report.issues)
+        assert not any("max_row_bytes" in i.message for i in report.issues)
+
+    def test_structural_error_and_serialization_error_both_surface(self):
+        row = {
+            "messages": [{"role": "not-a-real-role", "content": "hi"}],
+            "extra_metadata": {1, 2, 3},  # a set is not JSON-serializable
+        }
+        train = _dataset("train.jsonl", [row])
+        report = validate_sft_dataset(train)  # must not raise
+        errors = [i.message for i in report.issues if i.severity == "error"]
+        assert any("role must be one of" in m for m in errors)
+        assert any("not JSON-serializable" in m for m in errors)
+
+    def test_nan_rejected_at_load_never_reaches_validate(self, tmp_path):
+        path = _write(
+            tmp_path, "train.jsonl", '{"messages": [{"role": "assistant", "content": NaN}]}\n'
+        )
+        train = load_sft_dataset(path)  # NaN rejected at load — not a valid row
+        assert train.rows == []
+        assert any(i.severity == "error" for i in train.load_issues)
+        report = validate_sft_dataset(train)  # must not raise
+        assert report.ok is False

--- a/tests/unit/sft/test_validate.py
+++ b/tests/unit/sft/test_validate.py
@@ -313,6 +313,22 @@ class TestEmptyTextContentPartFullPipeline:
         report = validate_sft_dataset(train)
         assert report.ok is True
 
+    def test_non_canonical_content_key_fallback_does_not_count_as_trained(self, tmp_path):
+        # a stray `content` key alongside an empty `text` must not smuggle a
+        # trained turn past the empty-text-part rule.
+        text = (
+            '{"messages": [{"role": "assistant", '
+            '"content": [{"type": "text", "text": "", "content": "fallback"}]}]}\n'
+        )
+        path = _write(tmp_path, "train.jsonl", text)
+        train = load_sft_dataset(path)
+        report = validate_sft_dataset(train)
+        assert report.ok is False
+        assert any(
+            i.severity == "error" and "no trained assistant turn" in i.message
+            for i in report.issues
+        )
+
 
 class TestToolCallArgumentsNonFiniteFullPipeline:
     def test_nan_in_tool_call_arguments_produces_error_not_exception(self, tmp_path):

--- a/tests/unit/sft/test_validate.py
+++ b/tests/unit/sft/test_validate.py
@@ -286,3 +286,55 @@ class TestSerializationGuard:
         assert any(i.severity == "error" for i in train.load_issues)
         report = validate_sft_dataset(train)  # must not raise
         assert report.ok is False
+
+
+class TestEmptyTextContentPartFullPipeline:
+    def test_only_empty_text_part_does_not_count_as_trained(self, tmp_path):
+        text = (
+            '{"messages": [{"role": "user", "content": "hi"}, '
+            '{"role": "assistant", "content": [{"type": "text", "text": ""}]}]}\n'
+        )
+        path = _write(tmp_path, "train.jsonl", text)
+        train = load_sft_dataset(path)
+        report = validate_sft_dataset(train)
+        assert report.ok is False
+        assert any(
+            i.severity == "error" and "no trained assistant turn" in i.message
+            for i in report.issues
+        )
+
+    def test_non_empty_text_part_counts_as_trained(self, tmp_path):
+        text = (
+            '{"messages": [{"role": "user", "content": "hi"}, '
+            '{"role": "assistant", "content": [{"type": "text", "text": "hi there"}]}]}\n'
+        )
+        path = _write(tmp_path, "train.jsonl", text)
+        train = load_sft_dataset(path)
+        report = validate_sft_dataset(train)
+        assert report.ok is True
+
+
+class TestToolCallArgumentsNonFiniteFullPipeline:
+    def test_nan_in_tool_call_arguments_produces_error_not_exception(self, tmp_path):
+        text = (
+            '{"messages": [{"role": "assistant", "content": null, "tool_calls": '
+            '[{"id": "1", "type": "function", "function": {"name": "f", '
+            '"arguments": "{\\"score\\": NaN}"}}]}]}\n'
+        )
+        path = _write(tmp_path, "train.jsonl", text)
+        train = load_sft_dataset(path)
+        report = validate_sft_dataset(train)  # must not raise
+        assert report.ok is False
+        assert any("must be valid JSON" in i.message for i in report.issues)
+
+
+class TestLoneSurrogateFullPipeline:
+    def test_lone_surrogate_content_produces_error_not_exception(self, tmp_path):
+        path = _write(
+            tmp_path, "train.jsonl", '{"messages": [{"role": "assistant", "content": "\\ud800"}]}\n'
+        )
+        train = load_sft_dataset(path)  # valid JSON syntax — loads fine
+        assert len(train.rows) == 1
+        report = validate_sft_dataset(train)  # must not raise
+        assert report.ok is False
+        assert any("not JSON-serializable" in i.message for i in report.issues)

--- a/tests/unit/sft/test_validate.py
+++ b/tests/unit/sft/test_validate.py
@@ -1,0 +1,221 @@
+"""Tests for validate_sft_dataset / SftValidationReport."""
+
+from __future__ import annotations
+
+import json
+
+from benchmax.sft.dataset import SftDataset, SftRow, load_sft_dataset
+from benchmax.sft.validate import DEFAULT_MAX_ROW_BYTES, validate_sft_dataset
+
+_TRAINED_ROW = {
+    "messages": [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "yo"},
+    ]
+}
+
+
+def _dataset(path: str, rows_data: list[dict]) -> SftDataset:
+    rows = [SftRow(path, i + 1, data) for i, data in enumerate(rows_data)]
+    return SftDataset(path=path, rows=rows, load_issues=[])
+
+
+def _write(tmp_path, name, text):
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class TestValidDataset:
+    def test_ok_true_with_no_issues(self):
+        train = _dataset("train.jsonl", [_TRAINED_ROW])
+        report = validate_sft_dataset(train)
+        assert report.ok is True
+        assert bool(report) is True
+        assert not any(i.severity == "error" for i in report.issues)
+        assert report.train_row_count == 1
+        assert report.eval_row_count == 0
+
+    def test_multimodal_row_is_ok(self):
+        row = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+                        {"type": "text", "text": "what is this"},
+                    ],
+                },
+                {"role": "assistant", "content": "a cat"},
+            ]
+        }
+        train = _dataset("train.jsonl", [row])
+        report = validate_sft_dataset(train)
+        assert report.ok is True
+
+
+class TestEmptyTrain:
+    def test_empty_train_is_not_ok(self):
+        train = _dataset("train.jsonl", [])
+        report = validate_sft_dataset(train)
+        assert report.train_row_count == 0
+        assert report.ok is False
+        assert bool(report) is False
+        assert any(
+            i.severity == "error" and "train dataset is empty" in i.message for i in report.issues
+        )
+
+    def test_empty_train_via_load_sft_dataset(self, tmp_path):
+        path = _write(tmp_path, "train.jsonl", "\n\n")
+        train = load_sft_dataset(path)
+        report = validate_sft_dataset(train)
+        assert report.ok is False
+
+
+class TestEmptyEval:
+    def test_absent_eval_is_notice(self):
+        train = _dataset("train.jsonl", [_TRAINED_ROW])
+        report = validate_sft_dataset(train)
+        assert report.ok is True
+        notices = [i for i in report.issues if i.severity == "notice"]
+        assert any("no eval dataset provided" in i.message for i in notices)
+
+    def test_empty_eval_dataset_is_notice_not_error(self):
+        train = _dataset("train.jsonl", [_TRAINED_ROW])
+        eval_ds = _dataset("eval.jsonl", [])
+        report = validate_sft_dataset(train, eval_ds)
+        assert report.ok is True
+        assert report.eval_row_count == 0
+        notice = next(i for i in report.issues if "eval dataset is empty" in i.message)
+        assert notice.severity == "notice"
+
+    def test_nonempty_eval_counted(self):
+        train = _dataset("train.jsonl", [_TRAINED_ROW])
+        eval_ds = _dataset("eval.jsonl", [_TRAINED_ROW, _TRAINED_ROW])
+        report = validate_sft_dataset(train, eval_ds)
+        assert report.eval_row_count == 2
+        assert not any("no eval dataset" in i.message or "eval dataset is empty" in i.message for i in report.issues)
+
+
+class TestWeightNotice:
+    def test_weight_present_is_notice_not_error(self):
+        row = {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "yo", "weight": 1},
+            ]
+        }
+        train = _dataset("train.jsonl", [row])
+        report = validate_sft_dataset(train)
+        assert report.ok is True
+        weight_issues = [i for i in report.issues if "weight" in i.message and i.severity == "notice"]
+        assert len(weight_issues) == 1
+
+    def test_masking_summary_counts_trained_and_masked(self):
+        row = {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "a", "weight": 0},
+                {"role": "user", "content": "again"},
+                {"role": "assistant", "content": "b", "weight": 1},
+            ]
+        }
+        no_weight_row = _TRAINED_ROW
+        train = _dataset("train.jsonl", [row, no_weight_row])
+        report = validate_sft_dataset(train)
+        assert report.masking_summary.rows_with_weight == 1
+        assert report.masking_summary.masked_assistant_messages == 1
+        # trained: weight=1 message in `row`, plus the implicit-weight assistant message in no_weight_row
+        assert report.masking_summary.trained_assistant_messages == 2
+
+    def test_no_weight_rows_have_zero_masking_summary(self):
+        train = _dataset("train.jsonl", [_TRAINED_ROW])
+        report = validate_sft_dataset(train)
+        assert report.masking_summary.rows_with_weight == 0
+        assert report.masking_summary.masked_assistant_messages == 0
+        assert report.masking_summary.trained_assistant_messages == 1
+
+
+class TestRowSizeNotice:
+    def test_row_at_default_max_row_bytes_gets_notice(self):
+        big_content = "x" * (DEFAULT_MAX_ROW_BYTES + 1000)
+        row = {
+            "messages": [
+                {"role": "user", "content": big_content},
+                {"role": "assistant", "content": "ok"},
+            ]
+        }
+        assert len(json.dumps(row).encode("utf-8")) >= DEFAULT_MAX_ROW_BYTES
+        train = _dataset("train.jsonl", [row])
+        report = validate_sft_dataset(train)
+        size_notices = [i for i in report.issues if "max_row_bytes" in i.message]
+        assert len(size_notices) == 1
+        assert size_notices[0].severity == "notice"
+
+    def test_small_row_gets_no_size_notice(self):
+        train = _dataset("train.jsonl", [_TRAINED_ROW])
+        report = validate_sft_dataset(train)
+        assert not any("max_row_bytes" in i.message for i in report.issues)
+
+
+class TestTokenLengthStats:
+    def test_stats_reflect_char_over_four_heuristic(self):
+        row_a = {
+            "messages": [
+                {"role": "user", "content": "a" * 40},
+                {"role": "assistant", "content": "b" * 40},
+            ]
+        }
+        row_b = {
+            "messages": [
+                {"role": "user", "content": "c" * 4},
+                {"role": "assistant", "content": "d" * 4},
+            ]
+        }
+        train = _dataset("train.jsonl", [row_a, row_b])
+        report = validate_sft_dataset(train)
+        stats = report.token_length_stats
+        assert stats.max_tokens == 80 // 4
+        assert stats.min_tokens == 8 // 4
+        assert stats.rows_over_max_seq_len == 0
+
+    def test_row_over_max_seq_len_flagged_as_notice(self):
+        row = {
+            "messages": [
+                {"role": "user", "content": "a" * 400},
+                {"role": "assistant", "content": "ok"},
+            ]
+        }
+        train = _dataset("train.jsonl", [row])
+        report = validate_sft_dataset(train, max_seq_len=10)
+        assert report.token_length_stats.rows_over_max_seq_len == 1
+        notice = next(i for i in report.issues if "max_seq_len" in i.message)
+        assert notice.severity == "notice"
+        assert report.ok is True  # a heuristic overflow never blocks the gate
+
+
+class TestErrorClassesWithPhysicalLines:
+    def test_physical_lines_survive_blanks_and_malformed_json(self, tmp_path):
+        text = (
+            '{"messages": [{"role": "user", "content": "hi"}, '
+            '{"role": "assistant", "content": "yo"}]}\n'
+            "\n"
+            "{not valid json\n"
+            '{"messages": []}\n'
+        )
+        path = _write(tmp_path, "train.jsonl", text)
+        train = load_sft_dataset(path)
+
+        assert [r.physical_line for r in train.rows] == [1, 4]
+
+        report = validate_sft_dataset(train)
+        by_line = {i.physical_line: i for i in report.issues if i.severity == "error"}
+
+        assert 3 in by_line
+        assert "invalid JSON" in by_line[3].message
+
+        assert 4 in by_line
+        assert "non-empty list" in by_line[4].message
+
+        assert 1 not in by_line
+        assert report.ok is False


### PR DESCRIPTION
## Summary

Slice 3 of `docs/plans/sft-multimodal-interface.md` (Revision 4): the `benchmax/sft` package — the canonicalization boundary, row schema, legacy-shape normalization, and dataset-level validation for env-less SFT.

- `dataset.py` — `load_sft_dataset(path) -> SftDataset` reads raw JSONL itself (not `cli/_project.py`'s `_load_jsonl`), retains per-row `(source_path, physical_line)` provenance (1-indexed, counting blanks), turns malformed JSON / non-object rows into per-line error issues instead of raising, and normalizes every row on load. `canonical_jsonl(dataset) -> bytes` is the only serialization the upload path will accept.
- `schema.py` — structural row validation: role shape, ≥1 trained assistant turn (weight-aware), well-formed tool calls, well-formed content parts (text/image_url, `data:`/`https:` only), JSON-serializability.
- `normalize.py` — legacy shapes → canonical rows: `prompt_messages`/`completion_messages` split, bare `prompt`/`completion` strings, flat tool-call format → nested. Self-contained; multimodal content parts and per-message `weight` pass through untouched.
- `validate.py` — `validate_sft_dataset(train, eval=None, max_seq_len=8192, max_row_bytes=1 MiB) -> SftValidationReport`. `ok == (no error-severity issues) and (train row count >= 1)`; empty eval is a notice, not an error. Report carries issues, row counts, char/4 token-length stats, and a weight/masking summary.

Public surface: `benchmax.sft` exports `load_sft_dataset`, `validate_sft_dataset`, `SftDataset`, `SftValidationReport`.

Stacked on #71 (slice 1 content helpers), itself on #70 (slice 0 baseline). Out of scope here: CLI wiring (slice 5), platform upload plumbing (slice 4), scaffold template (slice 6).

## Test plan
- [x] `uv run pytest tests/unit/sft` — 66 passed (valid rows, every schema error class, weight notice, multimodal rows, split-format round-trip, row-size notice at 1 MiB, empty-train → `ok is False`, empty-eval → notice, physical line numbers through blanks + malformed JSON, canonicalization-preservation of `tools`/tool calls/`weight`/multimodal parts)
- [x] `uv run pytest tests/unit` — 1209 passed, 3 skipped
- [x] `uv run ruff check src/` — clean on `src/benchmax/sft/` (3 pre-existing unrelated errors elsewhere, present on main)