### PR TITLE
Add SFT platform plumbing: upload_sft_run + launch_sft_run

### DIFF
--- a/src/benchmax/platform/__init__.py
+++ b/src/benchmax/platform/__init__.py
@@ -2,7 +2,12 @@
 
 from .client import RolloutClient, StorageClient, TrainerClient
 from .credentials import platform_bearer
-from .training_run import UploadedTrainingRun, upload_training_run
+from .training_run import (
+    UploadedSftRun,
+    UploadedTrainingRun,
+    upload_sft_run,
+    upload_training_run,
+)
 from .validation import ValidationReport, validate_env
 
 # Imported last: login depends on credentials/device_auth (siblings), so this
@@ -13,6 +18,7 @@ __all__ = [
     "RolloutClient",
     "StorageClient",
     "TrainerClient",
+    "UploadedSftRun",
     "UploadedTrainingRun",
     "ValidationReport",
     # The seam token-getter: generated scripts pass it to a raw OpenAI client
@@ -20,6 +26,7 @@ __all__ = [
     # ensure_session — not just an internal credentials helper.
     "platform_bearer",
     "ensure_session",
+    "upload_sft_run",
     "upload_training_run",
     "validate_env",
 ]

--- a/src/benchmax/platform/client.py
+++ b/src/benchmax/platform/client.py
@@ -55,21 +55,30 @@ _UNKNOWN_LAUNCH_ARG_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Required alongside _UNKNOWN_LAUNCH_ARG_RE: an unknown-arg rejection about a
+# DIFFERENT arg name (a bad user-supplied launcher arg, an argument-worded
+# dataset-path error) must not be misclassified as "SFT unsupported" — only a
+# response that also names training_mode qualifies.
+_TRAINING_MODE_RE = re.compile(r"training[_\s-]?mode", re.IGNORECASE)
+
 
 def _looks_like_unknown_launch_arg_rejection(
     status_code: int | None, message: str
 ) -> bool:
     """Narrow, loose heuristic for the platform's unknown-launch-arg 4xx.
 
-    Deliberately conservative: requires both a 4xx status AND wording that
-    plausibly names an unrecognized/unknown argument, so ordinary 4xx
-    failures (bad dataset path, validation errors unrelated to arg names)
-    don't get misclassified. See the module-level TODO above — not a
-    stable contract.
+    Deliberately conservative: requires a 4xx status, wording that plausibly
+    names an unrecognized/unknown argument, AND a mention of training_mode
+    specifically — so an unrelated unknown-arg rejection (a bad user-supplied
+    launcher arg, an argument-worded bad-dataset-path error) doesn't get
+    misclassified as "the platform doesn't support SFT". See the
+    module-level TODO above — not a stable contract.
     """
     if status_code is None or not (400 <= status_code < 500):
         return False
-    return bool(_UNKNOWN_LAUNCH_ARG_RE.search(message))
+    return bool(_UNKNOWN_LAUNCH_ARG_RE.search(message)) and bool(
+        _TRAINING_MODE_RE.search(message)
+    )
 
 
 @dataclass(frozen=True)
@@ -560,7 +569,12 @@ class TrainerClient:
             "training_mode": "sft",
             "train_dataset_path": train_dataset_path,
         }
