### PR TITLE
Add sft_main.py scaffold template

### DIFF
--- a/src/benchmax/cli/scaffold/sft_eval_dataset.jsonl
+++ b/src/benchmax/cli/scaffold/sft_eval_dataset.jsonl
@@ -1,0 +1,2 @@
+{"messages": [{"role": "user", "content": "What is the capital of Japan?"}, {"role": "assistant", "content": "The capital of Japan is Tokyo."}]}
+{"messages": [{"role": "user", "content": "What is 10 minus 3?"}, {"role": "assistant", "content": "10 minus 3 equals 7."}]}

--- a/src/benchmax/cli/scaffold/sft_main.py
+++ b/src/benchmax/cli/scaffold/sft_main.py
@@ -1,0 +1,325 @@
+"""Env-less SFT dataset project (written by `castform setup --template sft`).
+
+Post-trains a model via supervised fine-tuning on `{"messages": [...]}` rows —
+the OpenAI fine-tuning chat format, with optional `tools` and per-assistant-
+message `weight` (0/1) for turn masking. There is no environment and no
+reward: `TRAINING_MODE = "sft"` is the explicit mode marker `castform` reads
+instead of discovering a `BaseEnv` subclass (see `benchmax.cli._project`).
+
+The whole run is reproducible from this file: the seed dataset is below, and
+the `VALIDATE_CONFIG` / `LAUNCH_CONFIG` blocks bake in the dataset/launch
+knobs so `castform validate` / `castform launch` need no extra flags (a CLI
+flag still overrides). `python main.py` drives the loop: data → validate,
+then STOP (`launch` is an explicit, confirmed step — it spends GPU credits).
+
+Multimodal: a user message may carry a content-part list (e.g. a `text` part
+plus an `image_url` part) instead of a plain string — see `_SEED_MULTIMODAL`
+below for a demonstration row. It is opt-in only: a vision base model is
+required, so `generate_data()` does not write it by default (see the comment
+above `_SEED_MULTIMODAL`).
+
+Weight/masking is experimental: trainer support for per-message `weight` is
+unconfirmed, so `launch()` blocks a weight-bearing dataset unless
+`LAUNCH_CONFIG["allow_experimental_weights"]` is set. Live launch is also
+gated behind `benchmax.platform.client.SFT_LAUNCH_SUPPORTED` (False as of
+writing — the platform doesn't yet accept env-less sft launch args); the
+upload→launch path below is fully implemented and unit-tested, it just can't
+reach a real platform yet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from benchmax.platform.client import SFT_LAUNCH_SUPPORTED, TrainerClient
+from benchmax.platform.login import ensure_session
+from benchmax.platform.training_run import upload_sft_run
+from benchmax.sft import SftValidationReport, load_sft_dataset, validate_sft_dataset
+
+# The explicit mode marker (see the module docstring) — read on its own by
+# `cli._project.load_project`, before any BaseEnv discovery is attempted.
+TRAINING_MODE = "sft"
+
+
+# ── Run config — validate/launch read these so the run reproduces from this file
+#    alone (a CLI flag still overrides). See `castform validate/launch --help`.
+VALIDATE_CONFIG = {
+    # "max_seq_len": 8192,     # char/4-heuristic token budget flagged as a notice
+    # "max_row_bytes": 1 << 20,  # per-row serialized-size notice threshold (1 MiB)
+}
+
+LAUNCH_CONFIG = {
+    "num_epochs": 2,  # eval tends to peak before the overfit tail; keep epochs modest
+    # "allow_experimental_weights": False,  # set True to launch a weight-bearing
+    #   dataset anyway — trainer masking support is unconfirmed (see the docstring).
+    # "type": "simple",  # GPU pool (gpu4 for 4B / gpu8 for 35B); "simple-cpu" = smoke
+}
+
+# LAUNCH_CONFIG keys resolved locally, never forwarded as a launcher arg: `name` is
+# the run name (see `_run_name`); `type` is not a wire arg; `allow_experimental_weights`
+# is the client-side weight gate override and must never reach the server as an
+# unknown launch arg.
+_LAUNCH_CONFIG_RESERVED = frozenset({"type", "name", "allow_experimental_weights"})
+
+
+# ── Runnable entrypoint ──────────────────────────────────────────────────────
+# `python main.py [data|validate|launch|all]` drives the whole loop SDK-directly —
+# no CLI needed, and this file stays the reproducible record of the run. Stages are
+# isolable and skip work whose output already exists (`--force` to redo):
+#
+#   python main.py data       generate/refresh the datasets (skip if present)
+#   python main.py validate   validate the dataset locally (no GPU, no rollouts)
+#   python main.py launch     validate-gate, then train on GPUs (spends credits)
+#   python main.py  (or all)  data → validate, then STOP (never auto-launches)
+#
+# Import-safe: this block runs ONLY under `python main.py`. When the castform CLI
+# imports this file it execs under the "main" stem, not "__main__", so nothing here
+# fires — `castform validate` / `launch` reuse the SAME SDK calls, no drift.
+
+TRAIN_FILE = "train_dataset.jsonl"
+EVAL_FILE = "eval_dataset.jsonl"
+
+# A tiny hardcoded 1x1 red-pixel PNG data URI (no pillow/PIL dependency — just a
+# literal base64 string). Used only by the opt-in `_SEED_MULTIMODAL` row below.
+_TINY_PNG_DATA_URI = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR42mP4z8AAAAMBAQD3A0FDAAAAAElFTkSuQmCC"
+)
+
+# The tiny seed dataset — synthetic, reproducible, text-only. `castform setup` also
+# commits these as train_dataset.jsonl / eval_dataset.jsonl so validate runs on day
+# one; regenerate them any time with `python main.py data --force`.
+_SEED_TRAIN = [
+    {
+        "messages": [
+            {"role": "user", "content": "What is the capital of France?"},
+            {"role": "assistant", "content": "The capital of France is Paris."},
+        ]
+    },
+    {
+        "messages": [
+            {"role": "user", "content": "What is 2 + 2?"},
+            {"role": "assistant", "content": "2 + 2 equals 4."},
+        ]
+    },
+    {
+        "messages": [
+            {"role": "user", "content": "What color is a clear daytime sky?"},
+            {"role": "assistant", "content": "A clear daytime sky is blue."},
+        ]
+    },
+]
+_SEED_EVAL = [
+    {
+        "messages": [
+            {"role": "user", "content": "What is the capital of Japan?"},
+            {"role": "assistant", "content": "The capital of Japan is Tokyo."},
+        ]
+    },
+    {
+        "messages": [
+            {"role": "user", "content": "What is 10 minus 3?"},
+            {"role": "assistant", "content": "10 minus 3 equals 7."},
+        ]
+    },
+]
+
+# Opt-in multimodal demonstration — NOT written by `generate_data()` by default (see
+# below). Enable it only when training against a VISION base model: append it to
+# `_SEED_TRAIN` (e.g. `_SEED_TRAIN + [_SEED_MULTIMODAL]`) before calling
+# `generate_data(force=True)`. Enabling it for a text-only base model is undefined
+# trainer behavior.
+_SEED_MULTIMODAL = {
+    "messages": [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What color is the square in this image?"},
+                {"type": "image_url", "image_url": {"url": _TINY_PNG_DATA_URI}},
+            ],
+        },
+        {"role": "assistant", "content": "The square is red."},
+    ]
+}
+
+
+def _write_jsonl(path: str, rows: list[dict[str, Any]]) -> None:
+    Path(path).write_text("".join(json.dumps(r) + "\n" for r in rows), "utf-8")
+
+
+def _run_name() -> str:
+    return LAUNCH_CONFIG.get("name") or "sft-run"
+
+
+def generate_data(force: bool = False) -> bool:
+    """Produce `train_dataset.jsonl` / `eval_dataset.jsonl`.
+
+    Provenance: a tiny synthetic seed, generated inline above (reproducible,
+    text-only). Replace it with your real task's data — hand-write the jsonl in
+    the OpenAI fine-tuning chat format, or generate it and inline the gen code
+    here so the dataset stays reproducible from this file. Re-run with --force
+    to regenerate; skip-if-exists otherwise. See `_SEED_MULTIMODAL` above to
+    opt into a multimodal demonstration row (vision base models only).
+    """
+    have = Path(TRAIN_FILE).exists() and Path(EVAL_FILE).exists()
+    if have and not force:
+        print(f"data: {TRAIN_FILE} / {EVAL_FILE} present — skipping (--force to redo)")
+        return True
+    _write_jsonl(TRAIN_FILE, _SEED_TRAIN)
+    _write_jsonl(EVAL_FILE, _SEED_EVAL)
+    print(f"data: wrote {len(_SEED_TRAIN)} train / {len(_SEED_EVAL)} eval rows")
+    return True
+
+
+def _print_scorecard(report: SftValidationReport) -> None:
+    """A minimal, SDK-direct scorecard (the CLI's `castform validate` prints a
+    richer one)."""
+    print(f"  rows: train {report.train_row_count} · eval {report.eval_row_count}")
+    stats = report.token_length_stats
+    print(
+        f"  tokens (char/4 heuristic): min {stats.min_tokens}  max {stats.max_tokens}"
+        f"  mean {stats.mean_tokens:.1f}"
+    )
+    masking = report.masking_summary
+    if masking.rows_with_weight:
+        print(
+            f"  masking: {masking.rows_with_weight} row(s) use per-message weight "
+            "(experimental)"
+        )
+    for issue in report.issues:
+        loc = (
+            f"{issue.source_path}:{issue.physical_line}"
+            if issue.source_path
+            else "(dataset)"
+        )
+        symbol = "✗" if issue.severity == "error" else "⚠"
+        print(f"  {symbol} {loc}  {issue.message}")
+    print(f"validate: {'PASS' if report.ok else 'FAIL'}")
+
+
+def validate() -> SftValidationReport:
+    """Validate the sft dataset pair locally (no GPU, no rollouts). Returns the
+    report."""
+    train = load_sft_dataset(TRAIN_FILE)
+    eval_dataset = load_sft_dataset(EVAL_FILE) if Path(EVAL_FILE).exists() else None
+    report = validate_sft_dataset(
+        train,
+        eval_dataset,
+        **{k: v for k, v in VALIDATE_CONFIG.items() if k in ("max_seq_len", "max_row_bytes")},
+    )
+    _print_scorecard(report)
+    return report
+
+
+def launch(assume_yes: bool = False) -> str | None:
+    """Validate-gate, weight-gate, confirm, then upload + launch an SFT training
+    run (spends credits). Returns the run id, or None if gated/aborted."""
+    report = validate()  # cheap pre-flight — never spend GPU on a broken dataset
+    if report is None or not report.ok:
+        print(
+            "launch: validate gate FAILED — fix the dataset before launching.",
+            file=sys.stderr,
+        )
+        return None
+
+    # Weight gate: a dataset using per-message `weight` (masking) is launch-blocking
+    # until trainer support is confirmed — a separate capability from
+    # SFT_LAUNCH_SUPPORTED below; the validate notice alone does not clear it.
+    if report.masking_summary.rows_with_weight and not LAUNCH_CONFIG.get(
+        "allow_experimental_weights", False
+    ):
+        print(
+            "launch: dataset uses per-message 'weight' (masking) — trainer support "
+            "is unconfirmed. Set allow_experimental_weights=True in LAUNCH_CONFIG to "
+            "launch anyway.",
+            file=sys.stderr,
+        )
+        return None
+
+    # LAUNCH_CONFIG feeds the launcher, minus the reserved/local-only keys. The
+    # server rejects any unknown key.
+    launcher_args = {
+        k: v for k, v in LAUNCH_CONFIG.items() if k not in _LAUNCH_CONFIG_RESERVED
+    }
+
+    # Guard before upload: no orphaned storage artifacts behind an API that cannot
+    # succeed yet (see SFT_LAUNCH_SUPPORTED's docstring).
+    if not SFT_LAUNCH_SUPPORTED:
+        print(
+            "launch: the platform does not accept env-less sft runs yet "
+            "(benchmax.platform.client.SFT_LAUNCH_SUPPORTED is False).",
+            file=sys.stderr,
+        )
+        return None
+
+    if not assume_yes:
+        reply = (
+            input(
+                f"Launch '{_run_name()}' on GPUs — this spends credits. Continue? [y/N] "
+            )
+            .strip()
+            .lower()
+        )
+        if reply not in ("y", "yes"):
+            print("launch: aborted.")
+            return None
+
+    train = load_sft_dataset(TRAIN_FILE)
+    eval_dataset = load_sft_dataset(EVAL_FILE) if Path(EVAL_FILE).exists() else None
+    uploaded = upload_sft_run(train=train, eval=eval_dataset, run_name=_run_name())
+
+    with TrainerClient() as client:
+        run_id = client.launch_sft_run(
+            name=_run_name(),
+            train_dataset_path=uploaded.train_dataset_path,
+            eval_dataset_path=uploaded.eval_dataset_path,
+            launcher_args=launcher_args or None,
+        )
+    print(f"launch: started run {run_id}")
+    return run_id
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="main.py",
+        description="Run the castform loop for this sft dataset: data → validate → launch.",
+    )
+    parser.add_argument(
+        "stage",
+        nargs="?",
+        default="all",
+        choices=["data", "validate", "launch", "all"],
+        help="Stage to run (default: all = data → validate, then STOP).",
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Regenerate datasets even if present."
+    )
+    parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Skip the launch confirmation (it spends GPU credits).",
+    )
+    args = parser.parse_args(argv)
+
+    ensure_session()  # best-effort: no-op if a credential resolves
+
+    ok = True
+    if args.stage in ("data", "all"):
+        generate_data(force=args.force)
+    if args.stage in ("validate", "all"):
+        report = validate()
+        ok = report is not None and report.ok  # non-zero exit on a failed validate
+    if args.stage == "launch":
+        ok = launch(assume_yes=args.yes) is not None  # None = gated / aborted / failed
+    # `all` / bare `python main.py` STOPS after validate — launch is never automatic
+    # (it spends GPU credits); run `python main.py launch` to train.
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/benchmax/cli/scaffold/sft_main.py
+++ b/src/benchmax/cli/scaffold/sft_main.py
@@ -272,7 +272,7 @@ def main(argv: list[str] | None = None) -> int:
         nargs="?",
         default="all",
         choices=["data", "validate", "launch", "all"],
-        help="stage to run (default: all = data → validate, then STOP).",
+        help="stage to run (default: all = data → validate, then stop).",
     )
     parser.add_argument(
         "--force", action="store_true", help="regenerate datasets even if present."

--- a/src/benchmax/cli/scaffold/sft_main.py
+++ b/src/benchmax/cli/scaffold/sft_main.py
@@ -40,8 +40,7 @@ from benchmax.platform.login import ensure_session
 from benchmax.platform.training_run import upload_sft_run
 from benchmax.sft import SftValidationReport, load_sft_dataset, validate_sft_dataset
 
-# The explicit mode marker (see the module docstring) — read on its own by
-# `cli._project.load_project`, before any BaseEnv discovery is attempted.
+# Explicit mode marker; read before BaseEnv discovery (see cli._project.load_project).
 TRAINING_MODE = "sft"
 
 
@@ -59,26 +58,11 @@ LAUNCH_CONFIG = {
     # "type": "simple",  # GPU pool (gpu4 for 4B / gpu8 for 35B); "simple-cpu" = smoke
 }
 
-# LAUNCH_CONFIG keys resolved locally, never forwarded as a launcher arg: `name` is
-# the run name (see `_run_name`); `type` is not a wire arg; `allow_experimental_weights`
-# is the client-side weight gate override and must never reach the server as an
-# unknown launch arg.
+# Resolved locally; never forwarded to the server as a launch arg.
 _LAUNCH_CONFIG_RESERVED = frozenset({"type", "name", "allow_experimental_weights"})
 
 
-# ── Runnable entrypoint ──────────────────────────────────────────────────────
-# `python main.py [data|validate|launch|all]` drives the whole loop SDK-directly —
-# no CLI needed, and this file stays the reproducible record of the run. Stages are
-# isolable and skip work whose output already exists (`--force` to redo):
-#
-#   python main.py data       generate/refresh the datasets (skip if present)
-#   python main.py validate   validate the dataset locally (no GPU, no rollouts)
-#   python main.py launch     validate-gate, then train on GPUs (spends credits)
-#   python main.py  (or all)  data → validate, then STOP (never auto-launches)
-#
-# Import-safe: this block runs ONLY under `python main.py`. When the castform CLI
-# imports this file it execs under the "main" stem, not "__main__", so nothing here
-# fires — `castform validate` / `launch` reuse the SAME SDK calls, no drift.
+# ── Runnable entrypoint (see the module docstring + main()'s argparse help) ──
 
 TRAIN_FILE = "train_dataset.jsonl"
 EVAL_FILE = "eval_dataset.jsonl"
@@ -90,9 +74,7 @@ _TINY_PNG_DATA_URI = (
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR42mP4z8AAAAMBAQD3A0FDAAAAAElFTkSuQmCC"
 )
 
-# The tiny seed dataset — synthetic, reproducible, text-only. `castform setup` also
-# commits these as train_dataset.jsonl / eval_dataset.jsonl so validate runs on day
-# one; regenerate them any time with `python main.py data --force`.
+# Tiny synthetic seed, text-only; regenerate with `python main.py data --force`.
 _SEED_TRAIN = [
     {
         "messages": [
@@ -128,11 +110,11 @@ _SEED_EVAL = [
     },
 ]
 
-# Opt-in multimodal demonstration — NOT written by `generate_data()` by default (see
-# below). Enable it only when training against a VISION base model: append it to
-# `_SEED_TRAIN` (e.g. `_SEED_TRAIN + [_SEED_MULTIMODAL]`) before calling
-# `generate_data(force=True)`. Enabling it for a text-only base model is undefined
-# trainer behavior.
+# Opt-in multimodal demonstration — NOT written by `generate_data()` by default.
+# Enable it only against a VISION base model (undefined trainer behavior otherwise)
+# by changing `generate_data()`'s `_write_jsonl(TRAIN_FILE, _SEED_TRAIN)` call below
+# to `_write_jsonl(TRAIN_FILE, _SEED_TRAIN + [_SEED_MULTIMODAL])`, then re-run with
+# `python main.py data --force`.
 _SEED_MULTIMODAL = {
     "messages": [
         {
@@ -198,7 +180,7 @@ def _print_scorecard(report: SftValidationReport) -> None:
         )
         symbol = "✗" if issue.severity == "error" else "⚠"
         print(f"  {symbol} {loc}  {issue.message}")
-    print(f"validate: {'PASS' if report.ok else 'FAIL'}")
+    print(f"validate: {'pass' if report.ok else 'fail'}")
 
 
 def validate() -> SftValidationReport:
@@ -221,33 +203,30 @@ def launch(assume_yes: bool = False) -> str | None:
     report = validate()  # cheap pre-flight — never spend GPU on a broken dataset
     if report is None or not report.ok:
         print(
-            "launch: validate gate FAILED — fix the dataset before launching.",
+            "launch: validate gate failed — fix the dataset before launching.",
             file=sys.stderr,
         )
         return None
 
-    # Weight gate: a dataset using per-message `weight` (masking) is launch-blocking
-    # until trainer support is confirmed — a separate capability from
-    # SFT_LAUNCH_SUPPORTED below; the validate notice alone does not clear it.
+    # Weight gate: a separate capability from SFT_LAUNCH_SUPPORTED below — the
+    # validate notice alone does not clear it.
     if report.masking_summary.rows_with_weight and not LAUNCH_CONFIG.get(
         "allow_experimental_weights", False
     ):
         print(
             "launch: dataset uses per-message 'weight' (masking) — trainer support "
-            "is unconfirmed. Set allow_experimental_weights=True in LAUNCH_CONFIG to "
+            "is unconfirmed. set allow_experimental_weights=True in LAUNCH_CONFIG to "
             "launch anyway.",
             file=sys.stderr,
         )
         return None
 
-    # LAUNCH_CONFIG feeds the launcher, minus the reserved/local-only keys. The
-    # server rejects any unknown key.
+    # Minus the reserved/local-only keys — the server rejects any unknown key.
     launcher_args = {
         k: v for k, v in LAUNCH_CONFIG.items() if k not in _LAUNCH_CONFIG_RESERVED
     }
 
-    # Guard before upload: no orphaned storage artifacts behind an API that cannot
-    # succeed yet (see SFT_LAUNCH_SUPPORTED's docstring).
+    # Guard before upload — avoids orphaned storage behind an API that can't succeed yet.
     if not SFT_LAUNCH_SUPPORTED:
         print(
             "launch: the platform does not accept env-less sft runs yet "
@@ -259,7 +238,7 @@ def launch(assume_yes: bool = False) -> str | None:
     if not assume_yes:
         reply = (
             input(
-                f"Launch '{_run_name()}' on GPUs — this spends credits. Continue? [y/N] "
+                f"launch '{_run_name()}' on GPUs — this spends credits. continue? [y/N] "
             )
             .strip()
             .lower()
@@ -286,23 +265,23 @@ def launch(assume_yes: bool = False) -> str | None:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="main.py",
-        description="Run the castform loop for this sft dataset: data → validate → launch.",
+        description="run the castform loop for this sft dataset: data → validate → launch.",
     )
     parser.add_argument(
         "stage",
         nargs="?",
         default="all",
         choices=["data", "validate", "launch", "all"],
-        help="Stage to run (default: all = data → validate, then STOP).",
+        help="stage to run (default: all = data → validate, then STOP).",
     )
     parser.add_argument(
-        "--force", action="store_true", help="Regenerate datasets even if present."
+        "--force", action="store_true", help="regenerate datasets even if present."
     )
     parser.add_argument(
         "-y",
         "--yes",
         action="store_true",
-        help="Skip the launch confirmation (it spends GPU credits).",
+        help="skip the launch confirmation (it spends GPU credits).",
     )
     args = parser.parse_args(argv)
 
@@ -316,8 +295,6 @@ def main(argv: list[str] | None = None) -> int:
         ok = report is not None and report.ok  # non-zero exit on a failed validate
     if args.stage == "launch":
         ok = launch(assume_yes=args.yes) is not None  # None = gated / aborted / failed
-    # `all` / bare `python main.py` STOPS after validate — launch is never automatic
-    # (it spends GPU credits); run `python main.py launch` to train.
     return 0 if ok else 1
 
 

--- a/src/benchmax/cli/scaffold/sft_train_dataset.jsonl
+++ b/src/benchmax/cli/scaffold/sft_train_dataset.jsonl
@@ -1,0 +1,3 @@
+{"messages": [{"role": "user", "content": "What is the capital of France?"}, {"role": "assistant", "content": "The capital of France is Paris."}]}
+{"messages": [{"role": "user", "content": "What is 2 + 2?"}, {"role": "assistant", "content": "2 + 2 equals 4."}]}
+{"messages": [{"role": "user", "content": "What color is a clear daytime sky?"}, {"role": "assistant", "content": "A clear daytime sky is blue."}]}

--- a/src/benchmax/cli/setup.py
+++ b/src/benchmax/cli/setup.py
@@ -59,6 +59,11 @@ _TEMPLATE_SEEDS = {
         "train": "rag_train_dataset.jsonl",
         "eval": "rag_eval_dataset.jsonl",
     },
+    "sft": {
+        "main": "sft_main.py",
+        "train": "sft_train_dataset.jsonl",
+        "eval": "sft_eval_dataset.jsonl",
+    },
 }
 
 
@@ -338,10 +343,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p.add_argument(
         "--template",
-        choices=["generic", "rag"],
+        choices=["generic", "rag", "sft"],
         default="generic",
-        help="Env seed: 'generic' = a minimal single-turn env, 'rag' = a SearchEnv "
-        "(both ship a runnable main.py + tiny datasets; default: generic)",
+        help="Env seed: 'generic' = a minimal single-turn env, 'rag' = a SearchEnv, "
+        "'sft' = an env-less supervised fine-tuning dataset (all three ship a "
+        "runnable main.py + tiny datasets; default: generic)",
     )
     p.add_argument(
         "--no-template",

--- a/src/benchmax/cli/setup.py
+++ b/src/benchmax/cli/setup.py
@@ -345,7 +345,7 @@ def register(sub: argparse._SubParsersAction) -> None:
         "--template",
         choices=["generic", "rag", "sft"],
         default="generic",
-        help="Env seed: 'generic' = a minimal single-turn env, 'rag' = a SearchEnv, "
+        help="env seed: 'generic' = a minimal single-turn env, 'rag' = a SearchEnv, "
         "'sft' = an env-less supervised fine-tuning dataset (all three ship a "
         "runnable main.py + tiny datasets; default: generic)",
     )

--- a/tests/unit/test_cli_setup.py
+++ b/tests/unit/test_cli_setup.py
@@ -212,6 +212,58 @@ def test_setup_template_rag_force_overwrites(tmp_path):
     assert "CustomSearchEnv" in main_py and main_py != "MINE"
 
 
+def test_setup_template_sft_writes_seed(tmp_path):
+    """--template sft writes a main.py the loader discovers as an sft-mode project
+    (TRAINING_MODE = 'sft', no BaseEnv subclass)."""
+    from benchmax.cli._project import _load_module_from_file
+
+    assert setup._cmd_setup(_ns(tmp_path, template="sft")) == 0
+    main_py = (tmp_path / "main.py").read_text()
+    assert 'TRAINING_MODE = "sft"' in main_py
+    assert "VALIDATE_CONFIG = {" in main_py
+    assert "LAUNCH_CONFIG = {" in main_py
+    mod = _load_module_from_file(tmp_path / "main.py")
+    assert mod.TRAINING_MODE == "sft"
+
+
+def test_setup_template_sft_writes_seed_and_datasets(tmp_path):
+    """--template sft ships a runnable main.py + tiny seed datasets (OpenAI
+    fine-tuning `messages` shape) — `load_project` surfaces it as sft-mode with no
+    env class and the on-disk dataset paths (never parsed by `load_project` itself)."""
+    from benchmax.cli._project import load_project
+    from benchmax.sft import load_sft_dataset
+
+    assert setup._cmd_setup(_ns(tmp_path, template="sft")) == 0
+    assert (tmp_path / "main.py").exists()
+    assert (tmp_path / "train_dataset.jsonl").exists()
+    assert (tmp_path / "eval_dataset.jsonl").exists()
+
+    project = load_project(directory=str(tmp_path))
+    assert project.training_mode == "sft"
+    assert project.env_class is None
+    assert project.sft_train_path == tmp_path / "train_dataset.jsonl"
+    assert project.sft_eval_path == tmp_path / "eval_dataset.jsonl"
+
+    train = load_sft_dataset(project.sft_train_path)
+    assert train.rows and "messages" in train.rows[0].data
+
+
+def test_setup_template_sft_refuses_existing_main_py(tmp_path, capsys):
+    """Same hollow-pass guard as generic/rag: existing main.py + no --force must
+    fail loudly and leave the file untouched."""
+    (tmp_path / "main.py").write_text("MINE")
+    assert setup._cmd_setup(_ns(tmp_path, template="sft")) == 1
+    assert (tmp_path / "main.py").read_text() == "MINE"  # untouched
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_setup_template_sft_force_overwrites(tmp_path):
+    (tmp_path / "main.py").write_text("MINE")
+    assert setup._cmd_setup(_ns(tmp_path, template="sft", force=True)) == 0
+    main_py = (tmp_path / "main.py").read_text()
+    assert 'TRAINING_MODE = "sft"' in main_py and main_py != "MINE"
+
+
 def test_setup_force_replaces_main_py_but_keeps_datasets(tmp_path):
     """--force clears the main.py overwrite guard but must NOT clobber datasets —
     real `castform data qa-gen` output is never overwritten by the placeholder seed."""

--- a/tests/unit/test_scaffold_runner.py
+++ b/tests/unit/test_scaffold_runner.py
@@ -22,11 +22,7 @@ _SEEDS = {
     "rag": _SCAFFOLD_DIR / "rag_main.py",
     "sft": _SCAFFOLD_DIR / "sft_main.py",
 }
-# RL seeds share the env-class runner surface (discover_env_class, validate_env,
-# upload_training_run, TrainerClient.launch_training_run); sft is env-less and uses
-# a different SDK surface (load_sft_dataset/validate_sft_dataset, upload_sft_run,
-# TrainerClient.launch_sft_run) — mode discrimination follows the same
-# `TRAINING_MODE` marker slice 5 wired into `cli._project`, not a parallel list.
+# sft is env-less with a different SDK surface than generic/rag — see mod/rl_mod/sft_mod below.
 _RL_SEEDS = ("generic", "rag")
 
 

--- a/tests/unit/test_scaffold_runner.py
+++ b/tests/unit/test_scaffold_runner.py
@@ -1,10 +1,13 @@
 """Every scaffold seed's `main.py` runnable stage-runner: argparse dispatch +
 SDK-direct stages (data → validate → launch), with the SDK monkeypatched (no
-network). Parametrized over both seeds — the runner is env-type-agnostic."""
+network). Parametrized over every seed for the mode-agnostic assertions (import
+safety, dispatch); RL-only and sft-only assertions get their own fixture, since
+the sft seed is env-less and uses a different SDK surface (see `_RL_SEEDS`)."""
 
 from __future__ import annotations
 
 import dataclasses
