### PR TITLE
Slice 7: skills + scaffold docs for SFT and multimodal

### DIFF
--- a/src/benchmax/cli/scaffold/CLAUDE.md
+++ b/src/benchmax/cli/scaffold/CLAUDE.md
@@ -1,8 +1,9 @@
 # Castform training project
 
-You are driving a reinforcement-learning run with the `castform` CLI. Keep the
-loop simple: tailor the seed env, make data, validate a cheap baseline on real
-rollouts, then decide whether to iterate or spend GPU on launch.
+You are driving a training run with the `castform` CLI — either a
+reinforcement-learning env or an env-less SFT dataset, see the mode check
+below. Keep the loop simple: tailor the seed, make data, validate a cheap
+baseline, then decide whether to iterate or spend GPU on launch.
 
 ## RL project, or SFT project?
 
@@ -11,13 +12,14 @@ Before following the workflow below, check `main.py`'s top for the mode marker
 
 - **`TRAINING_MODE = "sft"`** at module level, no `BaseEnv` subclass →
   an env-less supervised fine-tuning project (`castform setup --template sft`).
-  Skip env design entirely: there is no reward function, no tools, and no
-  rollout budget to tune. Data is `{"messages": [...]}` rows (see
-  generate-data's SFT section), `castform validate` is a local, no-rollout
-  dataset check (see verify-environment's SFT section), and `castform launch`
-  currently fails before upload —
-  `benchmax.platform.client.SFT_LAUNCH_SUPPORTED` is `False` (see launch-run's
-  SFT section).
+  Skip env design entirely: there is no reward function, no rollout-time tool
+  execution, and no rollout budget to tune (dataset rows may still carry a
+  `tools` list and tool-call demonstrations as static training examples — see
+  generate-data's SFT section). Data is `{"messages": [...]}` rows,
+  `castform validate` is a local, no-rollout dataset check (see
+  verify-environment's SFT section), and `castform launch` currently fails
+  before upload — `benchmax.platform.client.SFT_LAUNCH_SUPPORTED` is `False`
+  (see launch-run's SFT section).
 - **No `TRAINING_MODE` marker, a `BaseEnv` subclass present** → a
   reinforcement-learning project. The rest of this file, and the workflow
   below, describes that path.

--- a/src/benchmax/cli/scaffold/CLAUDE.md
+++ b/src/benchmax/cli/scaffold/CLAUDE.md
@@ -4,6 +4,28 @@ You are driving a reinforcement-learning run with the `castform` CLI. Keep the
 loop simple: tailor the seed env, make data, validate a cheap baseline on real
 rollouts, then decide whether to iterate or spend GPU on launch.
 
+## RL project, or SFT project?
+
+Before following the workflow below, check `main.py`'s top for the mode marker
+— don't assume every scaffolded project is a reinforcement-learning env:
+
+- **`TRAINING_MODE = "sft"`** at module level, no `BaseEnv` subclass →
+  an env-less supervised fine-tuning project (`castform setup --template sft`).
+  Skip env design entirely: there is no reward function, no tools, and no
+  rollout budget to tune. Data is `{"messages": [...]}` rows (see
+  generate-data's SFT section), `castform validate` is a local, no-rollout
+  dataset check (see verify-environment's SFT section), and `castform launch`
+  currently fails before upload —
+  `benchmax.platform.client.SFT_LAUNCH_SUPPORTED` is `False` (see launch-run's
+  SFT section).
+- **No `TRAINING_MODE` marker, a `BaseEnv` subclass present** → a
+  reinforcement-learning project. The rest of this file, and the workflow
+  below, describes that path.
+
+A `main.py` with neither — no marker and no `BaseEnv` subclass — is not a valid
+`castform` project; `castform validate`/`launch` raise loudly instead of
+guessing which mode was intended.
+
 ## Required workflow
 
 Every run follows the same stages:

--- a/src/benchmax/cli/scaffold/skills/design-environment/SKILL.md
+++ b/src/benchmax/cli/scaffold/skills/design-environment/SKILL.md
@@ -9,6 +9,21 @@ Use `BaseEnv` for the standard OpenAI-compatible conversation loop. Implement
 the structural `Environment` protocol directly only when another harness owns
 execution.
 
+## RL env, or no env at all?
+
+Build a `BaseEnv` only when the task needs reward-scored rollouts: the model
+acts (optionally with tools), something scores each attempt, and training
+improves the policy from that reward. If the task is closer to "train the model
+to reproduce these input → output conversations" — supervised fine-tuning (SFT)
+on existing demonstrations, no reward function involved — skip the env
+entirely. Set `TRAINING_MODE = "sft"` at the top of `main.py` instead of
+defining a `BaseEnv` subclass; `castform` reads that marker before it goes
+looking for an env class, and a project can't mix the two (a `TRAINING_MODE =
+"sft"` file with a `BaseEnv` subclass in it is a loud error, not a fallback).
+Scaffold the SFT layout directly with `castform setup --template sft`, then
+follow **generate-data**, **verify-environment**, and **launch-run** for the
+SFT-specific parts of each stage.
+
 ## Required shape
 
 ```python
@@ -126,6 +141,24 @@ async def run_tool(self, rollout_id, tool_name, **tool_args):
 
 Tool results may be strings or JSON-serializable values. A raised exception is
 an infrastructure failure and aborts the attempt.
+
+## Multimodal content (SFT datasets)
+
+A message's `content` does not have to be a plain string. A user message with
+`content: [{"type": "image_url", "image_url": {"url": "data:..."}}, {"type":
+"text", "text": "..."}]` is already legal — this is the **SFT dataset pathway**
+(env-less `TRAINING_MODE = "sft"` rows, see generate-data), where such rows are
+validated as-is and preserved through canonicalization. Read and render that
+content with `benchmax.envs.base.content`: `message_text` for the joined text,
+`content_preview` for a truncated single-line preview, `iter_image_refs` to walk
+image URLs in order, and `image_to_data_uri` to turn a local path or raw bytes
+into a `data:` URI for a row.
+
+This skill and the SFT dataset pathway do not cover RL-side multimodal — a
+`BaseEnv` transporting image content through a rollout, or a `compute_reward`
+reading list-shaped content. That is owned natively by harbor-proper's own
+multimodal environments (e.g. its Geo3K env); do not build a custom multimodal
+`BaseEnv` here — see harbor-proper's own docs for that path.
 
 ## Before launch
 

--- a/src/benchmax/cli/scaffold/skills/generate-data/SKILL.md
+++ b/src/benchmax/cli/scaffold/skills/generate-data/SKILL.md
@@ -65,6 +65,55 @@ signal. (Swap `correct` for your reward component.) Mix in some it gets right so
 the reward **varies** across rollouts — a green baseline needs both. A good mix is
 easy rows plus genuinely hard ones the cheap model reliably misses.
 
+### SFT — the `messages` row format
+
+For an env-less SFT project (`TRAINING_MODE = "sft"`, see design-environment),
+each row is the OpenAI fine-tuning chat format, not `prompt`/`ground_truth`:
+
+```jsonl
+{"messages": [{"role": "user", "content": "Translate 'hello' to French."}, {"role": "assistant", "content": "Bonjour."}]}
+```
+
+`messages` is required (per `benchmax.sft.schema`'s row contract) and every row
+needs at least one trained assistant turn. Two fields are optional: a top-level
+`tools` list (OpenAI tool-call format) and a per-assistant-message `weight` (`0`
+or `1`) to exclude that turn from the loss. `weight` is **experimental** —
+trainer support for it is unconfirmed, so `castform launch` blocks a
+weight-bearing dataset unless you pass `--allow-experimental-weights` (see
+launch-run). Load and validate rows with `benchmax.sft`:
+
+```python
+from benchmax.sft import load_sft_dataset, validate_sft_dataset
+
+train = load_sft_dataset("train_dataset.jsonl")
+report = validate_sft_dataset(train)
+```
+
+`load_sft_dataset` is the only reader for SFT data — it normalizes legacy shapes
+on load (a bare `prompt`/`completion` string, a `prompt_messages`/
+`completion_messages` split, flat tool-call entries), so those are also
+accepted as input and canonicalized into `messages` rows.
+
+A user message's `content` can be a list of parts instead of a plain string —
+e.g. a `text` part plus an `image_url` part — for a vision base model. Build the
+`image_url` value with `benchmax.envs.base.content.image_to_data_uri`, which
+turns a local path or raw bytes into a `data:` URI (an existing `data:`/
+`https:` string passes through unchanged):
+
+```python
+from benchmax.envs.base.content import image_to_data_uri
+
+image_url = image_to_data_uri("figure.png")  # -> "data:image/png;base64,..."
+```
+
+**Deriving SFT rows from traces**: `castform data traces` (below) writes
+RL-shaped `{prompt_messages, ground_truth, rollout_args}` rows, discarding the
+model's actual completion. For SFT, use the same `--dry-run` detected system
+prompt/tools, but keep the completion: append it as a trained
+`{"role": "assistant", ...}` message onto the detected `prompt_messages` to get
+a canonical `messages` row. There is no dedicated traces→SFT command yet — treat
+the detected prompt/tools as the starting point and assemble rows by hand.
+
 <!-- rag:start -->
 ### RAG — generate QA pairs from a corpus
 

--- a/src/benchmax/cli/scaffold/skills/launch-run/SKILL.md
+++ b/src/benchmax/cli/scaffold/skills/launch-run/SKILL.md
@@ -25,6 +25,30 @@ Defaults are fine for a smoke run. For a serious run, set the rollout budget and
 epochs deliberately. If eval falls while train rises, the best checkpoint may be
 before the final step.
 
+## SFT launch (and why it doesn't work yet)
+
+For an env-less SFT project (`TRAINING_MODE = "sft"`, see design-environment),
+`castform launch` follows the same shape — validate gate, then upload, then
+launch — but posts `training_mode: "sft"` instead of bundling an env:
+
+```bash
+castform launch --name my-sft-run
+```
+
+Before that: **the live platform does not accept `training_mode` as a launch
+arg yet.** `benchmax.platform.client.SFT_LAUNCH_SUPPORTED` is `False` as of
+writing, and the CLI checks it *before* uploading anything, so `castform
+launch` on an SFT project fails immediately with a clear error instead of
+orphaning uploaded datasets behind a launch that can't succeed. Don't tell a
+user an SFT project is launch-ready today — the upload→launch path is fully
+implemented and tested, it just has nowhere to land until platform support
+ships. Track `SFT_LAUNCH_SUPPORTED` for when that flips.
+
+A weight-bearing dataset (see generate-data's `weight` field — still
+experimental, unconfirmed trainer support) is separately launch-blocked with
+its own error until you pass `--allow-experimental-weights`, independent of the
+`SFT_LAUNCH_SUPPORTED` gate above.
+
 ## Going deeper
 
 ### Discover the accepted args (don't guess)

--- a/src/benchmax/cli/scaffold/skills/verify-environment/SKILL.md
+++ b/src/benchmax/cli/scaffold/skills/verify-environment/SKILL.md
@@ -74,6 +74,32 @@ wrong source identifier — audit the citation matcher before you trust it.
 > vary: that's fine — verify the reward discriminates via the injected-error check
 > below, try a tougher `--model`, and treat a constant-but-verified reward as launchable.
 
+## SFT validate: local, no rollouts
+
+For an env-less SFT project (`TRAINING_MODE = "sft"`, see design-environment),
+`castform validate` takes a different path entirely: it loads and validates the
+dataset **locally** — no remote rollouts, no LLM calls, no GPU — so it runs in
+well under a second even on a large file. There is no reward table and no
+`rewards vary` check; row and schema correctness is the whole gate.
+
+```bash
+castform validate                 # loads train_dataset.jsonl (+ eval_dataset.jsonl), validates, exits
+castform validate --json          # machine-readable report
+```
+
+The scorecard reports row counts (train/eval), a char/4-heuristic token-length
+summary (min/max/mean, plus a count of rows over `max_seq_len`), a masking
+summary (`weight` usage — see generate-data, still experimental), and any
+issues as `path:line  message`, each tagged `✗` (error, gate-failing) or `⚠`
+(notice, informational — e.g. `weight` present, or a row near the size limit).
+Exit is `0` iff the report is `ok`: no error-severity issues, and at least one
+train row (an empty/missing train dataset is itself an error; an empty eval
+dataset is only a notice). `--json` emits the same report shape, plus the `ok`
+verdict.
+
+Because nothing rolls out, this validate is safe and cheap to run on every data
+edit — no GPU cost, no waiting on remote infra.
+
 ## Going deeper
 
 ### Read the scorecard, not just the exit code

--- a/src/benchmax/cli/scaffold/skills/verify-environment/SKILL.md
+++ b/src/benchmax/cli/scaffold/skills/verify-environment/SKILL.md
@@ -78,8 +78,8 @@ wrong source identifier — audit the citation matcher before you trust it.
 
 For an env-less SFT project (`TRAINING_MODE = "sft"`, see design-environment),
 `castform validate` takes a different path entirely: it loads and validates the
-dataset **locally** — no remote rollouts, no LLM calls, no GPU — so it runs in
-well under a second even on a large file. There is no reward table and no
+dataset **locally** — no remote rollouts, no LLM calls, no GPU — so it's
+typically fast even on a large file. There is no reward table and no
 `rewards vary` check; row and schema correctness is the whole gate.
 
 ```bash

--- a/tests/unit/docs/test_skill_refs.py
+++ b/tests/unit/docs/test_skill_refs.py
@@ -1,12 +1,4 @@
-"""Slice 7 gate: the SFT/multimodal symbols and CLI flags named in the edited
-scaffold skill docs (design-environment, generate-data, verify-environment,
-launch-run, scaffold CLAUDE.md) actually exist, and every scaffold template
-still renders cleanly.
-
-Pre-existing harbor-proper env API references in those docs (`BaseEnv`,
-`JsonlDataset`, ...) are accepted skew per the plan's Risks section and are not
-gated here — only symbols/flags newly named by this slice.
-"""
+"""Keep scaffold documentation references valid."""
 
 from __future__ import annotations
 
@@ -69,10 +61,31 @@ def test_launch_allow_experimental_weights_flag_named_in_docs_is_registered():
     assert "--allow-experimental-weights" in launch_parser._option_string_actions
 
 
+def test_launch_name_flag_named_in_docs_is_registered():
+    launch_parser = _subparser("launch")
+    assert "--name" in launch_parser._option_string_actions
+
+
+def test_validate_json_flag_named_in_docs_is_registered():
+    validate_parser = _subparser("validate")
+    assert "--json" in validate_parser._option_string_actions
+
+
 def test_setup_template_sft_choice_named_in_docs_is_registered():
     setup_parser = _subparser("setup")
     action = setup_parser._option_string_actions["--template"]
     assert "sft" in action.choices
+
+
+def test_data_traces_dry_run_flag_named_in_docs_is_registered():
+    data_parser = _subparser("data")
+    data_command = next(
+        action
+        for action in data_parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+    traces_parser = data_command.choices["traces"]
+    assert "--dry-run" in traces_parser._option_string_actions
 
 
 def _ns(tmp, **kw):

--- a/tests/unit/docs/test_skill_refs.py
+++ b/tests/unit/docs/test_skill_refs.py
@@ -1,0 +1,106 @@
+"""Slice 7 gate: the SFT/multimodal symbols and CLI flags named in the edited
+scaffold skill docs (design-environment, generate-data, verify-environment,
+launch-run, scaffold CLAUDE.md) actually exist, and every scaffold template
+still renders cleanly.
+
+Pre-existing harbor-proper env API references in those docs (`BaseEnv`,
+`JsonlDataset`, ...) are accepted skew per the plan's Risks section and are not
+gated here — only symbols/flags newly named by this slice.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from benchmax.cli import build_parser, setup
+
+
+def test_content_helpers_named_in_docs_are_importable():
+    from benchmax.envs.base.content import (
+        content_preview,
+        image_to_data_uri,
+        iter_image_refs,
+        message_text,
+    )
+
+    assert callable(message_text)
+    assert callable(content_preview)
+    assert callable(iter_image_refs)
+    assert callable(image_to_data_uri)
+
+
+def test_sft_dataset_helpers_named_in_docs_are_importable():
+    from benchmax.sft import load_sft_dataset, validate_sft_dataset
+
+    assert callable(load_sft_dataset)
+    assert callable(validate_sft_dataset)
+
+
+def test_sft_schema_module_named_in_docs_is_importable():
+    from benchmax.sft import schema
+
+    assert callable(schema.validate_row)
+
+
+def test_sft_launch_supported_flag_named_in_docs_is_importable():
+    from benchmax.platform.client import SFT_LAUNCH_SUPPORTED
+
+    assert SFT_LAUNCH_SUPPORTED is False
+
+
+def test_training_mode_marker_named_in_docs_matches_the_real_mode_set():
+    from benchmax.cli._project import TRAINING_MODES
+
+    assert TRAINING_MODES == frozenset({"rl", "sft"})
+
+
+def _subparser(name: str) -> argparse.ArgumentParser:
+    parser = build_parser()
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction) and name in action.choices:
+            return action.choices[name]
+    raise AssertionError(f"could not locate the {name!r} subcommand in the parser")
+
+
+def test_launch_allow_experimental_weights_flag_named_in_docs_is_registered():
+    launch_parser = _subparser("launch")
+    assert "--allow-experimental-weights" in launch_parser._option_string_actions
+
+
+def test_setup_template_sft_choice_named_in_docs_is_registered():
+    setup_parser = _subparser("setup")
+    action = setup_parser._option_string_actions["--template"]
+    assert "sft" in action.choices
+
+
+def _ns(tmp, **kw):
+    base = dict(
+        dir=str(tmp),
+        agent="both",
+        force=False,
+        skip_login=True,
+        no_template=False,
+        template="generic",
+        verbose=False,
+    )
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+@pytest.mark.parametrize("template", ["generic", "rag", "sft"])
+def test_every_template_renders_via_castform_setup(tmp_path, template):
+    target = tmp_path / template
+    assert setup._cmd_setup(_ns(target, template=template)) == 0
+    assert (target / "main.py").exists()
+    assert (target / "train_dataset.jsonl").exists()
+    assert (target / "eval_dataset.jsonl").exists()
+    assert (target / "CLAUDE.md").exists()
+    for skill in (
+        "design-environment",
+        "generate-data",
+        "verify-environment",
+        "launch-run",
+    ):
+        assert (target / ".claude" / "skills" / skill / "SKILL.md").exists()


### PR DESCRIPTION
## Summary
- design-environment: RL-env-vs-SFT routing guidance, and multimodal content-part guidance framed for the SFT dataset pathway (RL multimodal pointed at harbor-proper's own environments, e.g. Geo3K)
- generate-data: the SFT `messages` row format (from `benchmax.sft.schema`), multimodal data URIs via `benchmax.envs.base.content.image_to_data_uri`, and a light traces->SFT pointer
- verify-environment: SFT's `castform validate` semantics — local, fast, no rollouts — contrasted with RL's rollout-based validate, plus the scorecard shape
- launch-run: SFT launch, `training_mode`, and the `SFT_LAUNCH_SUPPORTED = False` caveat (SFT launches don't work against the live platform yet)
- scaffold CLAUDE.md: RL-vs-SFT mode-selection guidance (`TRAINING_MODE` marker vs `BaseEnv` subclass)
- `weight` documented as experimental (pending trainer support) everywhere it's mentioned
- `tests/unit/docs/test_skill_refs.py`: every newly named SFT/multimodal symbol imports, `--allow-experimental-weights` and `--template sft` are checked against the real argparse surface, and all three setup templates (`generic`, `rag`, `sft`) still render via `castform setup`

Last slice of docs/plans/sft-multimodal-interface.md (Revision 4) — the plan is fully implemented after this merges.

## Test plan
- [x] `uv run pytest tests/unit/docs/test_skill_refs.py -q` — 10 passed
- [x] `uv run pytest tests/unit -q` — 1276 passed, 3 skipped
- [x] `uv run ruff check src/` — clean except 3 pre-existing, unrelated errors outside this diff (matches slice 5's note; no ruff config enforces them in CI)
- [x] Manual read-through of all 5 edited docs for voice/structure fit (advisory, not gate-blocking)