-        if eval_dataset_path is not None:
+        # Reconcile the reserved key against the explicit parameter last —
+        # launcher_args must never be able to smuggle an eval path back in
+        # (or clobber one) once eval_dataset_path has decided the outcome.
+        if eval_dataset_path is None:
+            args.pop("eval_dataset_path", None)
+        else:
             args["eval_dataset_path"] = eval_dataset_path
         body: dict[str, Any] = {
             "name": name,
@@ -575,9 +589,9 @@ class TrainerClient:
         except JobLaunchError as exc:
             if _looks_like_unknown_launch_arg_rejection(exc.status_code, exc.message):
                 raise SftLaunchNotSupportedError(
-                    "The platform does not accept env-less SFT runs yet "
+                    "the platform does not accept env-less SFT runs yet "
                     '("training_mode" is not a recognized launch arg). '
-                    "Wait for platform support to land, or track "
+                    "wait for platform support to land, or track "
                     "benchmax.platform.client.SFT_LAUNCH_SUPPORTED.",
                     exc.status_code,
                 ) from exc

--- a/src/benchmax/platform/client.py
+++ b/src/benchmax/platform/client.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import json
 import logging
+import re
 import textwrap
 import warnings
 from collections.abc import Iterator
@@ -25,6 +26,7 @@ from .exceptions import (
     RolloutNotFound,
     RolloutServerError,
     RolloutStreamError,
+    SftLaunchNotSupportedError,
     TrainerError,
 )
 
@@ -34,6 +36,40 @@ if TYPE_CHECKING:
     from types import ModuleType
 
     from benchmax.envs.base_env import BaseEnv
+
+
+# Flip to True once platform-service accepts `training_mode` as a recognized
+# POST /v1/train/runs/launch arg (see TrainerClient.launch_sft_run). Not
+# consumed anywhere in this module — the CLI/scaffold launch path gates its
+# pre-upload guard on this flag.
+SFT_LAUNCH_SUPPORTED = False
+
+# Best-effort, UNVERIFIED match for platform-service's "unrecognized launch
+# argument" rejection — the plan that motivated launch_sft_run points at
+# platform-service's src/lib/trainer-args.ts:425 for the real message, but
+# that repo isn't checked out here, so this hasn't been confirmed against a
+# live response. TODO: verify the actual message once platform-service is
+# reachable, and tighten/loosen this pattern accordingly.
+_UNKNOWN_LAUNCH_ARG_RE = re.compile(
+    r"\b(?:unrecogni[sz]ed|unknown)\b[^.]{0,40}\barg(?:ument)?s?\b",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_unknown_launch_arg_rejection(
+    status_code: int | None, message: str
+) -> bool:
+    """Narrow, loose heuristic for the platform's unknown-launch-arg 4xx.
+
+    Deliberately conservative: requires both a 4xx status AND wording that
+    plausibly names an unrecognized/unknown argument, so ordinary 4xx
+    failures (bad dataset path, validation errors unrelated to arg names)
+    don't get misclassified. See the module-level TODO above — not a
+    stable contract.
+    """
+    if status_code is None or not (400 <= status_code < 500):
+        return False
+    return bool(_UNKNOWN_LAUNCH_ARG_RE.search(message))
 
 
 @dataclass(frozen=True)
@@ -478,6 +514,78 @@ class TrainerClient:
         for warning in body.get("warnings", []) or []:
             warnings.warn(f"launch warning: {warning}", stacklevel=2)
         return body["runId"]
+
+    def launch_sft_run(
+        self,
+        name: str,
+        train_dataset_path: str,
+        eval_dataset_path: str | None = None,
+        launcher_args: dict[str, Any] | None = None,
+    ) -> str:
+        """Launch a new SFT (env-less) training run.
+
+        Posts ``training_mode: "sft"`` alongside the dataset paths. As of
+        writing, ``SFT_LAUNCH_SUPPORTED`` is ``False``: the live platform
+        does not yet recognize ``training_mode`` as a launch arg, so this
+        call is expected to fail against it — callers should gate on that
+        flag before calling this method at all (see the module docstring).
+
+        Args:
+            name: Name for the training run.
+            train_dataset_path: Path to the uploaded training dataset (see
+                ``upload_sft_run``).
+            eval_dataset_path: Path to the uploaded eval dataset, or ``None``
+                to omit eval entirely. ``None`` OMITS the eval field from the
+                request payload — no empty string, no null field — mirroring
+                ``upload_sft_run``'s optional-eval behavior.
+            launcher_args: Extra launcher args forwarded to the server.
+
+        Returns:
+            The training run ID.
+
+        Raises:
+            AuthenticationError: If API key is invalid.
+            SftLaunchNotSupportedError: If the platform's response looks like
+                its unknown-launch-arg rejection (see
+                ``_looks_like_unknown_launch_arg_rejection`` — a narrow,
+                UNVERIFIED heuristic, not a stable contract). The original
+                error is preserved as ``__cause__`` with its status code
+                intact.
+            JobLaunchError: Any other training-run launch failure — auth,
+                conflict, rate limit, server error, bad dataset path —
+                propagates unchanged.
+        """
+        args: dict[str, Any] = {
+            **(launcher_args or {}),
+            "training_mode": "sft",
+            "train_dataset_path": train_dataset_path,
+        }
+        if eval_dataset_path is not None:
+            args["eval_dataset_path"] = eval_dataset_path
+        body: dict[str, Any] = {
+            "name": name,
+            "args": args,
+        }
+        try:
+            response = self._http_client.post(
+                "/v1/train/runs/launch",
+                json=body,
+            )
+            self._handle_response_errors(response)
+        except JobLaunchError as exc:
+            if _looks_like_unknown_launch_arg_rejection(exc.status_code, exc.message):
+                raise SftLaunchNotSupportedError(
+                    "The platform does not accept env-less SFT runs yet "
+                    '("training_mode" is not a recognized launch arg). '
+                    "Wait for platform support to land, or track "
+                    "benchmax.platform.client.SFT_LAUNCH_SUPPORTED.",
+                    exc.status_code,
+                ) from exc
+            raise
+        response_body = response.json()
+        for warning in response_body.get("warnings", []) or []:
+            warnings.warn(f"launch warning: {warning}", stacklevel=2)
+        return response_body["runId"]
 
     def list_launch_args(self) -> list[LaunchArgSpec]:
         """Fetch the schema of launch args this platform accepts.

--- a/src/benchmax/platform/exceptions.py
+++ b/src/benchmax/platform/exceptions.py
@@ -22,6 +22,20 @@ class JobLaunchError(TrainerError):
     pass
 
 
+class SftLaunchNotSupportedError(JobLaunchError):
+    """The platform rejected an SFT launch as an unrecognized launch arg.
+
+    Raised only by ``TrainerClient.launch_sft_run`` when the response looks
+    like the platform's generic unknown-launch-arg rejection — a narrow,
+    best-effort heuristic (see that method's docstring for the exact match
+    and its verification caveat). Subclasses ``JobLaunchError`` so existing
+    ``except JobLaunchError`` call sites keep working; the original response
+    error is preserved as ``__cause__``.
+    """
+
+    pass
+
+
 class RolloutError(TrainerError):
     """Base for rollout-server errors. Carries HTTP status when available."""
 

--- a/src/benchmax/platform/training_run.py
+++ b/src/benchmax/platform/training_run.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from benchmax import config
 from benchmax.bundle import dump_bundle
+from benchmax.sft.dataset import SftDataset, canonical_jsonl
 
 from .client import StorageClient
 
@@ -44,6 +45,18 @@ class UploadedTrainingRun:
     env_metadata_path: str
     train_dataset_path: str
     eval_dataset_path: str
+
+
+@dataclass(frozen=True)
+class UploadedSftRun:
+    """Blob paths for an SFT run's uploaded datasets.
+
+    ``eval_dataset_path`` is ``None`` when no eval dataset was supplied to
+    :func:`upload_sft_run` — nothing is uploaded for eval in that case.
+    """
+
+    train_dataset_path: str
+    eval_dataset_path: str | None = None
 
 
 # Mirrors the platform's blob-path guard (isSafeBlobPath): the upload endpoint
@@ -127,35 +140,32 @@ def upload_training_run(
         local_modules=local_modules,
     )
 
-    train_jsonl = "\n".join(json.dumps(r) for r in train_dataset) + "\n"
-    eval_jsonl = "\n".join(json.dumps(r) for r in eval_dataset) + "\n"
+    train_jsonl = ("\n".join(json.dumps(r) for r in train_dataset) + "\n").encode()
+    eval_jsonl = ("\n".join(json.dumps(r) for r in eval_dataset) + "\n").encode()
 
     if env_prefix is None:
         env_hash = hashlib.sha256(bundle.pickled).hexdigest()[:16]
         env_prefix = f"envs/{run_name}/{env_hash}"
 
-    if dataset_prefix is None:
-        dataset_hash = hashlib.sha256(
-            train_jsonl.encode() + eval_jsonl.encode()
-        ).hexdigest()[:8]
-        dataset_prefix = f"datasets/{run_name}/{dataset_hash}"
-
     # Reject unsafe keys before uploading — covers both the run_name-derived
-    # defaults and any caller-supplied env_prefix/dataset_prefix override.
+    # defaults and any caller-supplied env_prefix override.
     _validate_blob_path(env_prefix, source="env_prefix/run_name")
-    _validate_blob_path(dataset_prefix, source="dataset_prefix/run_name")
 
     with tempfile.TemporaryDirectory() as tmp:
         tmpdir = Path(tmp)
         cls_local = tmpdir / "env-cls.pkl"
         meta_local = tmpdir / "env-metadata.json"
-        train_local = tmpdir / "train.jsonl"
-        eval_local = tmpdir / "eval.jsonl"
 
         cls_local.write_bytes(bundle.pickled)
         meta_local.write_bytes(bundle.metadata.to_json_bytes())
-        train_local.write_text(train_jsonl)
-        eval_local.write_text(eval_jsonl)
+
+        train_path, eval_path = _upload_dataset_pair(
+            storage_client=storage_client,
+            train_jsonl=train_jsonl,
+            eval_jsonl=eval_jsonl,
+            run_name=run_name,
+            dataset_prefix=dataset_prefix,
+        )
 
         return UploadedTrainingRun(
             env_cls_path=storage_client.upload_local_file(
@@ -164,10 +174,109 @@ def upload_training_run(
             env_metadata_path=storage_client.upload_local_file(
                 f"{env_prefix}/env-metadata.json", meta_local
             )["blobPath"],
-            train_dataset_path=storage_client.upload_local_file(
-                f"{dataset_prefix}/train.jsonl", train_local
-            )["blobPath"],
-            eval_dataset_path=storage_client.upload_local_file(
-                f"{dataset_prefix}/eval.jsonl", eval_local
-            )["blobPath"],
+            train_dataset_path=train_path,
+            # eval_jsonl is always provided here (never None), so eval_path is
+            # always a str — the SFT path is the only caller that sees None.
+            eval_dataset_path=eval_path,  # type: ignore[arg-type]
         )
+
+
+def _upload_dataset_pair(
+    *,
+    storage_client: StorageClient,
+    train_jsonl: bytes,
+    eval_jsonl: bytes | None,
+    run_name: str,
+    dataset_prefix: str | None,
+) -> tuple[str, str | None]:
+    """Upload a train (+ optional eval) JSONL pair to ``datasets/<run>/<hash>/``.
+
+    The reusable dataset-upload half shared by :func:`upload_training_run`
+    (eval always present) and :func:`upload_sft_run` (eval optional).
+    ``eval_jsonl=None`` uploads nothing for eval and returns ``None`` for its
+    path. The prefix hash covers whatever bytes are actually uploaded, so
+    train-only and train+eval runs land in different hash buckets.
+    """
+    if dataset_prefix is None:
+        hashed = train_jsonl + (eval_jsonl or b"")
+        dataset_hash = hashlib.sha256(hashed).hexdigest()[:8]
+        dataset_prefix = f"datasets/{run_name}/{dataset_hash}"
+
+    _validate_blob_path(dataset_prefix, source="dataset_prefix/run_name")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+
+        train_local = tmpdir / "train.jsonl"
+        train_local.write_bytes(train_jsonl)
+        train_path = storage_client.upload_local_file(
+            f"{dataset_prefix}/train.jsonl", train_local
+        )["blobPath"]
+
+        eval_path: str | None = None
+        if eval_jsonl is not None:
+            eval_local = tmpdir / "eval.jsonl"
+            eval_local.write_bytes(eval_jsonl)
+            eval_path = storage_client.upload_local_file(
+                f"{dataset_prefix}/eval.jsonl", eval_local
+            )["blobPath"]
+
+    return train_path, eval_path
+
+
+def upload_sft_run(
+    *,
+    train: SftDataset,
+    eval: SftDataset | None = None,
+    run_name: str,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    dataset_prefix: str | None = None,
+    storage_client: StorageClient | None = None,
+) -> UploadedSftRun:
+    """Serialize an SFT train (+ optional eval) dataset and upload it.
+
+    Serializes rows via :func:`benchmax.sft.dataset.canonical_jsonl` only —
+    the canonicalization boundary's upload side; there is no raw-rows entry
+    point. ``eval=None`` uploads nothing for eval and ``eval_dataset_path``
+    on the result is ``None``.
+
+    Default layout: ``datasets/<run_name>/<dataset_hash>/{train.jsonl,
+    eval.jsonl}`` (hash is sha256 of the uploaded bytes, truncated to 8 hex
+    chars — omits eval bytes when there's no eval dataset).
+
+    Args:
+        train: Canonicalized training dataset (see ``sft.load_sft_dataset``).
+        eval: Canonicalized eval dataset, or ``None`` to skip eval entirely.
+        run_name: Training run identifier; used as the storage path segment.
+        api_key: Platform API key. Optional — when omitted (and no
+            ``storage_client`` is passed) the bearer resolves per request via
+            the credential seam (``ACT_AS_TOKEN_PATH`` / ``PLATFORM_API_KEY``).
+        base_url: Platform base URL. Defaults to ``config.platform_url()``.
+        dataset_prefix: Override the default dataset directory. When set,
+            JSONL files land at ``<dataset_prefix>/{train.jsonl, eval.jsonl}``.
+        storage_client: BYOC. Pass an existing client to reuse its connection
+            pool, custom timeouts, or test fakes. Otherwise constructed from
+            ``api_key``/``base_url``.
+
+    Returns:
+        UploadedSftRun with the train path and the optional eval path.
+    """
+    if storage_client is None:
+        storage_client = StorageClient(
+            api_key=api_key,
+            base_url=base_url or config.platform_url(),
+        )
+
+    train_jsonl = canonical_jsonl(train)
+    eval_jsonl = canonical_jsonl(eval) if eval is not None else None
+
+    train_path, eval_path = _upload_dataset_pair(
+        storage_client=storage_client,
+        train_jsonl=train_jsonl,
+        eval_jsonl=eval_jsonl,
+        run_name=run_name,
+        dataset_prefix=dataset_prefix,
+    )
+
+    return UploadedSftRun(train_dataset_path=train_path, eval_dataset_path=eval_path)

--- a/tests/unit/platform/test_client.py
+++ b/tests/unit/platform/test_client.py
@@ -1215,3 +1215,87 @@ def test_launch_sft_run_propagates_401_as_authentication_error():
         trainer.launch_sft_run("r", train_dataset_path="a")
 
     assert exc_info.value.status_code == 401
+
+
+def test_launch_sft_run_unsupported_message_is_lowercase_display_copy():
+    """Regression: user-facing display copy stays lowercase (house rule) —
+    sentence starts must not be capitalized. Proper nouns / machine codes
+    ("training_mode", the module path) are exempt."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400, json={"error": 'Unrecognized launch argument: "training_mode"'}
+        )
+
+    trainer = _make_trainer_with_transport(handler)
+    with pytest.raises(SftLaunchNotSupportedError) as exc_info:
+        trainer.launch_sft_run("r", train_dataset_path="a")
+
+    message = str(exc_info.value)
+    sentences = [s.strip() for s in message.split(". ") if s.strip()]
+    for sentence in sentences:
+        first_word = sentence.split()[0]
+        assert first_word[:1].islower(), f"capitalized sentence start: {sentence!r}"
+
+
+def test_launch_sft_run_eval_none_wins_over_conflicting_launcher_arg():
+    """Regression: eval_dataset_path=None must omit the field even when
+    launcher_args tries to smuggle one in under the same reserved key."""
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        captured["body"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"runId": "sft-run-4"})
+
+    trainer = _make_trainer_with_transport(handler)
+    trainer.launch_sft_run(
+        "r",
+        train_dataset_path="a",
+        eval_dataset_path=None,
+        launcher_args={"eval_dataset_path": "sneaky/eval.jsonl"},
+    )
+
+    assert "eval_dataset_path" not in captured["body"]["args"]
+
+
+def test_launch_sft_run_unknown_arg_error_for_a_different_arg_is_not_translated():
+    """Regression: an unrecognized-launch-arg rejection about a DIFFERENT
+    (user-supplied) arg — no training_mode mention — must propagate as a
+    plain JobLaunchError, not the SFT-unsupported translation."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400, json={"error": 'Unrecognized launch argument: "num_epochs"'}
+        )
+
+    trainer = _make_trainer_with_transport(handler)
+    with pytest.raises(JobLaunchError) as exc_info:
+        trainer.launch_sft_run(
+            "r", train_dataset_path="a", launcher_args={"num_epochs": 3}
+        )
+
+    assert type(exc_info.value) is JobLaunchError
+    assert exc_info.value.status_code == 400
+
+
+def test_launch_sft_run_argument_worded_bad_dataset_path_is_not_translated():
+    """Regression: a bad-dataset-path error that happens to use unknown-arg
+    wording, but never mentions training_mode, must propagate unchanged."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "error": "Unknown argument value for train_dataset_path: "
+                "path does not exist in storage"
+            },
+        )
+
+    trainer = _make_trainer_with_transport(handler)
+    with pytest.raises(JobLaunchError) as exc_info:
+        trainer.launch_sft_run("r", train_dataset_path="a")
+
+    assert type(exc_info.value) is JobLaunchError
+    assert exc_info.value.status_code == 400