+import json
 import types
 from pathlib import Path
 
@@ -17,12 +20,30 @@ _SCAFFOLD_DIR = Path(scaffold_pkg.__file__).parent
 _SEEDS = {
     "generic": _SCAFFOLD_DIR / "generic_main.py",
     "rag": _SCAFFOLD_DIR / "rag_main.py",
+    "sft": _SCAFFOLD_DIR / "sft_main.py",
 }
+# RL seeds share the env-class runner surface (discover_env_class, validate_env,
+# upload_training_run, TrainerClient.launch_training_run); sft is env-less and uses
+# a different SDK surface (load_sft_dataset/validate_sft_dataset, upload_sft_run,
+# TrainerClient.launch_sft_run) — mode discrimination follows the same
+# `TRAINING_MODE` marker slice 5 wired into `cli._project`, not a parallel list.
+_RL_SEEDS = ("generic", "rag")
 
 
-@pytest.fixture(params=["generic", "rag"])
+@pytest.fixture(params=list(_SEEDS))
 def mod(request, tmp_path, monkeypatch):
-    """Load a scaffold seed as a module (its `__main__` block does not fire)."""
+    """Load a scaffold seed as a module (its `__main__` block does not fire).
+    Parametrized over EVERY seed — use this only for mode-agnostic assertions
+    (import safety, argparse dispatch). RL-only assertions belong on `rl_mod`."""
+    monkeypatch.chdir(tmp_path)
+    return _load_module_from_file(_SEEDS[request.param])
+
+
+@pytest.fixture(params=_RL_SEEDS)
+def rl_mod(request, tmp_path, monkeypatch):
+    """Like `mod`, but parametrized over the RL (env-class) seeds only — for
+    assertions that reach `discover_env_class`/`validate_env`/`upload_training_run`/
+    `launch_training_run`, none of which the env-less sft seed has."""
     monkeypatch.chdir(tmp_path)
     return _load_module_from_file(_SEEDS[request.param])
 
@@ -116,10 +137,11 @@ def test_main_exit_1_when_launch_gated(mod, monkeypatch):
     assert mod.main(["launch"]) == 1
 
 
-# ── validate stage: config-derived args reach validate_env ──────────────────────
+# ── validate stage: config-derived args reach validate_env (RL seeds only) ──────
 
 
-def test_validate_passes_config_derived_args(mod, tmp_path, monkeypatch):
+def test_validate_passes_config_derived_args(rl_mod, tmp_path, monkeypatch):
+    mod = rl_mod
     monkeypatch.chdir(tmp_path)
     (tmp_path / "train_dataset.jsonl").write_text('{"prompt": "q"}\n')
     (tmp_path / "eval_dataset.jsonl").write_text('{"prompt": "q2"}\n')
@@ -142,7 +164,7 @@ def test_validate_passes_config_derived_args(mod, tmp_path, monkeypatch):
     assert len(captured["train_dataset"]) == 1  # loaded off disk, not passed empty
 
 
-# ── launch stage: validate-gate, [y/N] confirm, and the asdict spread ───────────
+# ── launch stage: validate-gate, [y/N] confirm, and the asdict spread (RL seeds) ─
 
 
 def _patch_launch_sdk(mod, monkeypatch, launched: dict, *, validate_ok: bool = True):