--- a/tests/unit/platform/test_client.py
+++ b/tests/unit/platform/test_client.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from benchmax.platform.client import (
+    SFT_LAUNCH_SUPPORTED,
     ExampleValidation,
     LaunchArgSpec,
     RolloutClient,
@@ -18,8 +19,10 @@ from benchmax.platform.client import (
 )
 from benchmax.platform.exceptions import (
     AuthenticationError,
+    JobLaunchError,
     RolloutNotFound,
     RolloutServerError,
+    SftLaunchNotSupportedError,
 )
 
 
@@ -1078,3 +1081,137 @@ def test_validation_result_group_reward_folds_into_ok():
         examples=passing, group_reward=ExampleValidation(-1, False, "boom")
     )
     assert bad.ok is False
+
+
+# ---------------------------------------------------------------------------
+# launch_sft_run — training_mode wire format, optional-eval payload, and the
+# narrow unknown-launch-arg error translation (slice 4)
+# ---------------------------------------------------------------------------
+
+
+def test_sft_launch_supported_flag_defaults_to_false():
+    """Capability flag: flips to True only once the platform lands
+    training_mode support. Nothing in this module consumes it yet."""
+    assert SFT_LAUNCH_SUPPORTED is False
+
+
+def test_launch_sft_run_posts_training_mode_and_omits_eval_when_none():
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"runId": "sft-run-1"})
+
+    trainer = _make_trainer_with_transport(handler)
+    run_id = trainer.launch_sft_run(
+        "my-sft-run",
+        train_dataset_path="datasets/x/train.jsonl",
+    )
+
+    assert run_id == "sft-run-1"
+    assert "/train/runs/launch" in captured["url"]
+    args = captured["body"]["args"]
+    assert args["training_mode"] == "sft"
+    assert args["train_dataset_path"] == "datasets/x/train.jsonl"
+    assert "eval_dataset_path" not in args
+
+
+def test_launch_sft_run_includes_eval_when_present():
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        captured["body"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"runId": "sft-run-2"})
+
+    trainer = _make_trainer_with_transport(handler)
+    trainer.launch_sft_run(
+        "my-sft-run",
+        train_dataset_path="datasets/x/train.jsonl",
+        eval_dataset_path="datasets/x/eval.jsonl",
+    )
+
+    args = captured["body"]["args"]
+    assert args["eval_dataset_path"] == "datasets/x/eval.jsonl"
+
+
+def test_launch_sft_run_forwards_launcher_args():
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        captured["body"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"runId": "sft-run-3"})
+
+    trainer = _make_trainer_with_transport(handler)
+    trainer.launch_sft_run(
+        "my-sft-run",
+        train_dataset_path="a",
+        launcher_args={"num_epochs": 3},
+    )
+
+    args = captured["body"]["args"]
+    assert args["num_epochs"] == 3
+    assert args["training_mode"] == "sft"  # launcher_args can't clobber the mode
+
+
+def test_launch_sft_run_translates_recognized_unknown_arg_rejection():
+    """The narrow, UNVERIFIED heuristic: a 4xx whose message plausibly names
+    an unrecognized/unknown launch arg becomes the clear env-less-SFT error,
+    with the original preserved as __cause__ and its status code intact."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400, json={"error": 'Unrecognized launch argument: "training_mode"'}
+        )
+
+    trainer = _make_trainer_with_transport(handler)
+    with pytest.raises(SftLaunchNotSupportedError) as exc_info:
+        trainer.launch_sft_run("r", train_dataset_path="a")
+
+    assert exc_info.value.status_code == 400
+    assert isinstance(exc_info.value.__cause__, JobLaunchError)
+    assert exc_info.value.__cause__.status_code == 400
+    assert "does not accept env-less SFT runs yet" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("status", "message"),
+    [
+        (409, "A run with this name already exists"),
+        (429, "Too many requests — slow down"),
+        (500, "internal server error"),
+        (400, "train_dataset_path does not exist in storage"),
+    ],
+)
+def test_launch_sft_run_propagates_other_job_launch_errors_unchanged(status, message):
+    """Every other JobLaunchError (conflict, rate limit, 5xx, an unrelated
+    400 about a bad dataset path) MUST propagate completely unchanged — same
+    type, same message, same status code, never translated."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, json={"error": message})
+
+    trainer = _make_trainer_with_transport(handler)
+    with pytest.raises(JobLaunchError) as exc_info:
+        trainer.launch_sft_run("r", train_dataset_path="a")
+
+    assert type(exc_info.value) is JobLaunchError
+    assert exc_info.value.status_code == status
+    assert exc_info.value.message == message
+
+
+def test_launch_sft_run_propagates_401_as_authentication_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "invalid api key"})
+
+    trainer = _make_trainer_with_transport(handler)
+    with pytest.raises(AuthenticationError) as exc_info:
+        trainer.launch_sft_run("r", train_dataset_path="a")
+
+    assert exc_info.value.status_code == 401