@@ -179,7 +201,8 @@ def _seed_datasets(tmp_path):
     (tmp_path / "eval_dataset.jsonl").write_text('{"prompt": "q2"}\n')
 
 
-def test_launch_blocked_by_failing_validate(mod, tmp_path, monkeypatch):
+def test_launch_blocked_by_failing_validate(rl_mod, tmp_path, monkeypatch):
+    mod = rl_mod
     monkeypatch.chdir(tmp_path)
     launched: dict = {}
     _patch_launch_sdk(mod, monkeypatch, launched, validate_ok=False)
@@ -190,7 +213,8 @@ def test_launch_blocked_by_failing_validate(mod, tmp_path, monkeypatch):
     assert not launched  # never reached upload/launch
 
 
-def test_launch_declined_at_confirm(mod, tmp_path, monkeypatch):
+def test_launch_declined_at_confirm(rl_mod, tmp_path, monkeypatch):
+    mod = rl_mod
     monkeypatch.chdir(tmp_path)
     _seed_datasets(tmp_path)
     launched: dict = {}
@@ -200,7 +224,8 @@ def test_launch_declined_at_confirm(mod, tmp_path, monkeypatch):
     assert not launched  # aborted before spending credits
 
 
-def test_launch_confirmed_spreads_uploaded_paths(mod, tmp_path, monkeypatch):
+def test_launch_confirmed_spreads_uploaded_paths(rl_mod, tmp_path, monkeypatch):
+    mod = rl_mod
     monkeypatch.chdir(tmp_path)
     _seed_datasets(tmp_path)
     launched: dict = {}