--- a/tests/unit/platform/test_sft_training_run.py
+++ b/tests/unit/platform/test_sft_training_run.py
@@ -1,0 +1,157 @@
+"""Unit tests for benchmax.platform.upload_sft_run."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+from benchmax.platform import UploadedSftRun, upload_sft_run
+from benchmax.sft.dataset import SftDataset, SftRow, canonical_jsonl
+
+
+def _dataset(rows: list[dict[str, Any]], path: str = "train.jsonl") -> SftDataset:
+    return SftDataset(
+        path=path,
+        rows=[SftRow(path, i + 1, r) for i, r in enumerate(rows)],
+        load_issues=[],
+    )
+
+
+class FakeStorageClient:
+    """In-memory StorageClient stand-in. Records calls; returns synthetic blob paths."""
+
+    def __init__(self):
+        self.uploads: list[tuple[str, Path]] = []
+
+    def upload_local_file(
+        self, path: str, file_path: Path, *, expires_in_minutes: Optional[int] = None
+    ) -> dict:
+        self.uploads.append((path, Path(file_path)))
+        assert Path(file_path).exists(), f"File missing at upload: {file_path}"
+        return {
+            "blobPath": f"blob://{path}",
+            "uploadUrl": f"https://example.invalid/{path}",
+            "expiresAt": "2099-01-01T00:00:00Z",
+            "willOverwrite": False,
+        }
+
+
+class CapturingStorage:
+    """Records the raw bytes written for each uploaded path."""
+
+    def __init__(self):
+        self.captured: dict[str, bytes] = {}
+
+    def upload_local_file(self, path, file_path, **kwargs):
+        self.captured[path] = Path(file_path).read_bytes()
+        return {
+            "blobPath": f"blob://{path}",
+            "uploadUrl": "",
+            "expiresAt": "",
+            "willOverwrite": False,
+        }
+
+
+def test_upload_sft_run_eval_none_uploads_only_train():
+    storage = FakeStorageClient()
+    train = _dataset([{"messages": [{"role": "user", "content": "hi"}]}])
+
+    result = upload_sft_run(
+        train=train,
+        eval=None,
+        run_name="sft-run",
+        storage_client=storage,  # type: ignore[arg-type]
+    )
+
+    assert isinstance(result, UploadedSftRun)
+    assert result.eval_dataset_path is None
+    paths = [p for p, _ in storage.uploads]
+    assert len(paths) == 1
+    assert paths[0].endswith("/train.jsonl")
+
+
+def test_upload_sft_run_eval_present_uploads_both():
+    storage = FakeStorageClient()
+    train = _dataset([{"messages": [{"role": "user", "content": "hi"}]}])
+    eval_ds = _dataset(
+        [{"messages": [{"role": "user", "content": "bye"}]}], path="eval.jsonl"
+    )
+
+    result = upload_sft_run(
+        train=train,
+        eval=eval_ds,
+        run_name="sft-run",
+        storage_client=storage,  # type: ignore[arg-type]
+    )
+
+    assert result.train_dataset_path is not None
+    assert result.eval_dataset_path is not None
+    paths = {p for p, _ in storage.uploads}
+    assert any(p.endswith("/train.jsonl") for p in paths)
+    assert any(p.endswith("/eval.jsonl") for p in paths)
+    assert len(paths) == 2
+
+
+def test_upload_sft_run_output_is_byte_identical_to_canonical_jsonl():
+    """The upload helper must serialize via canonical_jsonl and nothing else."""
+    storage = CapturingStorage()
+    train = _dataset(
+        [
+            {"messages": [{"role": "user", "content": "hi"}], "tools": [{"a": 1}]},
+            {
+                "messages": [
+                    {"role": "user", "content": "q"},
+                    {"role": "assistant", "content": "a", "weight": 1},
+                ]
+            },
+        ]
+    )
+    eval_ds = _dataset(
+        [{"messages": [{"role": "user", "content": "eval-row"}]}], path="eval.jsonl"
+    )
+
+    upload_sft_run(
+        train=train,
+        eval=eval_ds,
+        run_name="byte-check",
+        dataset_prefix="fixed/ds",
+        storage_client=storage,  # type: ignore[arg-type]
+    )
+
+    assert storage.captured["fixed/ds/train.jsonl"] == canonical_jsonl(train)
+    assert storage.captured["fixed/ds/eval.jsonl"] == canonical_jsonl(eval_ds)
+
+
+def test_upload_sft_run_respects_dataset_prefix_override():
+    storage = FakeStorageClient()
+    train = _dataset([{"messages": [{"role": "user", "content": "hi"}]}])
+
+    upload_sft_run(
+        train=train,
+        eval=None,
+        run_name="run-y",
+        dataset_prefix="custom/data/path",
+        storage_client=storage,  # type: ignore[arg-type]
+    )
+
+    paths = [path for path, _ in storage.uploads]
+    assert paths == ["custom/data/path/train.jsonl"]
+
+
+def test_upload_sft_run_api_key_optional_resolves_via_seam(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def _fake_storage_client(*, api_key, base_url):
+        captured["api_key"] = api_key
+        captured["base_url"] = base_url
+        return FakeStorageClient()
+
+    monkeypatch.setattr(
+        "benchmax.platform.training_run.StorageClient", _fake_storage_client
+    )
+
+    train = _dataset([{"messages": [{"role": "user", "content": "hi"}]}])
+    result = upload_sft_run(train=train, eval=None, run_name="test")
+
+    assert captured["api_key"] is None
+    assert isinstance(result, UploadedSftRun)


### PR DESCRIPTION
## Summary
- Slice 4 of docs/plans/sft-multimodal-interface.md (platform plumbing).
- `platform/training_run.py`: extracts the dataset-upload half of `upload_training_run` into a shared `_upload_dataset_pair` helper; adds `upload_sft_run(train, eval=None, run_name, ...) -> UploadedSftRun`. Serializes rows via `sft.dataset.canonical_jsonl` only. `eval=None` uploads nothing for eval and `eval_dataset_path` is `None` on the result.
- `platform/client.py`: `TrainerClient.launch_sft_run(name, train_dataset_path, eval_dataset_path=None, launcher_args=None)` posts `training_mode: "sft"`; `eval_dataset_path=None` omits the field from the request payload entirely. Adds `SFT_LAUNCH_SUPPORTED = False` capability flag (not consumed here — slice 5 gates on it).
- `platform/exceptions.py`: new `SftLaunchNotSupportedError(JobLaunchError)`.
- `platform/__init__.py`: re-exports `upload_sft_run` + `UploadedSftRun` (mirrors `upload_training_run`/`UploadedTrainingRun`). `launch_sft_run` is a `TrainerClient` method only — no module-level wrapper, per the plan.

## Known assumption — needs verification
Error translation for `launch_sft_run` is intentionally narrow: only a 4xx response whose message loosely matches "unrecognized/unknown ... arg" (see `_looks_like_unknown_launch_arg_rejection` and its docstring in `client.py`) gets translated into `SftLaunchNotSupportedError`, with the original exception preserved as `__cause__` and its status code intact. Every other `JobLaunchError` (401/409/429/500/bad-dataset-path 400) propagates completely unchanged.

The plan doc points at `platform-service/src/lib/trainer-args.ts:425` for the real unknown-arg message format, but that repo is not checked out here and wasn't accessible while implementing this slice — the plan itself flags this as "not a stable contract." The regex and the test fixtures use an assumed message text. **This needs real verification against the live platform's actual error message before merge-time reliance; flagging for the at-merge / platform-verification checklist.**

## Test plan
- [x] `tests/unit/platform/test_sft_training_run.py` (new): `upload_sft_run` byte-identical to `canonical_jsonl`, eval=None uploads only train, eval-present uploads both, dataset_prefix override, api_key-optional seam resolution.
- [x] `tests/unit/platform/test_client.py` (extended): `SFT_LAUNCH_SUPPORTED` flag, `launch_sft_run` wire format (training_mode, eval omission/inclusion, launcher_args forwarding), recognized unknown-arg rejection → `SftLaunchNotSupportedError` with `__cause__`/status intact, and 409/429/500/bad-dataset-path-400/401 all propagate unchanged.
- [x] `uv run pytest tests/unit` — 1224 passed, 3 skipped.
- [x] `uv run ruff check src/` clean on all changed files (3 pre-existing, unrelated errors in `multi_model/example_usage.py`, `prompts/tools.py`, `rag/preprocess/email/...` — not touched by this change).