@@ -220,7 +245,8 @@ def test_launch_confirmed_spreads_uploaded_paths(mod, tmp_path, monkeypatch):
     )
 
 
-def test_launch_assume_yes_skips_prompt(mod, tmp_path, monkeypatch):
+def test_launch_assume_yes_skips_prompt(rl_mod, tmp_path, monkeypatch):
+    mod = rl_mod
     monkeypatch.chdir(tmp_path)
     _seed_datasets(tmp_path)
     launched: dict = {}
@@ -230,3 +256,155 @@ def test_launch_assume_yes_skips_prompt(mod, tmp_path, monkeypatch):
     )
     assert mod.launch(assume_yes=True) == "run-123"
     assert launched["name"] == mod._run_name()
+
+
+# ── sft seed: env-less validate/launch surface ──────────────────────────────────
+
+
+@pytest.fixture
+def sft_mod(tmp_path, monkeypatch):
+    """The sft seed loaded on its own (not parametrized — its SDK surface differs
+    from the RL seeds', see `_RL_SEEDS` above)."""
+    monkeypatch.chdir(tmp_path)
+    return _load_module_from_file(_SEEDS["sft"])
+
+
+def test_sft_seed_multimodal_row_validates(sft_mod):
+    """`_SEED_MULTIMODAL` must validate cleanly through `validate_sft_dataset` on
+    EVERY test run (not just when a user manually enables it) so the opt-in sample
+    can't silently rot. Checked against the module's own dataset functions so this
+    breaks the moment the seed or the schema drifts."""
+    from benchmax.sft.dataset import SftDataset, SftRow
+
+    dataset = SftDataset(
+        path="<_SEED_MULTIMODAL>",
+        rows=[SftRow("<_SEED_MULTIMODAL>", 1, sft_mod._SEED_MULTIMODAL)],
+        load_issues=[],
+    )
+    report = sft_mod.validate_sft_dataset(dataset)
+    assert report.ok, [
+        (i.severity, i.message) for i in report.issues if i.severity == "error"
+    ]
+
+
+def test_sft_validate_reads_real_dataset(sft_mod, tmp_path):
+    """`validate()` runs the real `load_sft_dataset`/`validate_sft_dataset` pair
+    against the seed data written by `generate_data()` — no network involved."""
+    sft_mod.generate_data()
+    report = sft_mod.validate()
+    assert report.ok
+    assert report.train_row_count == len(sft_mod._SEED_TRAIN)
+    assert report.eval_row_count == len(sft_mod._SEED_EVAL)
+
+
+def test_sft_launch_blocked_by_failing_validate(sft_mod, monkeypatch):
+    calls: list = []
+    monkeypatch.setattr(sft_mod, "validate", lambda: _fake_report(ok=False))
+    monkeypatch.setattr(sft_mod, "upload_sft_run", lambda **k: calls.append(k))
+    monkeypatch.setattr(
+        "builtins.input", lambda *a: (_ for _ in ()).throw(AssertionError)
+    )
+    assert sft_mod.launch() is None
+    assert not calls  # never reached upload
+
+
+def test_sft_launch_no_upload_while_unsupported(sft_mod, monkeypatch):
+    """The pre-upload capability guard: with `SFT_LAUNCH_SUPPORTED` false (its real
+    value as of writing — the live platform doesn't accept env-less sft runs yet),
+    `launch()` must record NO upload call and return None, `--yes` included."""
+    sft_mod.generate_data()
+    assert sft_mod.SFT_LAUNCH_SUPPORTED is False
+    calls: list = []
+    monkeypatch.setattr(sft_mod, "upload_sft_run", lambda **k: calls.append(k))
+    assert sft_mod.launch(assume_yes=True) is None
+    assert not calls
+
+
+def _fake_uploaded_sft_run(train_dataset_path="t", eval_dataset_path="v"):
+    Uploaded = dataclasses.make_dataclass(
+        "UploadedSftRun", ["train_dataset_path", "eval_dataset_path"]
+    )
+    return Uploaded(train_dataset_path, eval_dataset_path)
+
+
+def test_sft_launch_uploads_and_launches_when_supported(sft_mod, monkeypatch):
+    """With the capability flag patched true, `launch()` runs validate -> weight
+    gate -> upload_sft_run -> `TrainerClient.launch_sft_run`, in that order, and
+    spreads the uploaded paths into the launch call."""
+    sft_mod.generate_data()
+    monkeypatch.setattr(sft_mod, "SFT_LAUNCH_SUPPORTED", True)
+    monkeypatch.setattr(
+        sft_mod, "upload_sft_run", lambda **k: _fake_uploaded_sft_run()
+    )
+    launched: dict = {}
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def launch_sft_run(self, **kw):
+            launched.update(kw)
+            return "run-123"
+
+    monkeypatch.setattr(sft_mod, "TrainerClient", lambda: FakeClient())
+    monkeypatch.setattr("builtins.input", lambda *a: "y")
+
+    assert sft_mod.launch() == "run-123"
+    assert launched["train_dataset_path"] == "t"
+    assert launched["eval_dataset_path"] == "v"
+    assert launched["name"] == sft_mod._run_name()
+    assert "allow_experimental_weights" not in (launched["launcher_args"] or {})
+    assert "type" not in (launched["launcher_args"] or {})
+    assert (
+        launched["launcher_args"]["num_epochs"] == sft_mod.LAUNCH_CONFIG["num_epochs"]
+    )
+
+
+def test_sft_launch_blocked_by_weight_gate(sft_mod, tmp_path, monkeypatch):
+    """A weight-bearing dataset blocks launch before the SFT_LAUNCH_SUPPORTED guard
+    (and before upload) unless LAUNCH_CONFIG opts in via
+    `allow_experimental_weights`."""
+    weighted_row = {
+        "messages": [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "masked", "weight": 0},
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": "trained"},
+        ]
+    }
+    (tmp_path / sft_mod.TRAIN_FILE).write_text(json.dumps(weighted_row) + "\n")
+    (tmp_path / sft_mod.EVAL_FILE).write_text(json.dumps(weighted_row) + "\n")
+
+    monkeypatch.setattr(sft_mod, "SFT_LAUNCH_SUPPORTED", True)
+    calls: list = []
+    monkeypatch.setattr(sft_mod, "upload_sft_run", lambda **k: calls.append(k))
+    monkeypatch.setattr(
+        "builtins.input", lambda *a: (_ for _ in ()).throw(AssertionError)
+    )
+
+    assert sft_mod.launch(assume_yes=True) is None
+    assert not calls  # blocked before upload
+
+    sft_mod.LAUNCH_CONFIG["allow_experimental_weights"] = True
+    try:
+        monkeypatch.setattr(
+            sft_mod, "upload_sft_run", lambda **k: _fake_uploaded_sft_run()
+        )
+
+        class FakeClient:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def launch_sft_run(self, **kw):
+                return "run-456"
+
+        monkeypatch.setattr(sft_mod, "TrainerClient", lambda: FakeClient())
+        assert sft_mod.launch(assume_yes=True) == "run-456"
+    finally:
+        sft_mod.LAUNCH_CONFIG.pop("allow_experimental_weights", None)


### PR DESCRIPTION
## Summary
- Slice 6 of `docs/plans/sft-multimodal-interface.md`: new `castform setup --template sft` scaffold, mirroring `generic_main.py`/`rag_main.py`'s structure (`TRAINING_MODE = "sft"` marker, `VALIDATE_CONFIG`/`LAUNCH_CONFIG`, `generate_data`/`validate`/`launch`, import-safe `main()`).
- `launch()` reuses slice 5's exact gate order: validate → weight gate → launcher-arg assembly → `SFT_LAUNCH_SUPPORTED` guard (before any upload) → confirm → `upload_sft_run` → `TrainerClient.launch_sft_run`.
- Registered in `_TEMPLATE_SEEDS` + `--template` choices in `cli/setup.py`; ships `sft_train_dataset.jsonl` / `sft_eval_dataset.jsonl` seed files.
- Opt-in `_SEED_MULTIMODAL` demonstration row (hardcoded ~114-byte data-URI PNG, no pillow dependency) beside the default text-only `_SEED_TRAIN`/`_SEED_EVAL` — not written by default (undefined trainer behavior on a non-vision base model).
- No RL-side multimodal or scaffold doc changes — those are out of scope (RL multimodal is harbor-proper's; docs are slice 7).

## Test plan
- [x] `tests/unit/test_cli_setup.py`: overwrite/exit-code parity tests for the sft template, matching `generic`'s existing behavior exactly.
- [x] `tests/unit/test_scaffold_runner.py`: split the parametrized `mod` fixture into `mod` (all seeds, mode-agnostic dispatch/import-safety assertions) + `rl_mod` (env-class-specific assertions) + a dedicated `sft_mod` fixture, discriminating by the same `TRAINING_MODE` mechanism slice 5 wired in rather than a parallel list.
- [x] `_SEED_MULTIMODAL` validated through `validate_sft_dataset` unconditionally on every test run.
- [x] A test asserts `launch()` records no `upload_sft_run` call while `SFT_LAUNCH_SUPPORTED` is false.
- [x] `uv run pytest tests/unit` — 1266 passed, 3 skipped.
- [x] `uv run ruff check src/` — clean on touched files (3 pre-existing unrelated errors remain elsewhere, same as noted in slice 5).
- [x] Manual smoke: `castform setup --template sft` → `python main.py validate` and `castform validate` both exit 0 on the seed data.