### PR TITLE
neon corpus provider: slice a contract-freeze

### DIFF
--- a/packages/castform/pyproject.toml
+++ b/packages/castform/pyproject.toml
@@ -40,6 +40,12 @@ traces = ["tqdm>=4.66.0"]
 chroma = ["chromadb>=1.0.0", "snowballstemmer>=2.2.0"]
 pinecone = ["pinecone>=5.0.0"]
 turbopuffer = ["turbopuffer>=1.16.2"]
+neon = [
+    "psycopg[binary]>=3.2.0",
+    "pgvector>=0.3.0",
+    "openai>=2.15.0",
+    "pydantic>=2.0.0",
+]
 
 [dependency-groups]
 dev = [

--- a/packages/castform/src/castform/rag/corpus/neon/CONTRACT.md
+++ b/packages/castform/src/castform/rag/corpus/neon/CONTRACT.md
@@ -1,0 +1,183 @@
+# neon corpus provider — frozen contracts (slice a)
+
+design-lock for the neon lakebase (postgres + pgvector + bm25) corpus provider.
+this slice ships typed stubs, this doc, and parametrized test skeletons only. all
+real sql/client/filter/search logic lands in slices 1/2/4; the live raw-score
+smoke lands in slice 3. the seven contracts below are frozen here.
+
+> convention note: the existing `corpus/` tests are class-grouped with fake
+> injection and assert on native filter dicts — they do not use
+> `pytest.mark.parametrize`, `xfail`, or expected-sql assertions. this slice
+> deliberately introduces parametrized `xfail` skeletons for the not-yet-built
+> sql, because the brief mandates testable truth-table/score skeletons that
+> slices 1/2/4 fill in. flagged so reviewers know it is a new local convention.
+
+## 1. physical table + versioned-replace model
+
+managed physical table (per version):
+
+| column | type | notes |
+|---|---|---|
+| `id` | `text primary key` | chunk hash (sha256 hexdigest) |
+| `content` | `text not null` | |
+| `metadata` | `jsonb not null default '{}'` | |
+| `embedding` | `vector(3072)` | stored full precision |
+| `content_tsv` | `tsvector generated always as (to_tsvector(<config>::regconfig, content)) stored` | config **configurable**, baked per version |
+
+- **logical vs physical**: readers address a stable *logical name*; each ingest
+  builds `\<logical\>__v\<N\>` with its own indexes. an *active-version pointer* =
+  a `neon_corpus_versions` registry row + a `create or replace view \<logical\>`.
+- **atomic activate**: one transaction upserts the registry pointer and
+  re-points the view. **rollback**: re-point to a prior version; old physical
+  tables are retained until pruned, so rollback is O(1) and non-destructive.
+- chunk identity changes with content/metadata, so versioned *replace* (not
+  in-place upsert) is the correct shape.
+- indexes per version: `hnsw` (ann), `bm25` (lexical), `meta_gin` (jsonb
+  containment), `tsv_gin` (native fts fallback).
+- **pgvector dim gotcha (frozen decision)**: `vector` hnsw/ivfflat index only up
+  to 2000 dims, so 3072-dim ann is indexed on a `halfvec(3072)` cast expression
+  with `halfvec_cosine_ops` (halfvec supports hnsw up to 4000). storage stays
+  full-precision `vector(3072)`.
+
+artifacts: `schema.py` (`NeonTableSpec`, ddl templates, `physical_table_name`,
+`index_names`, activate/rollback stubs).
+
+## 2. credential constructor signature
+
+`dsn_provider: str | TokenProvider | None`, resolved lazily, mirroring
+turbopuffer's `as_token_provider`/`env_token`. **separate read vs write
+surfaces** — a single provider can't be both rw-ingest and ro-search:
+
+- read: `resolve_read_dsn_provider(...)` -> default `env_token("NEON_CORPUS_DSN_RO")`, select-only grant.
+- write: `resolve_write_dsn_provider(...)` -> default `env_token("NEON_CORPUS_DSN_RW")`, ddl+dml grant.
+
+the sandbox rollout env only ever receives the ro provider. artifacts:
+`credentials.py` (signatures), consumed by `search.py`/`source.py`/`client.py`.
+seam implemented in slice 4.
+
+## 3. 9-op filter truth table
+
+operators: `eq, ne, in, gt, gte, lt, lte, contains_any, contains_all`. the
+shared enum has six today; neon adds `ne, gt, lt` (promotion into the shared
+enum deferred to slice 4 — a local `NeonFieldOperator` superset holds the
+contract meanwhile). metadata is accessed via **bound json paths**
+(`metadata ->> %(k)s`), never `psycopg.sql.Identifier` on a caller key. cast is
+`::numeric` iff the dsl value is int/float, else text.
+
+value-present emitted sql (numeric variant shown; text variant drops `::numeric`):
+
+| op | emitted sql | cast | null/missing key | empty-array operand | negation |
+|---|---|---|---|---|---|
+| eq | `(metadata ->> %(k)s) = %(v)s` | text | exclude | — | `not (...)` |
+| ne | `(metadata ->> %(k)s) is distinct from %(v)s` | text | **include** | — | `not (...)` |
+| in | `(metadata ->> %(k)s) = any(%(v)s)` | text | exclude | exclude | `not (...)` |
+| gt | `(metadata ->> %(k)s)::numeric > %(v)s` | numeric | exclude | — | `not (...)` |
+| gte | `(metadata ->> %(k)s)::numeric >= %(v)s` | numeric | exclude | — | `not (...)` |
+| lt | `(metadata ->> %(k)s)::numeric < %(v)s` | numeric | exclude | — | `not (...)` |
+| lte | `(metadata ->> %(k)s)::numeric <= %(v)s` | numeric | exclude | — | `not (...)` |
+| contains_any | `(metadata -> %(k)s) ?| %(v)s` | jsonb_array | exclude | exclude | `not (...)` |
+| contains_all | `(metadata -> %(k)s) ?& %(v)s` | jsonb_array | exclude | **include** (vacuous) | `not (...)` |
+
+edge-condition rules (frozen):
+- **null / missing key**: `->>` yields sql null; under 3-valued logic every op
+  except `ne` drops the row. `ne` uses `is distinct from`, so a null/missing key
+  is "distinct from" the value and the row is **included** (null-safe ne).
+- **empty-array operand**: `in []` and `contains_any []` match nothing
+  (exclude); `contains_all []` is vacuously true (**include**) — the one
+  exception.
+- **negation**: `NotPredicate` -> `not (<inner>)`, inheriting 3-valued logic, so
+  `not (null)` is null and negating a leaf over a missing key still excludes.
+  null-inclusive negation would need `(<inner>) is not true`; the frozen
+  contract is plain `not (...)`.
+- **contains_any/all representation**: primary form is jsonb key-existence
+  `?|` / `?&` over an array-of-text field. the typed-array `&&` / `@>` form is
+  the deferred fallback for numeric/typed arrays (noted per row in
+  `filter_mapper.py`).
+
+artifacts: `filter_mapper.py` (`FILTER_TRUTH_TABLE`, `NEON_FIELD_OPERATORS`,
+`NEGATION_TEMPLATE`, `predicate_to_sql` stub); skeleton
+`tests/.../neon/test_filter_truth_table.py`.
+
+## 4. public score contract — one formula per mode
+
+native scorers disagree on direction: bm25 `<@>` is negative/lower-better,
+vector cosine distance is lower-better, rrf is higher-better. rather than surface
+three scales, the **public score is a uniform rank-based reciprocal rank**, always
+higher-better:
+
+```
+surfaced_score(rank) = 1 / (SURFACED_RANK_K + rank)   # rank 0-based, K = 60
+```
+
+- monotonic decreasing in rank by construction => `search_related`
+  relevance-descending holds regardless of the raw scorer range.
+- `rank` = 0-based position in a single query's result list ordered better-first
+  by that mode's native scorer (bm25 asc `<@>`, vector asc distance, hybrid the
+  fused ordering).
+- **multi-query dedup** mirrors `postgres/source.py`: a chunk hit by several
+  queries keeps the **max** reciprocal rank as `max_score`; results sort by
+  `(len(queries), not same_file, max_score)` all descending.
+- raw native scores retained internally, not surfaced. empirical `<@>` range
+  validation deferred to the slice 3 live smoke; formula + monotonicity + dedup
+  frozen here.
+
+exact numeric anchors (in the test skeleton): rank 0 -> `1/60 =
+0.016666666666666666`, rank 1 -> `1/61 = 0.01639344262295082`, rank 2 -> `1/62 =
+0.016129032258064516`. a chunk at rank 0 in query a and rank 2 in query b
+dedups to `max_score = 1/60`.
+
+artifacts: `search.py` (`surfaced_score`, `SURFACED_RANK_K`, `fuse_rrf` stub);
+skeleton `tests/.../neon/test_surfaced_score.py`.
+
+## 5. scan_chunks determinism
+
+`NeonChunkSource.scan_chunks(batch_size=1000) -> Iterator[Chunk]` yields the full
+corpus in a **stable order** `(file, index, id)` (`SCAN_ORDER_BY`) via keyset
+pagination, so qa-gen full-corpus materialization is reproducible run to run
+(not just count/sample reads). `file`/`index` come from chunk metadata
+(`source_file`, `chunk_index`); `id` (hash) is the final tiebreak. neon extension
+to the surface; promotion onto the shared `ChunkSource` protocol deferred.
+
+artifacts: `source.py` (`scan_chunks` stub, `SCAN_ORDER_BY`); skeleton
+`tests/.../neon/test_scan_chunks_determinism.py`.
+
+## 6. eval jsonl schema
+
+fields: `capability`, `search_mode`, `query`, `filter_dsl` (json dsl form or
+null), `gold_chunk_hashes` (exact — carried explicitly because `Chunk.to_dict`
+omits `hash`), `decoy_chunk_hashes`. per-mode thresholds + lexical-ablation delta
+are frozen:
+
+| mode | hit@5 | mrr@5 |
+|---|---|---|
+| lexical | 0.80 | 0.65 |
+| vector | 0.85 | 0.70 |
+| hybrid | 0.90 | 0.75 |
+
+`LEXICAL_ABLATION_MIN_DELTA = 0.05` — hybrid must beat lexical-only hit@5 by at
+least this. schema only; data built later. artifacts: `eval_schema.py`
+(`NeonEvalRecord`, `NeonEvalThresholds`, `DEFAULT_THRESHOLDS`).
+
+## 7. embedding dim/metric + internal query interface
+
+- `EMBEDDING_DIM = 3072`, `DISTANCE_METRIC = "cosine"` (`schema.py`).
+- internal request `NeonQueryRequest(mode, top_k, text, vector, filter, hybrid)`
+  (`search.py`). **filtering is orthogonal** (3 modes x filtered/unfiltered), not
+  a fourth mode. **hybrid rrf has a single owner** = the internal query layer
+  (`fuse_rrf`); no other component blends lexical+vector.
+
+## deviations from the brief (escalated, not silently re-planned)
+
+1. **no in-repo sql template exists.** the `postgres` provider is an http client
+   to the corpora api (client-side dict merge for `search_related`), and no
+   provider imports psycopg. neon is the first sql-emitting backend, so the sql
+   seam (bound json paths, `<@>`, halfvec index) is frozen here from first
+   principles rather than mirrored. turbopuffer is still the template for the
+   credential seam and the pickle-safe search client shape.
+2. **new test convention.** parametrized `xfail` skeletons are introduced (see
+   note at top); the house style is class-grouped fake-injection. justified by
+   the brief's testable-skeleton requirement.
+3. **shared operator enum untouched.** `ne/gt/lt` live in a neon-local
+   `NeonFieldOperator` superset; promoting them into
+   `search_schema/search_types.py` is a cross-cutting edit deferred to slice 4 to
+   keep this slice inside the `neon/` package.

--- a/packages/castform/src/castform/rag/corpus/neon/CONTRACT.md
+++ b/packages/castform/src/castform/rag/corpus/neon/CONTRACT.md
@@ -29,28 +29,43 @@ managed physical table (per version):
   owner-rights view (`security_invoker = false`) with an **explicit column list**
   (never `SELECT *`). each ingest builds `<logical>__v<N>` with its own indexes.
 - **per-version ledger** `neon_corpus_versions(logical_name, version, state,
-  created_at, ready_at, activated_at)` with state `building -> ready ->
-  activated -> retired`. this replaces the single-row pointer so concurrent
-  ingest / enumerate / prune / build-vs-ready are all well-defined.
-- **atomic activate**: one transaction under `pg_advisory_xact_lock(logical)`
-  upserts the ledger active row AND `create or replace view` — they commit or
-  roll back together (proven by `test_activation_rolls_back_atomically`).
-  **rollback**: re-point to any prior `ready`/`activated` version; old physical
-  tables retained until pruned → O(1), non-destructive.
-- **retention/pruning** (`RetentionPolicy`): keep >= 2 activated (rollback always
-  has a target) + >= 1 ready; older versions retired then pruned.
-- **RO grants** (`ReadGrantSpec`): the RO role gets schema `USAGE` + `SELECT` on
-  the stable view only, re-issued on FIRST view creation (`create or replace`
-  preserves an existing ACL but the first create has none). owner-rights view =>
-  RO never touches physical tables.
+  is_current, created_at, ready_at, activated_at, retired_at)`. `state` has a
+  **DB CHECK domain** `building -> ready -> activated -> retired`
+  (`VERSION_STATE_TRANSITIONS` frozen for Slice 2 enforcement).
+- **current-pointer invariant**: `state='activated'` is *historical* (published at
+  least once); `is_current` marks the SINGLE currently-published version. a
+  **partial unique index** `ON neon_corpus_versions (logical_name) WHERE
+  is_current` (`CREATE_CURRENT_POINTER_INDEX`) enforces exactly one current per
+  logical name. rollback flips `is_current` between two `activated` versions
+  without changing state.
+- **atomic activate** (`activate_version_sql(spec, grant)`): one transaction under
+  `pg_advisory_xact_lock(logical)` clears the prior `is_current`, sets this
+  version `activated`/`is_current`, `create or replace view`, AND issues the RO
+  grants from `grant` — commit or roll back together (proven by
+  `test_activation_rolls_back_atomically`). **rollback**: re-point `is_current` to
+  a prior `activated` version; old physical tables retained → O(1),
+  non-destructive.
+- **retention** (`RetentionPolicy`, self-validating): keep >= 2 activated
+  (rollback always has a target) + >= 1 ready. the **pruning seam** and full
+  concurrent allocation/prune race-safety are **deferred to Slice 2** (where the
+  real DDL/transactions land); the invariant + locking contract are frozen now.
+- **RO grants** (`ReadGrantSpec`): owner-rights view (`security_invoker = false`)
+  => RO gets schema `USAGE` + `SELECT` on the stable view only, never physical
+  tables. issued on FIRST view creation (`create or replace` preserves an existing
+  ACL but a first create has none), which is why activation carries `grant`.
+- **view identifier policy** (B4): the reader-facing view name is
+  `view_name(logical_name)` — validated printable-ASCII and length-fitted to 63
+  bytes (a long logical name is hash-fitted, same as physical names); readers
+  resolve it through `view_name`, never assume it equals the raw logical name.
 - indexes per version: `ann` (PROVISIONAL), `bm25` (lexical), `meta_gin`
   (`jsonb_path_ops`, serves `@>`), `scan` (btree `(source_file, chunk_index,
   id)`), `tsv_gin` (native fts fallback).
 - **injection-safe DDL** (B4): all identifiers via `psycopg.sql.Identifier`;
-  regconfig + options via allowlist + bound `sql.Literal`; version numbers
-  validated (`validate_version`, positive int, rejects bool); names length-safe
-  to 63 bytes via content-hash suffix (`_fit_identifier`); the execute seam
-  accepts `sql.Composable`, never `str`.
+  regconfig via allowlist + bound `sql.Literal`; version numbers validated
+  (`validate_version`, positive int, rejects bool); logical names validated
+  (`validate_logical_name`, printable ASCII); names **byte-safe** to 63 bytes with
+  a 64-bit content-hash suffix (`_fit_identifier` — collision-resistant, not a
+  uniqueness guarantee); the execute seam accepts `sql.Composable`, never `str`.
 
 ## 2. credential constructor signature
 
@@ -70,51 +85,62 @@ operators: `eq, ne, in, gt, gte, lt, lte, contains_any, contains_all` (shared si
 slice 4). metadata key + every value are **bound params** (`%(k)s`/`%(v)s`);
 `psycopg.sql.Identifier` is never used on caller keys.
 
-two safety properties are frozen (they drove the review REVISE):
+three safety properties are frozen (they drove the review):
 
 - **type-directed, never-throwing**: `eq/ne/in` and `contains_*` emit JSONB
-  **containment** (`metadata @> jsonb_build_object(...)`), which is type-aware and
-  needs no cast — a heterogeneous stored value can never abort the query. only
-  `gt/gte/lt/lte` cast, and they are **guarded** by `jsonb_typeof(metadata ->
-  key) = 'number'`.
-- **indexable**: containment is served by the `meta_gin` `jsonb_path_ops` GIN.
-  the old `?|`/`?&` forms are rejected — a whole-doc GIN cannot serve them (B3).
-  range predicates are not GIN-indexable (per-key expression btree is an
-  operational add-on).
+  **containment** (`metadata @> jsonb_build_object(...)`), type-aware, no cast. the
+  range ops are the only cast path, and the cast lives **inside a CASE** (`CASE
+  WHEN jsonb_typeof(...) = 'number' THEN (...)::numeric ... ELSE NULL END`) — NOT
+  behind `AND`, because Postgres does not guarantee `AND` short-circuits, whereas
+  a CASE only evaluates the matching branch, so `::numeric` never sees a
+  non-number.
+- **correct negation**: bare containment is two-valued (FALSE for missing/null/
+  wrong-type), so `not(false)` would wrongly INCLUDE those rows. every op therefore
+  also carries a **three-valued `negated_leaf_sql`** (`CASE WHEN NOT
+  jsonb_exists(metadata, key) THEN NULL WHEN jsonb_typeof(...) <> '<type>' THEN
+  NULL ELSE <containment> END`); `NotPredicate` wraps *that* in `not (...)`, so
+  `not(null) = null` keeps missing/null/wrong-type excluded. key existence uses
+  `jsonb_exists(metadata, %(k)s)` (function form; the `?` operator collides with
+  psycopg placeholders).
+- **indexable positives**: positive containment is served by the `meta_gin`
+  `jsonb_path_ops` GIN (the `?|`/`?&` forms are rejected — a whole-doc GIN cannot
+  serve them). negated CASE leaves and range CASEs are not GIN-eligible; neither is
+  empty-array `contains_all` (`@> '[]'` has no scalar token), so its
+  `empty_operand_indexable` is False (B3 caveat).
 
-canonical value-present sql (numeric value shown for eq/ne/in; text for contains):
+canonical POSITIVE sql (numeric value shown for eq/ne/in; text for contains; the
+cast token follows the value type — `CONTAINS_ATOM_BY_TYPE` freezes text/number/
+boolean shapes):
 
-| op | family | canonical sql | indexable |
+| op | family | positive sql | indexable |
 |---|---|---|---|
 | eq | containment | `metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))` | yes |
 | ne | negated containment | `(metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))) IS NOT TRUE` | no |
 | in | containment OR | `(metadata @> …%(v0)s…) OR (metadata @> …%(v1)s…)` | yes |
-| gt/gte/lt/lte | range | `jsonb_typeof(metadata -> %(k)s) = 'number' AND (metadata ->> %(k)s)::numeric {op} %(v)s::numeric` | no |
+| gt/gte/lt/lte | range CASE | `CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number' THEN (metadata ->> %(k)s)::numeric {op} %(v)s::numeric ELSE NULL END` | no |
 | contains_any | containment OR | `(metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v0)s::text))) OR …%(v1)s…)` | yes |
-| contains_all | array containment | `metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v0)s::text), to_jsonb(%(v1)s::text)))` | yes |
+| contains_all | array containment | `metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v0)s::text), to_jsonb(%(v1)s::text)))` | yes (empty operand: no) |
 
-**five distinct edge outcomes** (include / exclude), per op:
+**five distinct edge outcomes** of the POSITIVE leaf (negation inverts via the
+three-valued `negated_leaf_sql`, so a negated leaf still excludes
+missing/null/wrong-type):
 
-| op | missing key | json null | wrong type | empty operand | negated |
-|---|---|---|---|---|---|
-| eq | exclude | exclude | exclude | — | `not (…)` 3-valued |
-| ne | **include** | **include** | **include** | — | `not (…)` |
-| in | exclude | exclude | exclude | exclude | `not (…)` |
-| gt/gte/lt/lte | exclude | exclude | exclude | — | `not (…)` |
-| contains_any | exclude | exclude | exclude | exclude | `not (…)` |
-| contains_all | exclude | exclude | exclude | **include** | `not (…)` |
+| op | missing key | json null | wrong type | empty operand |
+|---|---|---|---|---|
+| eq | exclude | exclude | exclude | — |
+| ne | **include** | **include** | **include** | — |
+| in | exclude | exclude | exclude | exclude |
+| gt/gte/lt/lte | exclude | exclude | exclude | — |
+| contains_any | exclude | exclude | exclude | exclude |
+| contains_all | exclude | exclude | exclude | **include** |
 
-- **ne is null-safe** via `IS NOT TRUE`: missing/null/wrong-type => included; only
-  an equal stored value is excluded.
+- **ne is null-safe** via `IS NOT TRUE` (null-INCLUSIVE); this differs from
+  `NotPredicate(eq)`, which is null-EXCLUSIVE via the three-valued leaf.
 - **`contains_all []`**: `@> '{"key": []}'` is true iff the field is a present
-  array (empty array is contained in any array); when the field is **missing** it
-  is **excluded** (not vacuously true).
-- **negation**: `NotPredicate` -> `not (<inner>)`, inheriting 3-valued logic
-  (`not(null)` is null → a negated leaf over a missing key still excludes).
-  null-inclusive negation would need `(<inner>) is not true`; the frozen contract
-  is plain `not (…)`.
-- **value validation** (raises `InvalidFilterError` in slice 4): range ops
-  require a numeric value (int/float, **not** bool); `in`/`contains_*` require a
+  array; when the field is **missing** it is **excluded** (not vacuously true).
+  the empty-array case is NOT index-accelerated.
+- **value validation** (raises `InvalidFilterError` in slice 4): range ops require
+  a numeric value (int/float, **not** bool); `in`/`contains_*` require a
   homogeneous list (mixed json types and bool-as-number rejected); `eq/ne` take a
   single text/number/boolean scalar.
 
@@ -131,7 +157,9 @@ surfaced_score(rank) = 1 / (SURFACED_RANK_K + rank)   # rank 0-based, K = 60
   negative/lower-better, vector distance lower-better, rrf higher-better).
 - **native score preserved separately (NB1)**: `QueryHit.native_score` and the
   `native_score` result key carry the raw backend number for diagnostics /
-  calibration — never overloaded onto `max_score`.
+  calibration — never overloaded onto `max_score`. after dedup, `native_score`
+  comes from the **same winning hit that supplied `max_score`** (the best-ranked
+  occurrence), not averaged or retained per-query.
 - **multi-query dedup + ordering** (in `NeonChunkSource.search_related`): a chunk
   hit by several queries keeps the **max** reciprocal rank as `max_score`;
   results sort by the FULL 3-tuple `(len(queries), not same_file, max_score)` all
@@ -186,6 +214,18 @@ lakebase DB and then freeze only the proven form (see
 - **meta_gin index EXPLAIN** (B3). the `@>`/`jsonb_path_ops` pairing is standard
   postgres and frozen, but slice 3 should confirm via `EXPLAIN` that the
   containment predicates actually hit the GIN on live data.
+
+## deferred to the implementing slice (contract frozen now, enforcement later)
+
+- **B5 pruning seam + concurrent allocation/prune race-safety -> Slice 2.** the
+  ledger schema, state CHECK domain, current-pointer unique index, advisory-lock
+  activation contract, and retention policy are frozen here; the prune executor
+  and the concurrent build-vs-prune race tests land in Slice 2 with the real DDL.
+- **B7 fully-seeded behavioral tests -> the slice that implements each behavior
+  (1/2/4).** round 2 ships correctly-structured strict xfails (fake-backed,
+  non-vacuous, typed) that raise `NotImplementedError`; the real behavior
+  assertions (filter SQL execution, paged scan rows, transaction rollback events)
+  are filled when each behavior is implemented.
 
 ## deviations from the brief (surfaced, not silently re-planned)
 

--- a/packages/castform/src/castform/rag/corpus/neon/CONTRACT.md
+++ b/packages/castform/src/castform/rag/corpus/neon/CONTRACT.md
@@ -33,11 +33,14 @@ managed physical table (per version):
   **DB CHECK domain** `building -> ready -> activated -> retired`
   (`VERSION_STATE_TRANSITIONS` frozen for Slice 2 enforcement).
 - **current-pointer invariant**: `state='activated'` is *historical* (published at
-  least once); `is_current` marks the SINGLE currently-published version. a
-  **partial unique index** `ON neon_corpus_versions (logical_name) WHERE
-  is_current` (`CREATE_CURRENT_POINTER_INDEX`) enforces exactly one current per
-  logical name. rollback flips `is_current` between two `activated` versions
-  without changing state.
+  least once); `is_current` marks the currently-published version. a **partial
+  unique index** `ON neon_corpus_versions (logical_name) WHERE is_current`
+  (`CREATE_CURRENT_POINTER_INDEX`) enforces **at-most-one** current row per logical
+  name (zero is legal — e.g. before the first publish). a SUCCESSFUL atomic
+  activation establishes exactly-one for a published corpus; DB-enforced
+  *existence* of a current row, if ever required, needs a separate current-pointer
+  structure (out of scope now). rollback flips `is_current` between two
+  `activated` versions without changing state.
 - **atomic activate** (`activate_version_sql(spec, grant)`): one transaction under
   `pg_advisory_xact_lock(logical)` clears the prior `is_current`, sets this
   version `activated`/`is_current`, `create or replace view`, AND issues the RO

--- a/packages/castform/src/castform/rag/corpus/neon/CONTRACT.md
+++ b/packages/castform/src/castform/rag/corpus/neon/CONTRACT.md
@@ -2,17 +2,16 @@
 
 design-lock for the neon lakebase (postgres + pgvector + bm25) corpus provider.
 this slice ships typed stubs, this doc, and parametrized test skeletons only. all
-real sql/client/filter/search logic lands in slices 1/2/4; the live raw-score
-smoke lands in slice 3. the seven contracts below are frozen here.
+real sql/client/filter/search logic lands in slices 1/2/4; live verification of
+the ann access method + index EXPLAIN lands in slice 3 (see PROVISIONAL below).
 
 > convention note: the existing `corpus/` tests are class-grouped with fake
-> injection and assert on native filter dicts — they do not use
-> `pytest.mark.parametrize`, `xfail`, or expected-sql assertions. this slice
-> deliberately introduces parametrized `xfail` skeletons for the not-yet-built
-> sql, because the brief mandates testable truth-table/score skeletons that
-> slices 1/2/4 fill in. flagged so reviewers know it is a new local convention.
+> injection and no `parametrize`/`xfail`. this slice introduces parametrized
+> skeletons marked `xfail(raises=NotImplementedError, strict=True)` for the
+> not-yet-built sql, so they xfail cleanly (no silent XPASS) and flip to failing
+> the moment a stub is implemented incorrectly. flagged as a new local convention.
 
-## 1. physical table + versioned-replace model
+## 1. physical table + versioned-replace lifecycle
 
 managed physical table (per version):
 
@@ -21,26 +20,37 @@ managed physical table (per version):
 | `id` | `text primary key` | chunk hash (sha256 hexdigest) |
 | `content` | `text not null` | |
 | `metadata` | `jsonb not null default '{}'` | |
-| `embedding` | `vector(3072)` | stored full precision |
-| `content_tsv` | `tsvector generated always as (to_tsvector(<config>::regconfig, content)) stored` | config **configurable**, baked per version |
+| `embedding` | PROVISIONAL vector type | see §PROVISIONAL — not frozen |
+| `source_file` | `text not null` | typed scan-order column (B6) |
+| `chunk_index` | `integer not null` | typed scan-order column (B6) |
+| `content_tsv` | `tsvector generated always as (to_tsvector(<config>::regconfig, content)) stored` | config allowlisted, baked per version |
 
-- **logical vs physical**: readers address a stable *logical name*; each ingest
-  builds `\<logical\>__v\<N\>` with its own indexes. an *active-version pointer* =
-  a `neon_corpus_versions` registry row + a `create or replace view \<logical\>`.
-- **atomic activate**: one transaction upserts the registry pointer and
-  re-points the view. **rollback**: re-point to a prior version; old physical
-  tables are retained until pruned, so rollback is O(1) and non-destructive.
-- chunk identity changes with content/metadata, so versioned *replace* (not
-  in-place upsert) is the correct shape.
-- indexes per version: `hnsw` (ann), `bm25` (lexical), `meta_gin` (jsonb
-  containment), `tsv_gin` (native fts fallback).
-- **pgvector dim gotcha (frozen decision)**: `vector` hnsw/ivfflat index only up
-  to 2000 dims, so 3072-dim ann is indexed on a `halfvec(3072)` cast expression
-  with `halfvec_cosine_ops` (halfvec supports hnsw up to 4000). storage stays
-  full-precision `vector(3072)`.
-
-artifacts: `schema.py` (`NeonTableSpec`, ddl templates, `physical_table_name`,
-`index_names`, activate/rollback stubs).
+- **logical vs physical**: readers address a stable *logical name* via an
+  owner-rights view (`security_invoker = false`) with an **explicit column list**
+  (never `SELECT *`). each ingest builds `<logical>__v<N>` with its own indexes.
+- **per-version ledger** `neon_corpus_versions(logical_name, version, state,
+  created_at, ready_at, activated_at)` with state `building -> ready ->
+  activated -> retired`. this replaces the single-row pointer so concurrent
+  ingest / enumerate / prune / build-vs-ready are all well-defined.
+- **atomic activate**: one transaction under `pg_advisory_xact_lock(logical)`
+  upserts the ledger active row AND `create or replace view` — they commit or
+  roll back together (proven by `test_activation_rolls_back_atomically`).
+  **rollback**: re-point to any prior `ready`/`activated` version; old physical
+  tables retained until pruned → O(1), non-destructive.
+- **retention/pruning** (`RetentionPolicy`): keep >= 2 activated (rollback always
+  has a target) + >= 1 ready; older versions retired then pruned.
+- **RO grants** (`ReadGrantSpec`): the RO role gets schema `USAGE` + `SELECT` on
+  the stable view only, re-issued on FIRST view creation (`create or replace`
+  preserves an existing ACL but the first create has none). owner-rights view =>
+  RO never touches physical tables.
+- indexes per version: `ann` (PROVISIONAL), `bm25` (lexical), `meta_gin`
+  (`jsonb_path_ops`, serves `@>`), `scan` (btree `(source_file, chunk_index,
+  id)`), `tsv_gin` (native fts fallback).
+- **injection-safe DDL** (B4): all identifiers via `psycopg.sql.Identifier`;
+  regconfig + options via allowlist + bound `sql.Literal`; version numbers
+  validated (`validate_version`, positive int, rejects bool); names length-safe
+  to 63 bytes via content-hash suffix (`_fit_identifier`); the execute seam
+  accepts `sql.Composable`, never `str`.
 
 ## 2. credential constructor signature
 
@@ -48,105 +58,102 @@ artifacts: `schema.py` (`NeonTableSpec`, ddl templates, `physical_table_name`,
 turbopuffer's `as_token_provider`/`env_token`. **separate read vs write
 surfaces** — a single provider can't be both rw-ingest and ro-search:
 
-- read: `resolve_read_dsn_provider(...)` -> default `env_token("NEON_CORPUS_DSN_RO")`, select-only grant.
-- write: `resolve_write_dsn_provider(...)` -> default `env_token("NEON_CORPUS_DSN_RW")`, ddl+dml grant.
+- read: `resolve_read_dsn_provider(...)` -> default `env_token("NEON_CORPUS_DSN_RO")`, select-only.
+- write: `resolve_write_dsn_provider(...)` -> default `env_token("NEON_CORPUS_DSN_RW")`, ddl+dml.
 
-the sandbox rollout env only ever receives the ro provider. artifacts:
-`credentials.py` (signatures), consumed by `search.py`/`source.py`/`client.py`.
-seam implemented in slice 4.
+the sandbox rollout env only ever receives the ro provider. seam built in slice 4.
 
-## 3. 9-op filter truth table
+## 3. 9-op filter truth table (type-directed, indexable)
 
-operators: `eq, ne, in, gt, gte, lt, lte, contains_any, contains_all`. the
-shared enum has six today; neon adds `ne, gt, lt` (promotion into the shared
-enum deferred to slice 4 — a local `NeonFieldOperator` superset holds the
-contract meanwhile). metadata is accessed via **bound json paths**
-(`metadata ->> %(k)s`), never `psycopg.sql.Identifier` on a caller key. cast is
-`::numeric` iff the dsl value is int/float, else text.
+operators: `eq, ne, in, gt, gte, lt, lte, contains_any, contains_all` (shared six
++ `ne/gt/lt` in a neon-local superset; promotion to the shared enum deferred to
+slice 4). metadata key + every value are **bound params** (`%(k)s`/`%(v)s`);
+`psycopg.sql.Identifier` is never used on caller keys.
 
-value-present emitted sql (numeric variant shown; text variant drops `::numeric`):
+two safety properties are frozen (they drove the review REVISE):
 
-| op | emitted sql | cast | null/missing key | empty-array operand | negation |
+- **type-directed, never-throwing**: `eq/ne/in` and `contains_*` emit JSONB
+  **containment** (`metadata @> jsonb_build_object(...)`), which is type-aware and
+  needs no cast — a heterogeneous stored value can never abort the query. only
+  `gt/gte/lt/lte` cast, and they are **guarded** by `jsonb_typeof(metadata ->
+  key) = 'number'`.
+- **indexable**: containment is served by the `meta_gin` `jsonb_path_ops` GIN.
+  the old `?|`/`?&` forms are rejected — a whole-doc GIN cannot serve them (B3).
+  range predicates are not GIN-indexable (per-key expression btree is an
+  operational add-on).
+
+canonical value-present sql (numeric value shown for eq/ne/in; text for contains):
+
+| op | family | canonical sql | indexable |
+|---|---|---|---|
+| eq | containment | `metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))` | yes |
+| ne | negated containment | `(metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))) IS NOT TRUE` | no |
+| in | containment OR | `(metadata @> …%(v0)s…) OR (metadata @> …%(v1)s…)` | yes |
+| gt/gte/lt/lte | range | `jsonb_typeof(metadata -> %(k)s) = 'number' AND (metadata ->> %(k)s)::numeric {op} %(v)s::numeric` | no |
+| contains_any | containment OR | `(metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v0)s::text))) OR …%(v1)s…)` | yes |
+| contains_all | array containment | `metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v0)s::text), to_jsonb(%(v1)s::text)))` | yes |
+
+**five distinct edge outcomes** (include / exclude), per op:
+
+| op | missing key | json null | wrong type | empty operand | negated |
 |---|---|---|---|---|---|
-| eq | `(metadata ->> %(k)s) = %(v)s` | text | exclude | — | `not (...)` |
-| ne | `(metadata ->> %(k)s) is distinct from %(v)s` | text | **include** | — | `not (...)` |
-| in | `(metadata ->> %(k)s) = any(%(v)s)` | text | exclude | exclude | `not (...)` |
-| gt | `(metadata ->> %(k)s)::numeric > %(v)s` | numeric | exclude | — | `not (...)` |
-| gte | `(metadata ->> %(k)s)::numeric >= %(v)s` | numeric | exclude | — | `not (...)` |
-| lt | `(metadata ->> %(k)s)::numeric < %(v)s` | numeric | exclude | — | `not (...)` |
-| lte | `(metadata ->> %(k)s)::numeric <= %(v)s` | numeric | exclude | — | `not (...)` |
-| contains_any | `(metadata -> %(k)s) ?| %(v)s` | jsonb_array | exclude | exclude | `not (...)` |
-| contains_all | `(metadata -> %(k)s) ?& %(v)s` | jsonb_array | exclude | **include** (vacuous) | `not (...)` |
+| eq | exclude | exclude | exclude | — | `not (…)` 3-valued |
+| ne | **include** | **include** | **include** | — | `not (…)` |
+| in | exclude | exclude | exclude | exclude | `not (…)` |
+| gt/gte/lt/lte | exclude | exclude | exclude | — | `not (…)` |
+| contains_any | exclude | exclude | exclude | exclude | `not (…)` |
+| contains_all | exclude | exclude | exclude | **include** | `not (…)` |
 
-edge-condition rules (frozen):
-- **null / missing key**: `->>` yields sql null; under 3-valued logic every op
-  except `ne` drops the row. `ne` uses `is distinct from`, so a null/missing key
-  is "distinct from" the value and the row is **included** (null-safe ne).
-- **empty-array operand**: `in []` and `contains_any []` match nothing
-  (exclude); `contains_all []` is vacuously true (**include**) — the one
-  exception.
-- **negation**: `NotPredicate` -> `not (<inner>)`, inheriting 3-valued logic, so
-  `not (null)` is null and negating a leaf over a missing key still excludes.
-  null-inclusive negation would need `(<inner>) is not true`; the frozen
-  contract is plain `not (...)`.
-- **contains_any/all representation**: primary form is jsonb key-existence
-  `?|` / `?&` over an array-of-text field. the typed-array `&&` / `@>` form is
-  the deferred fallback for numeric/typed arrays (noted per row in
-  `filter_mapper.py`).
+- **ne is null-safe** via `IS NOT TRUE`: missing/null/wrong-type => included; only
+  an equal stored value is excluded.
+- **`contains_all []`**: `@> '{"key": []}'` is true iff the field is a present
+  array (empty array is contained in any array); when the field is **missing** it
+  is **excluded** (not vacuously true).
+- **negation**: `NotPredicate` -> `not (<inner>)`, inheriting 3-valued logic
+  (`not(null)` is null → a negated leaf over a missing key still excludes).
+  null-inclusive negation would need `(<inner>) is not true`; the frozen contract
+  is plain `not (…)`.
+- **value validation** (raises `InvalidFilterError` in slice 4): range ops
+  require a numeric value (int/float, **not** bool); `in`/`contains_*` require a
+  homogeneous list (mixed json types and bool-as-number rejected); `eq/ne` take a
+  single text/number/boolean scalar.
 
-artifacts: `filter_mapper.py` (`FILTER_TRUTH_TABLE`, `NEON_FIELD_OPERATORS`,
-`NEGATION_TEMPLATE`, `predicate_to_sql` stub); skeleton
-`tests/.../neon/test_filter_truth_table.py`.
+## 4. public score contract — one formula per mode (+ native score split)
 
-## 4. public score contract — one formula per mode
-
-native scorers disagree on direction: bm25 `<@>` is negative/lower-better,
-vector cosine distance is lower-better, rrf is higher-better. rather than surface
-three scales, the **public score is a uniform rank-based reciprocal rank**, always
-higher-better:
+uniform rank-based reciprocal rank, always higher-better:
 
 ```
 surfaced_score(rank) = 1 / (SURFACED_RANK_K + rank)   # rank 0-based, K = 60
 ```
 
 - monotonic decreasing in rank by construction => `search_related`
-  relevance-descending holds regardless of the raw scorer range.
-- `rank` = 0-based position in a single query's result list ordered better-first
-  by that mode's native scorer (bm25 asc `<@>`, vector asc distance, hybrid the
-  fused ordering).
-- **multi-query dedup** mirrors `postgres/source.py`: a chunk hit by several
-  queries keeps the **max** reciprocal rank as `max_score`; results sort by
-  `(len(queries), not same_file, max_score)` all descending.
-- raw native scores retained internally, not surfaced. empirical `<@>` range
-  validation deferred to the slice 3 live smoke; formula + monotonicity + dedup
-  frozen here.
-
-exact numeric anchors (in the test skeleton): rank 0 -> `1/60 =
-0.016666666666666666`, rank 1 -> `1/61 = 0.01639344262295082`, rank 2 -> `1/62 =
-0.016129032258064516`. a chunk at rank 0 in query a and rank 2 in query b
-dedups to `max_score = 1/60`.
-
-artifacts: `search.py` (`surfaced_score`, `SURFACED_RANK_K`, `fuse_rrf` stub);
-skeleton `tests/.../neon/test_surfaced_score.py`.
+  relevance-descending holds regardless of raw scorer direction (bm25 `<@>`
+  negative/lower-better, vector distance lower-better, rrf higher-better).
+- **native score preserved separately (NB1)**: `QueryHit.native_score` and the
+  `native_score` result key carry the raw backend number for diagnostics /
+  calibration — never overloaded onto `max_score`.
+- **multi-query dedup + ordering** (in `NeonChunkSource.search_related`): a chunk
+  hit by several queries keeps the **max** reciprocal rank as `max_score`;
+  results sort by the FULL 3-tuple `(len(queries), not same_file, max_score)` all
+  descending (mirrors `postgres/source.py`). result dicts key `{chunk, queries,
+  same_file, max_score, native_score}`.
+- exact numeric anchors: rank 0 -> `1/60 = 0.016666666666666666`, rank 1 ->
+  `1/61`, rank 2 -> `1/62`. empirical `<@>` range validation deferred to the slice
+  3 live smoke; formula + monotonicity + dedup frozen here.
 
 ## 5. scan_chunks determinism
 
 `NeonChunkSource.scan_chunks(batch_size=1000) -> Iterator[Chunk]` yields the full
-corpus in a **stable order** `(file, index, id)` (`SCAN_ORDER_BY`) via keyset
-pagination, so qa-gen full-corpus materialization is reproducible run to run
-(not just count/sample reads). `file`/`index` come from chunk metadata
-(`source_file`, `chunk_index`); `id` (hash) is the final tiebreak. neon extension
-to the surface; promotion onto the shared `ChunkSource` protocol deferred.
-
-artifacts: `source.py` (`scan_chunks` stub, `SCAN_ORDER_BY`); skeleton
-`tests/.../neon/test_scan_chunks_determinism.py`.
+corpus in a **total, pageable** order `(source_file, chunk_index, id)` over the
+TYPED NOT NULL columns (not JSONB extraction), backed by the `scan` btree. this
+avoids lexical `chunk_index` sorting (1,10,2), NULL-break keysets, and collation
+ambiguity; the keyset cursor is `(source_file, chunk_index, id) > (%s, %s, %s)`.
 
 ## 6. eval jsonl schema
 
-fields: `capability`, `search_mode`, `query`, `filter_dsl` (json dsl form or
-null), `gold_chunk_hashes` (exact — carried explicitly because `Chunk.to_dict`
-omits `hash`), `decoy_chunk_hashes`. per-mode thresholds + lexical-ablation delta
-are frozen:
+`NeonEvalRecord{capability, search_mode, query, filter_dsl (json dsl or null),
+gold_chunk_hashes (exact — carried explicitly because `Chunk.to_dict` omits
+`hash`), decoy_chunk_hashes}`. per-mode thresholds + lexical-ablation delta frozen:
 
 | mode | hit@5 | mrr@5 |
 |---|---|---|
@@ -154,30 +161,44 @@ are frozen:
 | vector | 0.85 | 0.70 |
 | hybrid | 0.90 | 0.75 |
 
-`LEXICAL_ABLATION_MIN_DELTA = 0.05` — hybrid must beat lexical-only hit@5 by at
-least this. schema only; data built later. artifacts: `eval_schema.py`
-(`NeonEvalRecord`, `NeonEvalThresholds`, `DEFAULT_THRESHOLDS`).
+`LEXICAL_ABLATION_MIN_DELTA = 0.05`. schema only; data built later.
 
 ## 7. embedding dim/metric + internal query interface
 
-- `EMBEDDING_DIM = 3072`, `DISTANCE_METRIC = "cosine"` (`schema.py`).
-- internal request `NeonQueryRequest(mode, top_k, text, vector, filter, hybrid)`
-  (`search.py`). **filtering is orthogonal** (3 modes x filtered/unfiltered), not
-  a fourth mode. **hybrid rrf has a single owner** = the internal query layer
-  (`fuse_rrf`); no other component blends lexical+vector.
+- `EMBEDDING_DIM = 3072`, `DISTANCE_METRIC = "cosine"`.
+- `NeonQueryRequest(mode, top_k, text, vector, filter, hybrid)`. **filtering
+  orthogonal** (3 modes x filtered/unfiltered), not a 4th mode. **hybrid rrf
+  single-owned** by the query layer (`fuse_rrf`).
 
-## deviations from the brief (escalated, not silently re-planned)
+## PROVISIONAL — must verify on live neon (slice 3)
 
-1. **no in-repo sql template exists.** the `postgres` provider is an http client
-   to the corpora api (client-side dict merge for `search_related`), and no
-   provider imports psycopg. neon is the first sql-emitting backend, so the sql
-   seam (bound json paths, `<@>`, halfvec index) is frozen here from first
-   principles rather than mirrored. turbopuffer is still the template for the
-   credential seam and the pickle-safe search client shape.
-2. **new test convention.** parametrized `xfail` skeletons are introduced (see
-   note at top); the house style is class-grouped fake-injection. justified by
-   the brief's testable-skeleton requirement.
-3. **shared operator enum untouched.** `ne/gt/lt` live in a neon-local
-   `NeonFieldOperator` superset; promoting them into
-   `search_schema/search_types.py` is a cross-cutting edit deferred to slice 4 to
-   keep this slice inside the `neon/` package.
+the following are **not frozen**; slice 3 must verify them against the live
+lakebase DB and then freeze only the proven form (see
+`schema.PROVISIONAL_ANN_OPTIONS`):
+
+- **ann access method + vector type + opclass** (B1). the stub emits vanilla
+  `hnsw`/`halfvec` as a *fallback*; the intended primary is native
+  `lakebase_ann` on `vector(3072)`. the 2000-dim `vector` hnsw limit and the
+  `halfvec` workaround are vanilla-pgvector facts, UNPROVEN for `lakebase_ann`.
+  slice 3 must: attempt `lakebase_ann` on `vector(3072)` AND the halfvec
+  alternative, verify index creation, cosine queries, matching query casts, and
+  `EXPLAIN` index use — then freeze the proven DDL.
+- **meta_gin index EXPLAIN** (B3). the `@>`/`jsonb_path_ops` pairing is standard
+  postgres and frozen, but slice 3 should confirm via `EXPLAIN` that the
+  containment predicates actually hit the GIN on live data.
+
+## deviations from the brief (surfaced, not silently re-planned)
+
+1. **no in-repo sql template exists** — the `postgres` provider is an http client
+   to the corpora api (client-side dict merge). neon is the first sql-emitting
+   backend; the sql seam is frozen from first principles. turbopuffer remains the
+   template for the credential seam + pickle-safe search client; score
+   dedup/order mirrors `postgres/source.py`'s 3-tuple.
+2. **new test convention** — parametrized `xfail(strict=True,
+   raises=NotImplementedError)` skeletons (house style is class-grouped
+   fake-injection). justified by the testable-skeleton requirement.
+3. **shared operator enum untouched** — `ne/gt/lt` in a neon-local superset;
+   promotion into `search_schema/search_types.py` deferred to slice 4.
+4. **`?|`/`?&` -> `@>` containment** — the filter representation changed from the
+   first draft's jsonb key-existence to indexable containment, reconciling B2
+   (type safety) and B3 (indexability) in one form.

--- a/packages/castform/src/castform/rag/corpus/neon/client.py
+++ b/packages/castform/src/castform/rag/corpus/neon/client.py
@@ -1,0 +1,44 @@
+"""Neon connection + SQL execution seam.
+
+Contract-freeze artifact (Slice A). Signatures only; psycopg and pgvector are
+imported lazily inside methods (never at module load) so this module — and the
+whole ``neon`` package — imports without the ``neon`` extra installed, matching
+the pickle-safe, lazy-import discipline of ``turbopuffer/search.py`` and
+``corpus/embed.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from castform.platform.credentials import TokenProvider
+
+
+class NeonClient:
+    """Thin connection + SQL-execution wrapper over a resolved Neon DSN.
+
+    Args:
+        dsn_provider: Callable resolving a DSN string per connection. The read
+            path passes an RO provider, the ingest path an RW provider.
+    """
+
+    def __init__(self, dsn_provider: TokenProvider) -> None:
+        self._dsn_provider = dsn_provider
+        self._conn: Any = None
+
+    def _connect(self) -> Any:
+        """Open (or reuse) a psycopg connection, registering pgvector adapters.
+
+        Design-lock stub: connection + adapter registration land in Slice 4.
+        The real body imports ``psycopg`` and ``pgvector.psycopg`` lazily here.
+        """
+        raise NotImplementedError("Neon connection is built in Slice 4")
+
+    def execute(
+        self, sql: str, params: dict[str, Any] | None = None
+    ) -> list[tuple[Any, ...]]:
+        """Execute a parameterized statement and return rows.
+
+        Design-lock stub: built in Slice 4.
+        """
+        raise NotImplementedError("Neon SQL execution is built in Slice 4")

--- a/packages/castform/src/castform/rag/corpus/neon/client.py
+++ b/packages/castform/src/castform/rag/corpus/neon/client.py
@@ -55,8 +55,17 @@ class NeonClient:
         """Run *statements* as one all-or-nothing transaction (B5).
 
         Used to publish a version so the ledger update and the ``CREATE OR
-        REPLACE VIEW`` commit or roll back together. If any statement raises, the
-        whole transaction is rolled back and the error propagates. Design-lock
-        stub: built in Slice 4.
+        REPLACE VIEW`` commit or roll back together. Statements run on the shared
+        connection; on the first failure the whole transaction is rolled back and
+        the error re-raised, leaving no partial state. The *orchestration* is real
+        (and unit-testable against an injected connection); only opening the
+        connection (``_connect``) is the Slice 4 stub.
         """
-        raise NotImplementedError("Neon transactions are built in Slice 4")
+        conn = self._conn if self._conn is not None else self._connect()
+        try:
+            for statement in statements:
+                conn.execute(statement)
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise

--- a/packages/castform/src/castform/rag/corpus/neon/client.py
+++ b/packages/castform/src/castform/rag/corpus/neon/client.py
@@ -5,13 +5,21 @@ imported lazily inside methods (never at module load) so this module — and the
 whole ``neon`` package — imports without the ``neon`` extra installed, matching
 the pickle-safe, lazy-import discipline of ``turbopuffer/search.py`` and
 ``corpus/embed.py``.
+
+The execute seam accepts **composable SQL** (``psycopg.sql.Composable``), never a
+raw ``str`` (B4): every identifier reaches the driver as ``sql.Identifier`` and
+every literal as a bound parameter or ``sql.Literal``, so dynamic table/view/index
+names cannot be injection vectors.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from castform.platform.credentials import TokenProvider
+
+if TYPE_CHECKING:
+    from psycopg import sql
 
 
 class NeonClient:
@@ -35,10 +43,20 @@ class NeonClient:
         raise NotImplementedError("Neon connection is built in Slice 4")
 
     def execute(
-        self, sql: str, params: dict[str, Any] | None = None
+        self, query: sql.Composable, params: dict[str, Any] | None = None
     ) -> list[tuple[Any, ...]]:
-        """Execute a parameterized statement and return rows.
+        """Execute one composable statement with bound params and return rows.
 
         Design-lock stub: built in Slice 4.
         """
         raise NotImplementedError("Neon SQL execution is built in Slice 4")
+
+    def execute_in_transaction(self, statements: list[sql.Composable]) -> None:
+        """Run *statements* as one all-or-nothing transaction (B5).
+
+        Used to publish a version so the ledger update and the ``CREATE OR
+        REPLACE VIEW`` commit or roll back together. If any statement raises, the
+        whole transaction is rolled back and the error propagates. Design-lock
+        stub: built in Slice 4.
+        """
+        raise NotImplementedError("Neon transactions are built in Slice 4")

--- a/packages/castform/src/castform/rag/corpus/neon/credentials.py
+++ b/packages/castform/src/castform/rag/corpus/neon/credentials.py
@@ -1,0 +1,61 @@
+"""Neon DSN credential seam — separate read and write provider surfaces.
+
+Contract-freeze artifact (Slice A). Signatures only; lazy resolution and the
+psycopg connection are wired in Slice 4.
+
+The Neon connection string (DSN) rides the same ``str | TokenProvider | None``
+seam turbopuffer uses for its API key (see ``rag/corpus/turbopuffer/search.py``
+and ``platform/credentials.py``): ``None`` reads the DSN from the environment at
+runtime (self-serve path), a ``str`` bakes a literal DSN into the pickled env
+(platform-orchestrated path), and a callable is invoked per connection.
+
+Read and write are deliberately *separate* provider surfaces. A single provider
+cannot be both the RW-ingest role (DDL + INSERT into version tables) and the
+RO-search role (SELECT only, no DDL/DML) — the RO grant is what the sandbox
+rollout env is handed, so it cannot mutate the corpus even if compromised.
+"""
+
+from __future__ import annotations
+
+from castform.platform.credentials import TokenProvider, as_token_provider, env_token
+
+READ_DSN_ENV_VAR = "NEON_CORPUS_DSN_RO"
+"""Env var holding the read-only (search) DSN. RO grant: SELECT only."""
+
+WRITE_DSN_ENV_VAR = "NEON_CORPUS_DSN_RW"
+"""Env var holding the read-write (ingest) DSN. RW grant: DDL + DML."""
+
+
+def resolve_read_dsn_provider(
+    dsn_provider: str | TokenProvider | None = None,
+) -> TokenProvider:
+    """Return the lazily-resolved read-only DSN provider for search.
+
+    Mirrors ``as_token_provider(value, env_token(READ_DSN_ENV_VAR))``. The
+    returned callable yields a DSN string carrying only the RO grant.
+    Design-lock stub: the resolution wiring lands in Slice 4.
+    """
+    raise NotImplementedError("read DSN resolution is built in Slice 4")
+
+
+def resolve_write_dsn_provider(
+    dsn_provider: str | TokenProvider | None = None,
+) -> TokenProvider:
+    """Return the lazily-resolved read-write DSN provider for ingest.
+
+    Mirrors ``as_token_provider(value, env_token(WRITE_DSN_ENV_VAR))``. The
+    returned callable yields a DSN string carrying the RW grant.
+    Design-lock stub: the resolution wiring lands in Slice 4.
+    """
+    raise NotImplementedError("write DSN resolution is built in Slice 4")
+
+
+__all__ = [
+    "READ_DSN_ENV_VAR",
+    "WRITE_DSN_ENV_VAR",
+    "TokenProvider",
+    "as_token_provider",
+    "env_token",
+    "resolve_read_dsn_provider",
+    "resolve_write_dsn_provider",
+]

--- a/packages/castform/src/castform/rag/corpus/neon/eval_schema.py
+++ b/packages/castform/src/castform/rag/corpus/neon/eval_schema.py
@@ -1,0 +1,67 @@
+"""Eval JSONL schema for the Neon corpus retrieval eval.
+
+Contract-freeze artifact (Slice A). The models here are the *real* frozen wire
+schema (they validate today); the eval *data* is generated in a later slice.
+
+Gold-chunk identity carries the hash explicitly
+-----------------------------------------------
+``Chunk.to_dict`` in ``rag/chunkers/models.py`` OMITS the ``hash`` field, so the
+gold/decoy references cannot be recovered from a serialized chunk. This schema
+therefore carries the chunk hashes as first-class fields (``gold_chunk_hashes``,
+``decoy_chunk_hashes``) — an eval record is self-contained and does not depend on
+re-deriving identity from content.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from castform.rag.corpus.search_schema.search_types import SearchMode
+
+
+class NeonEvalThresholds(BaseModel, frozen=True):
+    """Per-mode pass thresholds plus the lexical-ablation delta.
+
+    Args:
+        hit_at_k: Minimum hit@k (fraction of queries whose gold set is retrieved
+            within the top ``k``).
+        mrr_at_k: Minimum mean reciprocal rank over the top ``k``.
+        k: The retrieval depth ``k`` these thresholds are measured at.
+    """
+
+    hit_at_k: float
+    mrr_at_k: float
+    k: int = 5
+
+
+# Frozen default thresholds per mode. Hybrid must clear the highest bar; vector
+# beats lexical; the ablation delta is how much hybrid must beat lexical-only.
+DEFAULT_THRESHOLDS: dict[SearchMode, NeonEvalThresholds] = {
+    "lexical": NeonEvalThresholds(hit_at_k=0.80, mrr_at_k=0.65, k=5),
+    "vector": NeonEvalThresholds(hit_at_k=0.85, mrr_at_k=0.70, k=5),
+    "hybrid": NeonEvalThresholds(hit_at_k=0.90, mrr_at_k=0.75, k=5),
+}
+
+LEXICAL_ABLATION_MIN_DELTA = 0.05
+"""Minimum hit@5 improvement hybrid must show over lexical-only retrieval."""
+
+
+class NeonEvalRecord(BaseModel):
+    """One retrieval-eval example.
+
+    Args:
+        capability: The retrieval capability under test (e.g. a filter or mode).
+        search_mode: Mode the example exercises.
+        query: The eval query text.
+        filter_dsl: Optional filter predicate in the JSON DSL form
+            (``search_schema`` serialization), or ``None`` for unfiltered.
+        gold_chunk_hashes: Exact chunk-hash ids that count as correct hits.
+        decoy_chunk_hashes: Chunk-hash ids that must NOT be surfaced as hits.
+    """
+
+    capability: str
+    search_mode: SearchMode
+    query: str
+    filter_dsl: dict | None = None
+    gold_chunk_hashes: list[str] = Field(min_length=1)
+    decoy_chunk_hashes: list[str] = Field(default_factory=list)

--- a/packages/castform/src/castform/rag/corpus/neon/filter_mapper.py
+++ b/packages/castform/src/castform/rag/corpus/neon/filter_mapper.py
@@ -1,34 +1,41 @@
 """Filter DSL -> parameterized, INDEXABLE SQL truth table for the Neon corpus.
 
 Contract-freeze artifact (Slice A). This module freezes, per operator: the
-type-directed SQL shape, its five distinct edge outcomes (missing key, JSON null,
-wrong stored type, empty operand, negated), whether the shape is index-eligible,
-and the value-validation rules. The translator that walks a ``FilterPredicate``
-tree and emits ``(sql, params)`` is Slice 4 — ``predicate_to_sql`` is a stub.
+type-directed positive SQL, the three-valued *negated-leaf* SQL, the five edge
+outcomes, index-eligibility, and the value-validation rules. The translator that
+walks a ``FilterPredicate`` tree and emits ``(sql, params)`` is Slice 4 —
+``predicate_to_sql`` is a stub.
 
-Two safety properties are frozen here (they drove the review REVISE):
+Three safety properties are frozen (they drove the review):
 
-1. **Type-directed, never-throwing.** ``eq/ne/in`` and the ``contains_*`` ops are
-   emitted as JSONB **containment** (``metadata @> jsonb_build_object(...)``),
-   which is *type-aware* (``'{"a":5}' @> '{"a":"5"}'`` is false) and therefore
-   needs no cast — a heterogeneous stored value can never abort the query. The
-   range ops (``gt/gte/lt/lte``) are the only cast path, and they are **guarded**
-   by ``jsonb_typeof(metadata -> key) = 'number'`` so ``::numeric`` is reached
-   only for numbers.
-2. **Indexable.** Containment is served by a ``jsonb_path_ops`` GIN (see
-   ``schema.CREATE_META_GIN_INDEX_SKELETON``). The earlier ``?|``/``?&`` forms are
-   NOT used: a whole-doc GIN cannot serve ``(metadata -> key) ?| values`` and
-   ``jsonb_path_ops`` does not index key-existence at all (B3). Range predicates
-   are not GIN-indexable; a per-key expression btree is an operational add-on.
+1. **Type-directed, never-throwing.** ``eq/ne/in`` and ``contains_*`` emit JSONB
+   **containment** (``metadata @> jsonb_build_object(...)``), which is type-aware
+   (``'{"a":5}' @> '{"a":"5"}'`` is false) and needs no cast. The range ops are
+   the only cast path, and the cast is placed **inside a CASE** (``CASE WHEN
+   jsonb_typeof(...) = 'number' THEN (...)::numeric ... ELSE NULL END``) — NOT
+   behind ``AND``. Postgres does not guarantee ``AND`` short-circuits, but a CASE
+   only evaluates the matching branch, so ``::numeric`` never sees a non-number.
+2. **Correct negation.** Bare containment is two-valued (FALSE for a
+   missing/null/wrong-type key), so ``NOT(FALSE)`` would wrongly INCLUDE those
+   rows. Every op therefore also exposes a **three-valued negated leaf**
+   (``negated_leaf_sql``) that yields SQL ``NULL`` for missing/null/wrong-type via
+   a guarding CASE; ``NotPredicate`` wraps *that* in ``NOT(...)``, so
+   ``NOT(NULL) = NULL`` keeps those rows excluded (matching the truth table).
+3. **Indexable positives.** The positive containment forms are served by the
+   ``meta_gin`` ``jsonb_path_ops`` GIN. Negated leaves (CASE) and range CASEs are
+   not GIN-eligible — and neither is empty-array ``contains_all`` (``@> '[]'`` has
+   no scalar token in ``jsonb_path_ops``), so its ``empty_operand_indexable`` is
+   False (B3 caveat).
 
 Bound-path discipline: the metadata key and every value are bound parameters
-(``%(k)s`` / ``%(v)s``); ``psycopg.sql.Identifier`` is reserved for trusted
-schema-owned names, never for caller JSON keys.
+(``%(k)s`` / ``%(v)s``); key existence uses ``jsonb_exists(metadata, %(k)s)`` (the
+function form, not the ``?`` operator, which collides with psycopg placeholder
+parsing). ``psycopg.sql.Identifier`` is never used on caller keys.
 
 Operator set: nine field ops. The shared enum carries six (``eq, in, gte, lte,
 contains_any, contains_all``); Neon adds ``ne, gt, lt`` in a local superset;
-promoting them into ``search_schema/search_types.py`` is a Slice 4 cross-cutting
-edit kept out of this slice.
+promoting them into ``search_schema/search_types.py`` is a Slice 4 edit kept out
+of this slice.
 """
 
 from __future__ import annotations
@@ -64,6 +71,21 @@ CAST_BY_SCALAR_TYPE: dict[ScalarJsonType, str] = {
     "number": "numeric",
     "boolean": "boolean",
 }
+# The ``jsonb_typeof`` token the CASE guard compares against, per value type.
+JSON_TYPEOF_BY_SCALAR_TYPE: dict[ScalarJsonType, str] = {
+    "text": "string",
+    "number": "number",
+    "boolean": "boolean",
+}
+
+# Explicit contains_* element shapes per type (freezes numeric/boolean, not just
+# text): the single-element containment atom Slice 4 ORs (contains_any) or
+# array-joins (contains_all).
+CONTAINS_ATOM_BY_TYPE: dict[ScalarJsonType, str] = {
+    "text": "metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v)s::text)))",
+    "number": "metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v)s::numeric)))",
+    "boolean": "metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v)s::boolean)))",
+}
 
 # Per-condition outcome for a single leaf. ``depends`` = matches iff the stored
 # value satisfies the op; the other four are fixed regardless of value.
@@ -78,28 +100,32 @@ class FilterOpSpec:
     Args:
         op: The Neon field operator.
         family: ``containment`` (indexable ``@>``), ``negated_containment``
-            (``@> ... IS NOT TRUE``), or ``range`` (guarded numeric cast).
-        canonical_sql: The exact emitted SQL for a representative value-present
-            case. ``%(k)s`` binds the key; ``%(v)s`` / ``%(v0)s`` / ``%(v1)s`` bind
-            values. ``in``/``contains_any`` show the two-element OR expansion;
-            ``contains_all`` shows the two-element single-containment form.
-        value_types: Scalar JSON types this op accepts (element types for the
-            list ops).
-        indexable: Whether ``meta_gin`` (``jsonb_path_ops``) can serve it.
-        outcomes: Fixed include/exclude behavior per edge condition.
+            (``@> ... IS NOT TRUE``), or ``range`` (guarded CASE cast).
+        positive_sql: The WHERE form for a NON-negated leaf. Representative
+            value-present case; ``%(k)s`` binds the key, ``%(v)s``/``%(v0)s``/
+            ``%(v1)s`` bind values. Indexable iff ``indexable``.
+        negated_leaf_sql: The THREE-VALUED expression a ``NotPredicate`` wraps in
+            ``NOT(...)``. Yields NULL for missing/null/wrong-type so negation
+            still excludes them.
+        value_types: Scalar JSON types this op accepts (element types for lists).
+        indexable: Whether ``meta_gin`` can serve ``positive_sql`` (non-empty
+            operand).
+        empty_operand_indexable: For list ops, whether the empty-operand case is
+            index-accelerated (False for ``contains_all []``).
+        outcomes: Fixed include/exclude behavior of the POSITIVE leaf per edge
+            condition (negation inverts via ``negated_leaf_sql``).
     """
 
     op: NeonFieldOperator
     family: Literal["containment", "negated_containment", "range"]
-    canonical_sql: str
+    positive_sql: str
+    negated_leaf_sql: str
     value_types: tuple[ScalarJsonType, ...]
     indexable: bool
+    empty_operand_indexable: bool
     outcomes: dict[EdgeConditions, Outcome]
 
 
-# Every op excludes on missing key / JSON null / wrong stored type EXCEPT ``ne``
-# (null-safe: ``IS NOT TRUE`` flips NULL/false to true, so a missing/null/wrong
-# value is *included*).
 _SCALAR_EXCLUDING = {
     "missing_key": "exclude",
     "json_null": "exclude",
@@ -113,117 +139,181 @@ _NE_INCLUDING = {
     "empty_operand": "na",
 }
 
+# Guarding CASE that makes a containment leaf three-valued for negation. The
+# ``{inner}`` is the positive containment; the type guard also catches json-null
+# (its jsonb_typeof is 'null').
+_NEG_CASE = (
+    "CASE WHEN NOT jsonb_exists(metadata, %(k)s) THEN NULL "
+    "WHEN jsonb_typeof(metadata -> %(k)s) <> '{jtype}' THEN NULL "
+    "ELSE {inner} END"
+)
+
 
 # --- Contract #3: the frozen 9-op truth table ---------------------------------
 FILTER_TRUTH_TABLE: tuple[FilterOpSpec, ...] = (
     FilterOpSpec(
         op="eq",
         family="containment",
-        canonical_sql="metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))",
+        positive_sql="metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))",
+        negated_leaf_sql=_NEG_CASE.format(
+            jtype="number",
+            inner="metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))",
+        ),
         value_types=("text", "number", "boolean"),
         indexable=True,
+        empty_operand_indexable=False,
         outcomes=dict(_SCALAR_EXCLUDING),
     ),
     FilterOpSpec(
-        # Null-safe: missing/null/wrong-type rows are INCLUDED; only an equal
-        # stored value is excluded.
+        # ne is null-INCLUSIVE by design: (@>) IS NOT TRUE includes
+        # missing/null/wrong-type and excludes only an equal stored value. This
+        # differs from NotPredicate(eq), which is null-EXCLUSIVE.
         op="ne",
         family="negated_containment",
-        canonical_sql=(
+        positive_sql=(
+            "(metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))) "
+            "IS NOT TRUE"
+        ),
+        negated_leaf_sql=(
             "(metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))) "
             "IS NOT TRUE"
         ),
         value_types=("text", "number", "boolean"),
         indexable=False,
+        empty_operand_indexable=False,
         outcomes=dict(_NE_INCLUDING),
     ),
     FilterOpSpec(
         op="in",
         family="containment",
-        canonical_sql=(
+        positive_sql=(
             "(metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v0)s::numeric)) OR "
             "metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v1)s::numeric)))"
         ),
+        negated_leaf_sql=_NEG_CASE.format(
+            jtype="number",
+            inner=(
+                "(metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v0)s::numeric)) OR "
+                "metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v1)s::numeric)))"
+            ),
+        ),
         value_types=("text", "number", "boolean"),
         indexable=True,
+        empty_operand_indexable=True,  # empty in => constant FALSE, no scan
         outcomes={**_SCALAR_EXCLUDING, "empty_operand": "exclude"},
     ),
     FilterOpSpec(
         op="gt",
         family="range",
-        canonical_sql=(
-            "jsonb_typeof(metadata -> %(k)s) = 'number' "
-            "AND (metadata ->> %(k)s)::numeric > %(v)s::numeric"
+        positive_sql=(
+            "CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number' "
+            "THEN (metadata ->> %(k)s)::numeric > %(v)s::numeric ELSE NULL END"
+        ),
+        negated_leaf_sql=(
+            "CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number' "
+            "THEN (metadata ->> %(k)s)::numeric > %(v)s::numeric ELSE NULL END"
         ),
         value_types=("number",),
         indexable=False,
+        empty_operand_indexable=False,
         outcomes=dict(_SCALAR_EXCLUDING),
     ),
     FilterOpSpec(
         op="gte",
         family="range",
-        canonical_sql=(
-            "jsonb_typeof(metadata -> %(k)s) = 'number' "
-            "AND (metadata ->> %(k)s)::numeric >= %(v)s::numeric"
+        positive_sql=(
+            "CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number' "
+            "THEN (metadata ->> %(k)s)::numeric >= %(v)s::numeric ELSE NULL END"
+        ),
+        negated_leaf_sql=(
+            "CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number' "
+            "THEN (metadata ->> %(k)s)::numeric >= %(v)s::numeric ELSE NULL END"
         ),
         value_types=("number",),
         indexable=False,
+        empty_operand_indexable=False,
         outcomes=dict(_SCALAR_EXCLUDING),
     ),
     FilterOpSpec(
         op="lt",
         family="range",
-        canonical_sql=(
-            "jsonb_typeof(metadata -> %(k)s) = 'number' "
-            "AND (metadata ->> %(k)s)::numeric < %(v)s::numeric"
+        positive_sql=(
+            "CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number' "
+            "THEN (metadata ->> %(k)s)::numeric < %(v)s::numeric ELSE NULL END"
+        ),
+        negated_leaf_sql=(
+            "CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number' "
+            "THEN (metadata ->> %(k)s)::numeric < %(v)s::numeric ELSE NULL END"
         ),
         value_types=("number",),
         indexable=False,
+        empty_operand_indexable=False,
         outcomes=dict(_SCALAR_EXCLUDING),
     ),
     FilterOpSpec(
         op="lte",
         family="range",
-        canonical_sql=(
-            "jsonb_typeof(metadata -> %(k)s) = 'number' "
-            "AND (metadata ->> %(k)s)::numeric <= %(v)s::numeric"
+        positive_sql=(
+            "CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number' "
+            "THEN (metadata ->> %(k)s)::numeric <= %(v)s::numeric ELSE NULL END"
+        ),
+        negated_leaf_sql=(
+            "CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number' "
+            "THEN (metadata ->> %(k)s)::numeric <= %(v)s::numeric ELSE NULL END"
         ),
         value_types=("number",),
         indexable=False,
+        empty_operand_indexable=False,
         outcomes=dict(_SCALAR_EXCLUDING),
     ),
     FilterOpSpec(
         # Array membership via per-element containment OR. Empty operand => no
-        # atoms => FALSE => exclude.
+        # atoms => FALSE => exclude (constant, no scan).
         op="contains_any",
         family="containment",
-        canonical_sql=(
+        positive_sql=(
             "(metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v0)s::text))) OR "
             "metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v1)s::text))))"
         ),
+        negated_leaf_sql=_NEG_CASE.format(
+            jtype="array",
+            inner=(
+                "(metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v0)s::text))) OR "
+                "metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v1)s::text))))"
+            ),
+        ),
         value_types=("text", "number", "boolean"),
         indexable=True,
+        empty_operand_indexable=True,  # empty => constant FALSE
         outcomes={**_SCALAR_EXCLUDING, "empty_operand": "exclude"},
     ),
     FilterOpSpec(
         # Superset via single array containment. Empty operand => ``@> '[]'`` =>
-        # TRUE iff the field is present as an array (missing key still excludes).
+        # TRUE iff the field is a present array (missing key still excludes), and
+        # ``@> '[]'`` has no jsonb_path_ops scalar token => NOT index-accelerated.
         op="contains_all",
         family="containment",
-        canonical_sql=(
+        positive_sql=(
             "metadata @> jsonb_build_object(%(k)s, "
             "jsonb_build_array(to_jsonb(%(v0)s::text), to_jsonb(%(v1)s::text)))"
         ),
+        negated_leaf_sql=_NEG_CASE.format(
+            jtype="array",
+            inner=(
+                "metadata @> jsonb_build_object(%(k)s, "
+                "jsonb_build_array(to_jsonb(%(v0)s::text), to_jsonb(%(v1)s::text)))"
+            ),
+        ),
         value_types=("text", "number", "boolean"),
         indexable=True,
+        empty_operand_indexable=False,  # @> '[]' full-scans (B3 caveat)
         outcomes={**_SCALAR_EXCLUDING, "empty_operand": "include"},
     ),
 )
 
-# Negation contract: ``NotPredicate`` wraps inner SQL as ``NOT (<inner>)`` and
-# inherits SQL three-valued logic — ``NOT (NULL)`` is NULL, so negating a leaf
-# over a missing key still *excludes* that row. Null-inclusive negation would
-# need ``(<inner>) IS NOT TRUE``; the frozen contract is plain ``NOT (...)``.
+# ``NotPredicate`` wraps the op's THREE-VALUED ``negated_leaf_sql`` (never the
+# indexable positive), so ``NOT(NULL) = NULL`` keeps missing/null/wrong-type rows
+# excluded. Null-inclusive negation would need ``IS NOT TRUE`` (that is ``ne``).
 NEGATION_TEMPLATE = "NOT ({inner})"
 
 FILTER_TRUTH_TABLE_BY_OP: dict[NeonFieldOperator, FilterOpSpec] = {
@@ -248,8 +338,9 @@ def predicate_to_sql(
     """Translate a predicate tree to parameterized SQL + bound params.
 
     Enforces the value-validation rules above (rejecting mixed-type lists and
-    bool-as-number), emits the type-directed containment/range SQL, and
-    capability-gates unsupported ops via the search-schema exceptions.
+    bool-as-number), emits the type-directed containment/range SQL (positive
+    leaves for plain predicates, ``NOT(negated_leaf_sql)`` under ``NotPredicate``),
+    and capability-gates unsupported ops via the search-schema exceptions.
     Design-lock stub: the tree walk lands in Slice 4.
     """
     raise NotImplementedError("filter SQL emission is built in Slice 4")

--- a/packages/castform/src/castform/rag/corpus/neon/filter_mapper.py
+++ b/packages/castform/src/castform/rag/corpus/neon/filter_mapper.py
@@ -1,0 +1,186 @@
+"""Filter DSL -> parameterized SQL truth table for the Neon corpus.
+
+Contract-freeze artifact (Slice A). This module freezes the *shape* of the SQL
+each of the nine field operators emits and how each behaves against the five
+edge conditions (value present, JSON null, missing key, empty-array operand,
+negation). The translator that walks a ``FilterPredicate`` tree and emits the
+final ``(sql, params)`` pair is built in Slice 4 — ``predicate_to_sql`` is a stub.
+
+Bound-path discipline
+---------------------
+Metadata is accessed through JSON path operators with the *key bound as a
+parameter* (``metadata ->> %(k)s``), never by interpolating the key into an
+identifier. ``psycopg.sql.Identifier`` is reserved for trusted schema-owned
+names (table/column), never for arbitrary caller-supplied JSON keys. Values are
+always bound; the only per-op variation is the cast (``::numeric`` vs text) and
+the array/containment operator family.
+
+Operator set
+------------
+Nine field operators. The shared ``FieldOperator`` enum in
+``search_schema/search_types.py`` today carries six (``eq, in, gte, lte,
+contains_any, contains_all``); Neon adds ``ne, gt, lt``. Promoting the three new
+ops into the shared enum is deferred to Slice 4 — this module declares a local
+superset so the contract can be frozen without a cross-cutting schema edit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from castform.rag.corpus.search_schema.search_types import FilterPredicate
+
+NeonFieldOperator = Literal[
+    "eq", "ne", "in", "gt", "gte", "lt", "lte", "contains_any", "contains_all"
+]
+"""The nine Neon field operators (shared six + ne/gt/lt)."""
+
+NEON_FIELD_OPERATORS: tuple[NeonFieldOperator, ...] = (
+    "eq",
+    "ne",
+    "in",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "contains_any",
+    "contains_all",
+)
+
+# Cast rule: comparison and equality ops cast to ``numeric`` iff the DSL value is
+# an int/float (or a list thereof for ``in``); otherwise text via ``->>``.
+# ``contains_any``/``contains_all`` treat the field as a JSONB array of text and
+# use the JSONB key-existence operators ``?|`` / ``?&`` (the ``@>`` / ``&&``
+# array form is the deferred typed-array fallback, noted per row).
+
+CastKind = Literal["numeric", "text", "jsonb_array"]
+
+# NULL / missing-key emission semantics for a single leaf. ``exclude`` = the
+# leaf is NULL under 3-valued logic and the row drops; ``include`` = the leaf is
+# TRUE for a NULL/missing left operand (only ``ne`` via IS DISTINCT FROM).
+NullSemantic = Literal["exclude", "include"]
+
+
+@dataclass(frozen=True)
+class FilterOpSpec:
+    """Frozen SQL contract for one field operator.
+
+    Args:
+        op: The Neon field operator.
+        sql_template: Emitted SQL for the value-present case. ``%(k)s`` binds the
+            metadata key, ``%(v)s`` binds the value (or ``%(v)s::type[]`` array).
+        cast: How the left operand / value is cast.
+        null_or_missing: Behavior when the key is JSON-null or absent.
+        empty_array: Behavior when the operand array is empty (in/contains_*),
+            or ``None`` for scalar ops.
+        typed_array_fallback: Deferred alternative representation, if any.
+    """
+
+    op: NeonFieldOperator
+    sql_template: str
+    cast: CastKind
+    null_or_missing: NullSemantic
+    empty_array: Literal["exclude", "include"] | None
+    typed_array_fallback: str | None = None
+
+
+# --- Contract #3: the frozen 9-op truth table ---------------------------------
+# Value-present SQL per op. Numeric variants shown; the text variant drops the
+# ``::numeric`` cast and compares ``metadata ->> %(k)s`` directly.
+FILTER_TRUTH_TABLE: tuple[FilterOpSpec, ...] = (
+    FilterOpSpec(
+        op="eq",
+        sql_template="(metadata ->> %(k)s) = %(v)s",
+        cast="text",
+        null_or_missing="exclude",
+        empty_array=None,
+    ),
+    FilterOpSpec(
+        # IS DISTINCT FROM makes ne null-safe: a missing/JSON-null key is
+        # "distinct from" any concrete value, so ne *includes* such rows.
+        op="ne",
+        sql_template="(metadata ->> %(k)s) IS DISTINCT FROM %(v)s",
+        cast="text",
+        null_or_missing="include",
+        empty_array=None,
+    ),
+    FilterOpSpec(
+        op="in",
+        sql_template="(metadata ->> %(k)s) = ANY(%(v)s)",
+        cast="text",
+        null_or_missing="exclude",
+        empty_array="exclude",
+    ),
+    FilterOpSpec(
+        op="gt",
+        sql_template="(metadata ->> %(k)s)::numeric > %(v)s",
+        cast="numeric",
+        null_or_missing="exclude",
+        empty_array=None,
+    ),
+    FilterOpSpec(
+        op="gte",
+        sql_template="(metadata ->> %(k)s)::numeric >= %(v)s",
+        cast="numeric",
+        null_or_missing="exclude",
+        empty_array=None,
+    ),
+    FilterOpSpec(
+        op="lt",
+        sql_template="(metadata ->> %(k)s)::numeric < %(v)s",
+        cast="numeric",
+        null_or_missing="exclude",
+        empty_array=None,
+    ),
+    FilterOpSpec(
+        op="lte",
+        sql_template="(metadata ->> %(k)s)::numeric <= %(v)s",
+        cast="numeric",
+        null_or_missing="exclude",
+        empty_array=None,
+    ),
+    FilterOpSpec(
+        # JSONB key-existence-any over an array-of-text field. Empty operand
+        # array => matches nothing (exclude).
+        op="contains_any",
+        sql_template="(metadata -> %(k)s) ?| %(v)s",
+        cast="jsonb_array",
+        null_or_missing="exclude",
+        empty_array="exclude",
+        typed_array_fallback="(metadata -> %(k)s) && %(v)s  -- typed array &&",
+    ),
+    FilterOpSpec(
+        # JSONB key-existence-all. Empty operand array is vacuously TRUE
+        # (include) — the one op where an empty operand does not exclude.
+        op="contains_all",
+        sql_template="(metadata -> %(k)s) ?& %(v)s",
+        cast="jsonb_array",
+        null_or_missing="exclude",
+        empty_array="include",
+        typed_array_fallback="(metadata -> %(k)s) @> %(v)s  -- typed array @>",
+    ),
+)
+
+# Negation contract: ``NotPredicate`` wraps its inner SQL as ``NOT (<inner>)`` and
+# inherits SQL three-valued logic — ``NOT (NULL)`` is NULL, so negating a leaf
+# over a missing key still *excludes* the row. Making negation null-inclusive
+# would require ``(<inner>) IS NOT TRUE``; the frozen contract is plain
+# ``NOT (...)``. This sharp edge is documented in CONTRACT.md.
+NEGATION_TEMPLATE = "NOT ({inner})"
+
+FILTER_TRUTH_TABLE_BY_OP: dict[NeonFieldOperator, FilterOpSpec] = {
+    spec.op: spec for spec in FILTER_TRUTH_TABLE
+}
+
+
+def predicate_to_sql(
+    predicate: FilterPredicate | None,
+) -> tuple[str, dict[str, object]]:
+    """Translate a predicate tree to a parameterized SQL fragment + bound params.
+
+    Returns ``(sql, params)`` where every metadata key and value is a bound
+    parameter. Capability-gates unsupported ops via the search-schema
+    exceptions. Design-lock stub: the tree walk lands in Slice 4.
+    """
+    raise NotImplementedError("filter SQL emission is built in Slice 4")

--- a/packages/castform/src/castform/rag/corpus/neon/filter_mapper.py
+++ b/packages/castform/src/castform/rag/corpus/neon/filter_mapper.py
@@ -1,27 +1,34 @@
-"""Filter DSL -> parameterized SQL truth table for the Neon corpus.
+"""Filter DSL -> parameterized, INDEXABLE SQL truth table for the Neon corpus.
 
-Contract-freeze artifact (Slice A). This module freezes the *shape* of the SQL
-each of the nine field operators emits and how each behaves against the five
-edge conditions (value present, JSON null, missing key, empty-array operand,
-negation). The translator that walks a ``FilterPredicate`` tree and emits the
-final ``(sql, params)`` pair is built in Slice 4 — ``predicate_to_sql`` is a stub.
+Contract-freeze artifact (Slice A). This module freezes, per operator: the
+type-directed SQL shape, its five distinct edge outcomes (missing key, JSON null,
+wrong stored type, empty operand, negated), whether the shape is index-eligible,
+and the value-validation rules. The translator that walks a ``FilterPredicate``
+tree and emits ``(sql, params)`` is Slice 4 — ``predicate_to_sql`` is a stub.
 
-Bound-path discipline
----------------------
-Metadata is accessed through JSON path operators with the *key bound as a
-parameter* (``metadata ->> %(k)s``), never by interpolating the key into an
-identifier. ``psycopg.sql.Identifier`` is reserved for trusted schema-owned
-names (table/column), never for arbitrary caller-supplied JSON keys. Values are
-always bound; the only per-op variation is the cast (``::numeric`` vs text) and
-the array/containment operator family.
+Two safety properties are frozen here (they drove the review REVISE):
 
-Operator set
-------------
-Nine field operators. The shared ``FieldOperator`` enum in
-``search_schema/search_types.py`` today carries six (``eq, in, gte, lte,
-contains_any, contains_all``); Neon adds ``ne, gt, lt``. Promoting the three new
-ops into the shared enum is deferred to Slice 4 — this module declares a local
-superset so the contract can be frozen without a cross-cutting schema edit.
+1. **Type-directed, never-throwing.** ``eq/ne/in`` and the ``contains_*`` ops are
+   emitted as JSONB **containment** (``metadata @> jsonb_build_object(...)``),
+   which is *type-aware* (``'{"a":5}' @> '{"a":"5"}'`` is false) and therefore
+   needs no cast — a heterogeneous stored value can never abort the query. The
+   range ops (``gt/gte/lt/lte``) are the only cast path, and they are **guarded**
+   by ``jsonb_typeof(metadata -> key) = 'number'`` so ``::numeric`` is reached
+   only for numbers.
+2. **Indexable.** Containment is served by a ``jsonb_path_ops`` GIN (see
+   ``schema.CREATE_META_GIN_INDEX_SKELETON``). The earlier ``?|``/``?&`` forms are
+   NOT used: a whole-doc GIN cannot serve ``(metadata -> key) ?| values`` and
+   ``jsonb_path_ops`` does not index key-existence at all (B3). Range predicates
+   are not GIN-indexable; a per-key expression btree is an operational add-on.
+
+Bound-path discipline: the metadata key and every value are bound parameters
+(``%(k)s`` / ``%(v)s``); ``psycopg.sql.Identifier`` is reserved for trusted
+schema-owned names, never for caller JSON keys.
+
+Operator set: nine field ops. The shared enum carries six (``eq, in, gte, lte,
+contains_any, contains_all``); Neon adds ``ne, gt, lt`` in a local superset;
+promoting them into ``search_schema/search_types.py`` is a Slice 4 cross-cutting
+edit kept out of this slice.
 """
 
 from __future__ import annotations
@@ -48,139 +55,201 @@ NEON_FIELD_OPERATORS: tuple[NeonFieldOperator, ...] = (
     "contains_all",
 )
 
-# Cast rule: comparison and equality ops cast to ``numeric`` iff the DSL value is
-# an int/float (or a list thereof for ``in``); otherwise text via ``->>``.
-# ``contains_any``/``contains_all`` treat the field as a JSONB array of text and
-# use the JSONB key-existence operators ``?|`` / ``?&`` (the ``@>`` / ``&&``
-# array form is the deferred typed-array fallback, noted per row).
+# JSON scalar type of a bound value -> the explicit SQL cast used inside
+# ``to_jsonb(... ::cast)``. Python ``bool`` is checked BEFORE ``int`` (bool is an
+# int subclass) so a boolean is never silently treated as a number.
+ScalarJsonType = Literal["text", "number", "boolean"]
+CAST_BY_SCALAR_TYPE: dict[ScalarJsonType, str] = {
+    "text": "text",
+    "number": "numeric",
+    "boolean": "boolean",
+}
 
-CastKind = Literal["numeric", "text", "jsonb_array"]
-
-# NULL / missing-key emission semantics for a single leaf. ``exclude`` = the
-# leaf is NULL under 3-valued logic and the row drops; ``include`` = the leaf is
-# TRUE for a NULL/missing left operand (only ``ne`` via IS DISTINCT FROM).
-NullSemantic = Literal["exclude", "include"]
+# Per-condition outcome for a single leaf. ``depends`` = matches iff the stored
+# value satisfies the op; the other four are fixed regardless of value.
+Outcome = Literal["depends", "exclude", "include", "na"]
+EdgeConditions = Literal["missing_key", "json_null", "wrong_type", "empty_operand"]
 
 
 @dataclass(frozen=True)
 class FilterOpSpec:
-    """Frozen SQL contract for one field operator.
+    """Frozen SQL + edge-outcome contract for one field operator.
 
     Args:
         op: The Neon field operator.
-        sql_template: Emitted SQL for the value-present case. ``%(k)s`` binds the
-            metadata key, ``%(v)s`` binds the value (or ``%(v)s::type[]`` array).
-        cast: How the left operand / value is cast.
-        null_or_missing: Behavior when the key is JSON-null or absent.
-        empty_array: Behavior when the operand array is empty (in/contains_*),
-            or ``None`` for scalar ops.
-        typed_array_fallback: Deferred alternative representation, if any.
+        family: ``containment`` (indexable ``@>``), ``negated_containment``
+            (``@> ... IS NOT TRUE``), or ``range`` (guarded numeric cast).
+        canonical_sql: The exact emitted SQL for a representative value-present
+            case. ``%(k)s`` binds the key; ``%(v)s`` / ``%(v0)s`` / ``%(v1)s`` bind
+            values. ``in``/``contains_any`` show the two-element OR expansion;
+            ``contains_all`` shows the two-element single-containment form.
+        value_types: Scalar JSON types this op accepts (element types for the
+            list ops).
+        indexable: Whether ``meta_gin`` (``jsonb_path_ops``) can serve it.
+        outcomes: Fixed include/exclude behavior per edge condition.
     """
 
     op: NeonFieldOperator
-    sql_template: str
-    cast: CastKind
-    null_or_missing: NullSemantic
-    empty_array: Literal["exclude", "include"] | None
-    typed_array_fallback: str | None = None
+    family: Literal["containment", "negated_containment", "range"]
+    canonical_sql: str
+    value_types: tuple[ScalarJsonType, ...]
+    indexable: bool
+    outcomes: dict[EdgeConditions, Outcome]
+
+
+# Every op excludes on missing key / JSON null / wrong stored type EXCEPT ``ne``
+# (null-safe: ``IS NOT TRUE`` flips NULL/false to true, so a missing/null/wrong
+# value is *included*).
+_SCALAR_EXCLUDING = {
+    "missing_key": "exclude",
+    "json_null": "exclude",
+    "wrong_type": "exclude",
+    "empty_operand": "na",
+}
+_NE_INCLUDING = {
+    "missing_key": "include",
+    "json_null": "include",
+    "wrong_type": "include",
+    "empty_operand": "na",
+}
 
 
 # --- Contract #3: the frozen 9-op truth table ---------------------------------
-# Value-present SQL per op. Numeric variants shown; the text variant drops the
-# ``::numeric`` cast and compares ``metadata ->> %(k)s`` directly.
 FILTER_TRUTH_TABLE: tuple[FilterOpSpec, ...] = (
     FilterOpSpec(
         op="eq",
-        sql_template="(metadata ->> %(k)s) = %(v)s",
-        cast="text",
-        null_or_missing="exclude",
-        empty_array=None,
+        family="containment",
+        canonical_sql="metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))",
+        value_types=("text", "number", "boolean"),
+        indexable=True,
+        outcomes=dict(_SCALAR_EXCLUDING),
     ),
     FilterOpSpec(
-        # IS DISTINCT FROM makes ne null-safe: a missing/JSON-null key is
-        # "distinct from" any concrete value, so ne *includes* such rows.
+        # Null-safe: missing/null/wrong-type rows are INCLUDED; only an equal
+        # stored value is excluded.
         op="ne",
-        sql_template="(metadata ->> %(k)s) IS DISTINCT FROM %(v)s",
-        cast="text",
-        null_or_missing="include",
-        empty_array=None,
+        family="negated_containment",
+        canonical_sql=(
+            "(metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))) "
+            "IS NOT TRUE"
+        ),
+        value_types=("text", "number", "boolean"),
+        indexable=False,
+        outcomes=dict(_NE_INCLUDING),
     ),
     FilterOpSpec(
         op="in",
-        sql_template="(metadata ->> %(k)s) = ANY(%(v)s)",
-        cast="text",
-        null_or_missing="exclude",
-        empty_array="exclude",
+        family="containment",
+        canonical_sql=(
+            "(metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v0)s::numeric)) OR "
+            "metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v1)s::numeric)))"
+        ),
+        value_types=("text", "number", "boolean"),
+        indexable=True,
+        outcomes={**_SCALAR_EXCLUDING, "empty_operand": "exclude"},
     ),
     FilterOpSpec(
         op="gt",
-        sql_template="(metadata ->> %(k)s)::numeric > %(v)s",
-        cast="numeric",
-        null_or_missing="exclude",
-        empty_array=None,
+        family="range",
+        canonical_sql=(
+            "jsonb_typeof(metadata -> %(k)s) = 'number' "
+            "AND (metadata ->> %(k)s)::numeric > %(v)s::numeric"
+        ),
+        value_types=("number",),
+        indexable=False,
+        outcomes=dict(_SCALAR_EXCLUDING),
     ),
     FilterOpSpec(
         op="gte",
-        sql_template="(metadata ->> %(k)s)::numeric >= %(v)s",
-        cast="numeric",
-        null_or_missing="exclude",
-        empty_array=None,
+        family="range",
+        canonical_sql=(
+            "jsonb_typeof(metadata -> %(k)s) = 'number' "
+            "AND (metadata ->> %(k)s)::numeric >= %(v)s::numeric"
+        ),
+        value_types=("number",),
+        indexable=False,
+        outcomes=dict(_SCALAR_EXCLUDING),
     ),
     FilterOpSpec(
         op="lt",
-        sql_template="(metadata ->> %(k)s)::numeric < %(v)s",
-        cast="numeric",
-        null_or_missing="exclude",
-        empty_array=None,
+        family="range",
+        canonical_sql=(
+            "jsonb_typeof(metadata -> %(k)s) = 'number' "
+            "AND (metadata ->> %(k)s)::numeric < %(v)s::numeric"
+        ),
+        value_types=("number",),
+        indexable=False,
+        outcomes=dict(_SCALAR_EXCLUDING),
     ),
     FilterOpSpec(
         op="lte",
-        sql_template="(metadata ->> %(k)s)::numeric <= %(v)s",
-        cast="numeric",
-        null_or_missing="exclude",
-        empty_array=None,
+        family="range",
+        canonical_sql=(
+            "jsonb_typeof(metadata -> %(k)s) = 'number' "
+            "AND (metadata ->> %(k)s)::numeric <= %(v)s::numeric"
+        ),
+        value_types=("number",),
+        indexable=False,
+        outcomes=dict(_SCALAR_EXCLUDING),
     ),
     FilterOpSpec(
-        # JSONB key-existence-any over an array-of-text field. Empty operand
-        # array => matches nothing (exclude).
+        # Array membership via per-element containment OR. Empty operand => no
+        # atoms => FALSE => exclude.
         op="contains_any",
-        sql_template="(metadata -> %(k)s) ?| %(v)s",
-        cast="jsonb_array",
-        null_or_missing="exclude",
-        empty_array="exclude",
-        typed_array_fallback="(metadata -> %(k)s) && %(v)s  -- typed array &&",
+        family="containment",
+        canonical_sql=(
+            "(metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v0)s::text))) OR "
+            "metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v1)s::text))))"
+        ),
+        value_types=("text", "number", "boolean"),
+        indexable=True,
+        outcomes={**_SCALAR_EXCLUDING, "empty_operand": "exclude"},
     ),
     FilterOpSpec(
-        # JSONB key-existence-all. Empty operand array is vacuously TRUE
-        # (include) — the one op where an empty operand does not exclude.
+        # Superset via single array containment. Empty operand => ``@> '[]'`` =>
+        # TRUE iff the field is present as an array (missing key still excludes).
         op="contains_all",
-        sql_template="(metadata -> %(k)s) ?& %(v)s",
-        cast="jsonb_array",
-        null_or_missing="exclude",
-        empty_array="include",
-        typed_array_fallback="(metadata -> %(k)s) @> %(v)s  -- typed array @>",
+        family="containment",
+        canonical_sql=(
+            "metadata @> jsonb_build_object(%(k)s, "
+            "jsonb_build_array(to_jsonb(%(v0)s::text), to_jsonb(%(v1)s::text)))"
+        ),
+        value_types=("text", "number", "boolean"),
+        indexable=True,
+        outcomes={**_SCALAR_EXCLUDING, "empty_operand": "include"},
     ),
 )
 
-# Negation contract: ``NotPredicate`` wraps its inner SQL as ``NOT (<inner>)`` and
+# Negation contract: ``NotPredicate`` wraps inner SQL as ``NOT (<inner>)`` and
 # inherits SQL three-valued logic — ``NOT (NULL)`` is NULL, so negating a leaf
-# over a missing key still *excludes* the row. Making negation null-inclusive
-# would require ``(<inner>) IS NOT TRUE``; the frozen contract is plain
-# ``NOT (...)``. This sharp edge is documented in CONTRACT.md.
+# over a missing key still *excludes* that row. Null-inclusive negation would
+# need ``(<inner>) IS NOT TRUE``; the frozen contract is plain ``NOT (...)``.
 NEGATION_TEMPLATE = "NOT ({inner})"
 
 FILTER_TRUTH_TABLE_BY_OP: dict[NeonFieldOperator, FilterOpSpec] = {
     spec.op: spec for spec in FILTER_TRUTH_TABLE
 }
 
+# Value-validation rules frozen for Slice 4's predicate_to_sql (each raises
+# InvalidFilterError from search_schema.search_exceptions):
+#   - range ops require a numeric value (int/float, NOT bool);
+#   - in/contains_* require a homogeneous list — mixed JSON types are rejected,
+#     and a Python bool is never accepted where a number is expected;
+#   - eq/ne accept a single text/number/boolean scalar.
+RANGE_OPS: frozenset[NeonFieldOperator] = frozenset({"gt", "gte", "lt", "lte"})
+LIST_OPS: frozenset[NeonFieldOperator] = frozenset(
+    {"in", "contains_any", "contains_all"}
+)
+
 
 def predicate_to_sql(
     predicate: FilterPredicate | None,
 ) -> tuple[str, dict[str, object]]:
-    """Translate a predicate tree to a parameterized SQL fragment + bound params.
+    """Translate a predicate tree to parameterized SQL + bound params.
 
-    Returns ``(sql, params)`` where every metadata key and value is a bound
-    parameter. Capability-gates unsupported ops via the search-schema
-    exceptions. Design-lock stub: the tree walk lands in Slice 4.
+    Enforces the value-validation rules above (rejecting mixed-type lists and
+    bool-as-number), emits the type-directed containment/range SQL, and
+    capability-gates unsupported ops via the search-schema exceptions.
+    Design-lock stub: the tree walk lands in Slice 4.
     """
     raise NotImplementedError("filter SQL emission is built in Slice 4")

--- a/packages/castform/src/castform/rag/corpus/neon/schema.py
+++ b/packages/castform/src/castform/rag/corpus/neon/schema.py
@@ -1,29 +1,35 @@
-"""Physical table schema and versioned-replace model for the Neon corpus.
+"""Physical table schema and versioned-replace lifecycle for the Neon corpus.
 
-Contract-freeze artifact (Slice A). The DDL string templates and identifier
-helpers here are the *frozen* physical model; the executor that runs them is
-built in Slice 2. Nothing in this module opens a connection or emits real SQL
-against a database.
+Contract-freeze artifact (Slice A). The identifier helpers, allowlists, and
+validation here are implemented (they are the frozen safety contract); the DDL
+*assembly* and execution are Slice 2 stubs that return ``psycopg.sql`` composables
+built from these helpers — never interpolated strings.
 
-Versioned-replace model
------------------------
+Versioned-replace lifecycle
+---------------------------
 A corpus is addressed by a stable *logical name*. Each ingest builds a fresh
-*physical* table ``<logical>__v<version>`` with its own indexes, so an in-flight
-rebuild never mutates the table readers are querying. An *active-version pointer*
-(a registry row plus a ``CREATE OR REPLACE VIEW`` under the logical name) is
-flipped in a single transaction to publish a new version, and flipped back to
-roll one back. Old physical tables are retained until explicitly pruned, which is
-what makes rollback O(1) and non-destructive.
+*physical* table ``<logical>__v<version>`` with its own indexes; readers query a
+stable owner-rights view under the logical name. A per-version *ledger*
+(``neon_corpus_versions``) tracks each version's state (building -> ready ->
+activated -> retired) with timestamps, so concurrent ingest, enumerate, prune,
+and build-vs-ready are all well-defined. Activation flips the ledger's active
+row AND re-points the view in one transaction under a per-logical advisory lock;
+rollback re-points to any prior ``ready``/``activated`` version (old physical
+tables are retained until pruned, so rollback is O(1) and non-destructive).
 
-Chunk identity is content+metadata derived (see ``rag/chunkers/models.py``:
+Chunk identity is content+metadata derived (``rag/chunkers/models.py``:
 ``hash = sha256(metadata_str + "\\n" + content)``), so re-ingesting changed
-content yields new ids — the reason a whole-table versioned replace, not an
-in-place upsert, is the correct shape.
+content yields new ids — hence versioned *replace*, not in-place upsert.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import hashlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from psycopg import sql
 
 # --- Contract #7: embedding dim / metric (frozen) ------------------------------
 
@@ -34,8 +40,56 @@ DISTANCE_METRIC = "cosine"
 """Vector distance metric. Fixed for the managed table; index uses cosine ops."""
 
 DEFAULT_TEXT_SEARCH_CONFIG = "pg_catalog.english"
-"""Default Postgres text-search config. Configurable per corpus, never hardcoded
-downstream — the tsvector generated column bakes this per physical version."""
+"""Default Postgres text-search config for the tsvector generated column."""
+
+# B4: regconfig is never interpolated raw — only a value from this allowlist is
+# accepted, then emitted as a bound ``sql.Literal`` cast to ``regconfig``.
+ALLOWED_TEXT_SEARCH_CONFIGS: frozenset[str] = frozenset(
+    {"pg_catalog.english", "pg_catalog.simple"}
+)
+
+MAX_IDENTIFIER_BYTES = 63
+"""Postgres identifier length limit; longer names are hash-suffixed."""
+
+# Explicit column list for the stable view — never ``SELECT *`` (B4). ``id`` is
+# the chunk hash; ``source_file``/``chunk_index`` are typed non-null columns that
+# back deterministic scan ordering (B6).
+TABLE_COLUMNS: tuple[str, ...] = (
+    "id",
+    "content",
+    "metadata",
+    "embedding",
+    "source_file",
+    "chunk_index",
+    "content_tsv",
+)
+VIEW_COLUMNS: tuple[str, ...] = TABLE_COLUMNS
+
+
+# --- B1 (Group 2): ANN access method / vector type / opclass are PROVISIONAL ----
+# The native Lakebase ANN access method, the vector column type, and the opclass
+# are NOT frozen here. Vanilla pgvector caps ``vector`` HNSW/IVFFlat at 2000 dims
+# (so 3072 would need ``halfvec``), but that is an UNPROVEN assumption for
+# Lakebase's ``lakebase_ann``. Slice 3 must verify on the live DB before any of
+# these is frozen. See CONTRACT.md "PROVISIONAL" and PROVISIONAL_ANN_OPTIONS.
+PROVISIONAL_ANN_OPTIONS: tuple[dict[str, str], ...] = (
+    {
+        "access_method": "lakebase_ann",
+        "vector_type": "vector(3072)",
+        "opclass": "vector_cosine_ops",
+        "status": "provisional-primary",
+    },
+    {
+        "access_method": "hnsw",
+        "vector_type": "halfvec(3072)",
+        "opclass": "halfvec_cosine_ops",
+        "status": "provisional-fallback",
+    },
+)
+
+
+VersionState = Literal["building", "ready", "activated", "retired"]
+"""Lifecycle states for one physical corpus version (B5)."""
 
 
 @dataclass(frozen=True)
@@ -44,12 +98,12 @@ class NeonTableSpec:
 
     Args:
         logical_name: Stable logical corpus name (readers address this).
-        version: Monotonic physical version number for this build.
+        version: Monotonic physical version number (>= 1).
         embedding_dim: Vector column dimensionality. Defaults to EMBEDDING_DIM.
         distance_metric: Vector distance metric. Defaults to DISTANCE_METRIC.
-        text_search_config: Postgres ``regconfig`` for the tsvector column and
-            the lexical tokenizer. Baked into the generated column of this
-            version (a config change requires a new version, not an ALTER).
+        text_search_config: Postgres ``regconfig`` for the tsvector column; must
+            be in ALLOWED_TEXT_SEARCH_CONFIGS. Baked per physical version (a
+            config change requires a new version, not an ALTER).
     """
 
     logical_name: str
@@ -57,106 +111,230 @@ class NeonTableSpec:
     embedding_dim: int = EMBEDDING_DIM
     distance_metric: str = DISTANCE_METRIC
     text_search_config: str = DEFAULT_TEXT_SEARCH_CONFIG
-    _reserved: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class NeonVersionRecord:
+    """One row of the per-version ledger (B5).
+
+    Args:
+        logical_name: Logical corpus this version belongs to.
+        version: Physical version number.
+        state: Lifecycle state.
+        created_at: When the physical table build started (epoch seconds).
+        ready_at: When the build finished and indexes were valid, else None.
+        activated_at: When this version became the active pointer, else None.
+    """
+
+    logical_name: str
+    version: int
+    state: VersionState
+    created_at: float
+    ready_at: float | None = None
+    activated_at: float | None = None
+
+
+@dataclass(frozen=True)
+class RetentionPolicy:
+    """Version retention / pruning policy (B5).
+
+    Args:
+        keep_activated: Number of most-recent activated versions to retain
+            (>= 2 so rollback always has a target).
+        keep_ready: Number of most-recent non-activated ``ready`` versions to
+            retain for fast promotion.
+    """
+
+    keep_activated: int = 2
+    keep_ready: int = 1
+
+
+DEFAULT_RETENTION = RetentionPolicy()
+
+
+@dataclass(frozen=True)
+class ReadGrantSpec:
+    """RO grant the ingest role must issue so the search role can read (B5).
+
+    The stable view is owner-rights (``security_invoker = false``), so the RO
+    role needs only schema ``USAGE`` and ``SELECT`` on the view — never on the
+    physical version tables. These grants must be (re)issued on FIRST view
+    creation (``CREATE OR REPLACE VIEW`` preserves an existing ACL but the
+    first create has none).
+
+    Args:
+        schema: Schema holding the corpus objects.
+        view: Stable logical view name.
+        ro_role: The read-only role receiving USAGE + SELECT.
+    """
+
+    schema: str
+    view: str
+    ro_role: str
+
+
+# --- identifier + value validation (B4, implemented — the safety contract) -----
+
+
+def validate_version(version: int) -> int:
+    """Return *version* if it is a positive int, else raise ValueError."""
+    if isinstance(version, bool) or not isinstance(version, int) or version < 1:
+        raise ValueError(f"version must be a positive int, got {version!r}")
+    return version
+
+
+def validate_text_search_config(config: str) -> str:
+    """Return *config* if allowlisted, else raise ValueError (B4)."""
+    if config not in ALLOWED_TEXT_SEARCH_CONFIGS:
+        raise ValueError(
+            f"text_search_config {config!r} not in allowlist "
+            f"{sorted(ALLOWED_TEXT_SEARCH_CONFIGS)}"
+        )
+    return config
+
+
+def _fit_identifier(base: str, reserved: int) -> str:
+    """Fit *base* into MAX_IDENTIFIER_BYTES leaving *reserved* bytes for a suffix.
+
+    Long names are truncated and given a stable 8-char content hash so distinct
+    logical names never collide after truncation (B4).
+    """
+    budget = MAX_IDENTIFIER_BYTES - reserved
+    if budget < 9:
+        raise ValueError(f"reserved={reserved} leaves no room for an identifier")
+    if len(base.encode()) <= budget:
+        return base
+    digest = hashlib.sha256(base.encode()).hexdigest()[:8]
+    keep = budget - 9  # 8 hash chars + one '_' separator
+    return f"{base[:keep]}_{digest}"
 
 
 def physical_table_name(logical_name: str, version: int) -> str:
-    """Return the physical table name for a corpus version: ``<logical>__v<N>``."""
-    return f"{logical_name}__v{version}"
+    """Return the physical table name for a corpus version: ``<logical>__v<N>``.
+
+    Length-safe: the logical portion is hashed if the full name would exceed the
+    63-byte identifier limit. The same fitted base backs all per-version indexes.
+    """
+    validate_version(version)
+    suffix = f"__v{version}"
+    # Reserve room for both the version suffix and the longest index suffix.
+    reserved = len(suffix) + len(_LONGEST_INDEX_SUFFIX)
+    return f"{_fit_identifier(logical_name, reserved)}{suffix}"
+
+
+_INDEX_SUFFIXES: dict[str, str] = {
+    "ann": "_ann",
+    "bm25": "_bm25",
+    "meta_gin": "_meta_gin",
+    "scan": "_scan",
+    "tsv_gin": "_tsv_gin",
+}
+_LONGEST_INDEX_SUFFIX = max(_INDEX_SUFFIXES.values(), key=len)
 
 
 def index_names(logical_name: str, version: int) -> dict[str, str]:
     """Return the per-version index identifier set for a corpus version.
 
-    Keys: ``hnsw`` (ANN over the embedding), ``bm25`` (lexical), ``meta_gin``
-    (JSONB metadata containment), ``tsv_gin`` (native FTS fallback).
+    Keys: ``ann`` (PROVISIONAL vector index, see PROVISIONAL_ANN_OPTIONS),
+    ``bm25`` (lexical), ``meta_gin`` (``jsonb_path_ops`` for ``@>`` containment,
+    B3), ``scan`` (btree on ``(source_file, chunk_index, id)``, B6), ``tsv_gin``
+    (native FTS fallback). All are length-safe.
     """
     base = physical_table_name(logical_name, version)
-    return {
-        "hnsw": f"{base}_hnsw",
-        "bm25": f"{base}_bm25",
-        "meta_gin": f"{base}_meta_gin",
-        "tsv_gin": f"{base}_tsv_gin",
-    }
+    return {key: f"{base}{suffix}" for key, suffix in _INDEX_SUFFIXES.items()}
 
 
-# --- Contract #1: DDL constant templates (frozen shapes, not executed) ---------
+# --- DDL assembly seams (Slice 2 stubs; return psycopg.sql composables) --------
+# Reference skeletons documenting the FROZEN physical shape. These are NOT
+# executed by ``str`` interpolation — Slice 2 composes them with
+# ``sql.SQL(...).format(sql.Identifier(...), ...)`` and bound ``sql.Literal`` for
+# the regconfig, using only validated inputs from the helpers above.
 
-# The embedding is stored as ``vector(3072)`` but pgvector HNSW/IVFFlat index the
-# ``vector`` type only up to 2000 dims, so the ANN index is built on a
-# ``halfvec(3072)`` cast expression (HNSW supports halfvec up to 4000 dims).
-CREATE_TABLE_TEMPLATE = """
+CREATE_TABLE_SKELETON = """
 CREATE TABLE {table} (
     id text PRIMARY KEY,
     content text NOT NULL,
     metadata jsonb NOT NULL DEFAULT '{{}}'::jsonb,
-    embedding vector({dim}),
+    embedding {vector_type},
+    source_file text NOT NULL,
+    chunk_index integer NOT NULL,
     content_tsv tsvector
         GENERATED ALWAYS AS (to_tsvector({tsconfig}::regconfig, content)) STORED
 )
 """.strip()
 
-CREATE_HNSW_INDEX_TEMPLATE = (
-    "CREATE INDEX {index} ON {table} "
-    "USING hnsw ((embedding::halfvec({dim})) halfvec_cosine_ops)"
-)
-
-# Lexical ranking uses the bm25 ``<@>`` operator over a bm25 index tokenized with
-# the same configurable text-search config; the tsvector GIN index below is the
-# portable native-FTS fallback (ts_rank_cd).
-CREATE_BM25_INDEX_TEMPLATE = (
-    "CREATE INDEX {index} ON {table} USING bm25 (id, content) "
-    "WITH (key_field='id', text_config={tsconfig})"
-)
-
-CREATE_META_GIN_INDEX_TEMPLATE = (
+# B3: metadata predicates are emitted as ``@>`` containment (see filter_mapper),
+# which ``jsonb_path_ops`` GIN accelerates. ``?|``/``?&`` are intentionally NOT
+# used — a whole-doc GIN cannot serve them.
+CREATE_META_GIN_INDEX_SKELETON = (
     "CREATE INDEX {index} ON {table} USING gin (metadata jsonb_path_ops)"
 )
 
-CREATE_TSV_GIN_INDEX_TEMPLATE = (
+# B6: deterministic scan order is backed by a typed btree, not JSONB extraction.
+CREATE_SCAN_INDEX_SKELETON = (
+    "CREATE INDEX {index} ON {table} (source_file, chunk_index, id)"
+)
+
+CREATE_TSV_GIN_INDEX_SKELETON = (
     "CREATE INDEX {index} ON {table} USING gin (content_tsv)"
 )
 
-# Active-version pointer: a registry table plus a view under the logical name.
-CREATE_REGISTRY_TABLE = """
+CREATE_LEDGER_SKELETON = """
 CREATE TABLE IF NOT EXISTS neon_corpus_versions (
-    logical_name text PRIMARY KEY,
-    active_version int NOT NULL,
-    updated_at timestamptz NOT NULL DEFAULT now()
+    logical_name text NOT NULL,
+    version integer NOT NULL,
+    state text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    ready_at timestamptz,
+    activated_at timestamptz,
+    PRIMARY KEY (logical_name, version)
 )
 """.strip()
 
-ACTIVATE_VIEW_TEMPLATE = "CREATE OR REPLACE VIEW {logical} AS SELECT * FROM {table}"
-
-UPSERT_ACTIVE_VERSION_TEMPLATE = (
-    "INSERT INTO neon_corpus_versions (logical_name, active_version) "
-    "VALUES (%(logical)s, %(version)s) "
-    "ON CONFLICT (logical_name) DO UPDATE SET "
-    "active_version = EXCLUDED.active_version, updated_at = now()"
+# Owner-rights view (security_invoker = false) so the RO role never touches
+# physical tables. Explicit column list, never SELECT *.
+ACTIVATE_VIEW_SKELETON = (
+    "CREATE OR REPLACE VIEW {view} WITH (security_invoker = false) AS "
+    "SELECT {columns} FROM {table}"
 )
 
 
-def create_table_ddl(spec: NeonTableSpec) -> str:
-    """Return the ``CREATE TABLE`` DDL for a physical corpus version.
+def create_table_ddl(spec: NeonTableSpec) -> sql.Composed:
+    """Return the ``CREATE TABLE`` composable for a physical corpus version.
 
-    Design-lock stub: the executor and DDL assembly land in Slice 2.
+    Composed from ``sql.Identifier`` (table) + a bound ``sql.Literal`` regconfig
+    drawn from ALLOWED_TEXT_SEARCH_CONFIGS, using the PROVISIONAL vector type
+    resolved in Slice 3. Design-lock stub: assembly lands in Slice 2.
     """
     raise NotImplementedError("schema DDL assembly is built in Slice 2")
 
 
-def activate_version_sql(spec: NeonTableSpec) -> list[str]:
-    """Return the ordered, single-transaction statements that publish a version.
+def activate_version_sql(spec: NeonTableSpec) -> list[sql.Composed]:
+    """Return the single-transaction composables that publish a version (B5).
 
-    Atomic activate = upsert the registry pointer + ``CREATE OR REPLACE VIEW``
-    under the logical name, run in one transaction. Design-lock stub.
+    Ordered: acquire ``pg_advisory_xact_lock`` on the logical name, upsert the
+    ledger active row, ``CREATE OR REPLACE VIEW`` (owner-rights, explicit
+    columns), and re-issue the RO grants on first create. All in one transaction
+    so the ledger update and view replacement commit or roll back together.
+    Design-lock stub: assembly lands in Slice 2.
     """
     raise NotImplementedError("version activation is built in Slice 2")
 
 
-def rollback_version_sql(logical_name: str, target_version: int) -> list[str]:
-    """Return the statements that roll the active pointer back to a prior version.
+def rollback_version_sql(logical_name: str, target_version: int) -> list[sql.Composed]:
+    """Return the composables that re-point the active version to a prior one.
 
     Non-destructive: prior physical tables are retained, so rollback re-points
-    the registry + view. Design-lock stub.
+    the ledger + view under the advisory lock. Design-lock stub: built in Slice 2.
     """
+    validate_version(target_version)
     raise NotImplementedError("version rollback is built in Slice 2")
+
+
+def read_grant_sql(grant: ReadGrantSpec) -> list[sql.Composed]:
+    """Return the ``GRANT USAGE``/``GRANT SELECT`` composables for the RO role.
+
+    Issued on first view creation (see ReadGrantSpec). Design-lock stub: built
+    in Slice 2.
+    """
+    raise NotImplementedError("RO grant assembly is built in Slice 2")

--- a/packages/castform/src/castform/rag/corpus/neon/schema.py
+++ b/packages/castform/src/castform/rag/corpus/neon/schema.py
@@ -1,0 +1,162 @@
+"""Physical table schema and versioned-replace model for the Neon corpus.
+
+Contract-freeze artifact (Slice A). The DDL string templates and identifier
+helpers here are the *frozen* physical model; the executor that runs them is
+built in Slice 2. Nothing in this module opens a connection or emits real SQL
+against a database.
+
+Versioned-replace model
+-----------------------
+A corpus is addressed by a stable *logical name*. Each ingest builds a fresh
+*physical* table ``<logical>__v<version>`` with its own indexes, so an in-flight
+rebuild never mutates the table readers are querying. An *active-version pointer*
+(a registry row plus a ``CREATE OR REPLACE VIEW`` under the logical name) is
+flipped in a single transaction to publish a new version, and flipped back to
+roll one back. Old physical tables are retained until explicitly pruned, which is
+what makes rollback O(1) and non-destructive.
+
+Chunk identity is content+metadata derived (see ``rag/chunkers/models.py``:
+``hash = sha256(metadata_str + "\\n" + content)``), so re-ingesting changed
+content yields new ids — the reason a whole-table versioned replace, not an
+in-place upsert, is the correct shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# --- Contract #7: embedding dim / metric (frozen) ------------------------------
+
+EMBEDDING_DIM = 3072
+"""Embedding vector dimensionality (text-embedding-3-large)."""
+
+DISTANCE_METRIC = "cosine"
+"""Vector distance metric. Fixed for the managed table; index uses cosine ops."""
+
+DEFAULT_TEXT_SEARCH_CONFIG = "pg_catalog.english"
+"""Default Postgres text-search config. Configurable per corpus, never hardcoded
+downstream — the tsvector generated column bakes this per physical version."""
+
+
+@dataclass(frozen=True)
+class NeonTableSpec:
+    """Frozen description of one physical corpus-version table.
+
+    Args:
+        logical_name: Stable logical corpus name (readers address this).
+        version: Monotonic physical version number for this build.
+        embedding_dim: Vector column dimensionality. Defaults to EMBEDDING_DIM.
+        distance_metric: Vector distance metric. Defaults to DISTANCE_METRIC.
+        text_search_config: Postgres ``regconfig`` for the tsvector column and
+            the lexical tokenizer. Baked into the generated column of this
+            version (a config change requires a new version, not an ALTER).
+    """
+
+    logical_name: str
+    version: int
+    embedding_dim: int = EMBEDDING_DIM
+    distance_metric: str = DISTANCE_METRIC
+    text_search_config: str = DEFAULT_TEXT_SEARCH_CONFIG
+    _reserved: dict[str, object] = field(default_factory=dict)
+
+
+def physical_table_name(logical_name: str, version: int) -> str:
+    """Return the physical table name for a corpus version: ``<logical>__v<N>``."""
+    return f"{logical_name}__v{version}"
+
+
+def index_names(logical_name: str, version: int) -> dict[str, str]:
+    """Return the per-version index identifier set for a corpus version.
+
+    Keys: ``hnsw`` (ANN over the embedding), ``bm25`` (lexical), ``meta_gin``
+    (JSONB metadata containment), ``tsv_gin`` (native FTS fallback).
+    """
+    base = physical_table_name(logical_name, version)
+    return {
+        "hnsw": f"{base}_hnsw",
+        "bm25": f"{base}_bm25",
+        "meta_gin": f"{base}_meta_gin",
+        "tsv_gin": f"{base}_tsv_gin",
+    }
+
+
+# --- Contract #1: DDL constant templates (frozen shapes, not executed) ---------
+
+# The embedding is stored as ``vector(3072)`` but pgvector HNSW/IVFFlat index the
+# ``vector`` type only up to 2000 dims, so the ANN index is built on a
+# ``halfvec(3072)`` cast expression (HNSW supports halfvec up to 4000 dims).
+CREATE_TABLE_TEMPLATE = """
+CREATE TABLE {table} (
+    id text PRIMARY KEY,
+    content text NOT NULL,
+    metadata jsonb NOT NULL DEFAULT '{{}}'::jsonb,
+    embedding vector({dim}),
+    content_tsv tsvector
+        GENERATED ALWAYS AS (to_tsvector({tsconfig}::regconfig, content)) STORED
+)
+""".strip()
+
+CREATE_HNSW_INDEX_TEMPLATE = (
+    "CREATE INDEX {index} ON {table} "
+    "USING hnsw ((embedding::halfvec({dim})) halfvec_cosine_ops)"
+)
+
+# Lexical ranking uses the bm25 ``<@>`` operator over a bm25 index tokenized with
+# the same configurable text-search config; the tsvector GIN index below is the
+# portable native-FTS fallback (ts_rank_cd).
+CREATE_BM25_INDEX_TEMPLATE = (
+    "CREATE INDEX {index} ON {table} USING bm25 (id, content) "
+    "WITH (key_field='id', text_config={tsconfig})"
+)
+
+CREATE_META_GIN_INDEX_TEMPLATE = (
+    "CREATE INDEX {index} ON {table} USING gin (metadata jsonb_path_ops)"
+)
+
+CREATE_TSV_GIN_INDEX_TEMPLATE = (
+    "CREATE INDEX {index} ON {table} USING gin (content_tsv)"
+)
+
+# Active-version pointer: a registry table plus a view under the logical name.
+CREATE_REGISTRY_TABLE = """
+CREATE TABLE IF NOT EXISTS neon_corpus_versions (
+    logical_name text PRIMARY KEY,
+    active_version int NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT now()
+)
+""".strip()
+
+ACTIVATE_VIEW_TEMPLATE = "CREATE OR REPLACE VIEW {logical} AS SELECT * FROM {table}"
+
+UPSERT_ACTIVE_VERSION_TEMPLATE = (
+    "INSERT INTO neon_corpus_versions (logical_name, active_version) "
+    "VALUES (%(logical)s, %(version)s) "
+    "ON CONFLICT (logical_name) DO UPDATE SET "
+    "active_version = EXCLUDED.active_version, updated_at = now()"
+)
+
+
+def create_table_ddl(spec: NeonTableSpec) -> str:
+    """Return the ``CREATE TABLE`` DDL for a physical corpus version.
+
+    Design-lock stub: the executor and DDL assembly land in Slice 2.
+    """
+    raise NotImplementedError("schema DDL assembly is built in Slice 2")
+
+
+def activate_version_sql(spec: NeonTableSpec) -> list[str]:
+    """Return the ordered, single-transaction statements that publish a version.
+
+    Atomic activate = upsert the registry pointer + ``CREATE OR REPLACE VIEW``
+    under the logical name, run in one transaction. Design-lock stub.
+    """
+    raise NotImplementedError("version activation is built in Slice 2")
+
+
+def rollback_version_sql(logical_name: str, target_version: int) -> list[str]:
+    """Return the statements that roll the active pointer back to a prior version.
+
+    Non-destructive: prior physical tables are retained, so rollback re-points
+    the registry + view. Design-lock stub.
+    """
+    raise NotImplementedError("version rollback is built in Slice 2")

--- a/packages/castform/src/castform/rag/corpus/neon/schema.py
+++ b/packages/castform/src/castform/rag/corpus/neon/schema.py
@@ -89,7 +89,21 @@ PROVISIONAL_ANN_OPTIONS: tuple[dict[str, str], ...] = (
 
 
 VersionState = Literal["building", "ready", "activated", "retired"]
-"""Lifecycle states for one physical corpus version (B5)."""
+"""Lifecycle states for one physical corpus version (B5).
+
+``activated`` is *historical* — the version has been published at least once.
+Which single version is *currently* published is tracked separately by the
+``is_current`` flag (see the current-pointer invariant below), so a rollback flips
+``is_current`` between two ``activated`` versions without changing their state.
+"""
+
+# Frozen legal state transitions (enforced in Slice 2 alongside the DB CHECK).
+VERSION_STATE_TRANSITIONS: dict[VersionState, tuple[VersionState, ...]] = {
+    "building": ("ready",),
+    "ready": ("activated", "retired"),
+    "activated": ("retired",),
+    "retired": (),
+}
 
 
 @dataclass(frozen=True)
@@ -120,18 +134,23 @@ class NeonVersionRecord:
     Args:
         logical_name: Logical corpus this version belongs to.
         version: Physical version number.
-        state: Lifecycle state.
+        state: Lifecycle state (historical).
+        is_current: Whether this is the single currently-published version the
+            reader view points to (at most one true per logical name).
         created_at: When the physical table build started (epoch seconds).
         ready_at: When the build finished and indexes were valid, else None.
-        activated_at: When this version became the active pointer, else None.
+        activated_at: When this version was first published, else None.
+        retired_at: When this version was retired, else None.
     """
 
     logical_name: str
     version: int
     state: VersionState
-    created_at: float
+    is_current: bool = False
+    created_at: float = 0.0
     ready_at: float | None = None
     activated_at: float | None = None
+    retired_at: float | None = None
 
 
 @dataclass(frozen=True)
@@ -147,6 +166,14 @@ class RetentionPolicy:
 
     keep_activated: int = 2
     keep_ready: int = 1
+
+    def __post_init__(self) -> None:
+        # Enforce the documented minimum, not just describe it: rollback needs a
+        # prior activated version to fall back to.
+        if self.keep_activated < 2:
+            raise ValueError("keep_activated must be >= 2 so rollback has a target")
+        if self.keep_ready < 1:
+            raise ValueError("keep_ready must be >= 1")
 
 
 DEFAULT_RETENTION = RetentionPolicy()
@@ -193,20 +220,54 @@ def validate_text_search_config(config: str) -> str:
     return config
 
 
+_HASH_WIDTH = 16  # 64-bit content-hash suffix
+
+
+def validate_logical_name(logical_name: str) -> str:
+    """Return *logical_name* if it is a non-empty printable-ASCII string.
+
+    Restricting to ASCII keeps byte-length == char-length for the stable
+    reader-facing view identifier and avoids surprising multibyte truncation
+    (B4). Raises ValueError otherwise.
+    """
+    if not logical_name or not logical_name.isascii() or not logical_name.isprintable():
+        raise ValueError(
+            f"logical_name must be non-empty printable ASCII, got {logical_name!r}"
+        )
+    return logical_name
+
+
 def _fit_identifier(base: str, reserved: int) -> str:
     """Fit *base* into MAX_IDENTIFIER_BYTES leaving *reserved* bytes for a suffix.
 
-    Long names are truncated and given a stable 8-char content hash so distinct
-    logical names never collide after truncation (B4).
+    Byte-safe: the budget and truncation are measured in UTF-8 bytes (not
+    characters) and a partial trailing codepoint is dropped, so a multibyte name
+    can never exceed the 63-byte limit. Over-budget names keep a 16-hex (64-bit)
+    content hash — post-truncation collisions are cryptographically improbable,
+    not impossible (this is collision-resistance, not a uniqueness guarantee).
     """
     budget = MAX_IDENTIFIER_BYTES - reserved
-    if budget < 9:
+    min_suffix = _HASH_WIDTH + 1  # hash chars + '_' separator
+    if budget < min_suffix + 1:
         raise ValueError(f"reserved={reserved} leaves no room for an identifier")
-    if len(base.encode()) <= budget:
+    raw = base.encode()
+    if len(raw) <= budget:
         return base
-    digest = hashlib.sha256(base.encode()).hexdigest()[:8]
-    keep = budget - 9  # 8 hash chars + one '_' separator
-    return f"{base[:keep]}_{digest}"
+    digest = hashlib.sha256(raw).hexdigest()[:_HASH_WIDTH]
+    keep = budget - min_suffix
+    truncated = raw[:keep].decode("utf-8", errors="ignore")
+    return f"{truncated}_{digest}"
+
+
+def view_name(logical_name: str) -> str:
+    """Return the stable reader-facing VIEW identifier for *logical_name* (B4).
+
+    The view carries no per-version suffix, so it uses the full 63-byte budget.
+    Readers MUST resolve the view through this function rather than assume it
+    equals ``logical_name`` (a long name is hash-fitted, same as physical names).
+    """
+    validate_logical_name(logical_name)
+    return _fit_identifier(logical_name, reserved=0)
 
 
 def physical_table_name(logical_name: str, version: int) -> str:
@@ -215,6 +276,7 @@ def physical_table_name(logical_name: str, version: int) -> str:
     Length-safe: the logical portion is hashed if the full name would exceed the
     63-byte identifier limit. The same fitted base backs all per-version indexes.
     """
+    validate_logical_name(logical_name)
     validate_version(version)
     suffix = f"__v{version}"
     # Reserve room for both the version suffix and the longest index suffix.
@@ -283,13 +345,22 @@ CREATE_LEDGER_SKELETON = """
 CREATE TABLE IF NOT EXISTS neon_corpus_versions (
     logical_name text NOT NULL,
     version integer NOT NULL,
-    state text NOT NULL,
+    state text NOT NULL
+        CHECK (state IN ('building', 'ready', 'activated', 'retired')),
+    is_current boolean NOT NULL DEFAULT false,
     created_at timestamptz NOT NULL DEFAULT now(),
     ready_at timestamptz,
     activated_at timestamptz,
+    retired_at timestamptz,
     PRIMARY KEY (logical_name, version)
 )
 """.strip()
+
+# Current-pointer invariant (B5): at most one published version per logical name.
+CREATE_CURRENT_POINTER_INDEX = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS neon_corpus_current "
+    "ON neon_corpus_versions (logical_name) WHERE is_current"
+)
 
 # Owner-rights view (security_invoker = false) so the RO role never touches
 # physical tables. Explicit column list, never SELECT *.
@@ -309,14 +380,18 @@ def create_table_ddl(spec: NeonTableSpec) -> sql.Composed:
     raise NotImplementedError("schema DDL assembly is built in Slice 2")
 
 
-def activate_version_sql(spec: NeonTableSpec) -> list[sql.Composed]:
+def activate_version_sql(
+    spec: NeonTableSpec, grant: ReadGrantSpec
+) -> list[sql.Composed]:
     """Return the single-transaction composables that publish a version (B5).
 
-    Ordered: acquire ``pg_advisory_xact_lock`` on the logical name, upsert the
-    ledger active row, ``CREATE OR REPLACE VIEW`` (owner-rights, explicit
-    columns), and re-issue the RO grants on first create. All in one transaction
-    so the ledger update and view replacement commit or roll back together.
-    Design-lock stub: assembly lands in Slice 2.
+    Ordered, all under one ``pg_advisory_xact_lock`` on the logical name:
+    acquire the lock; clear the prior ``is_current`` row; set this version
+    ``state='activated'``, ``is_current=true``; ``CREATE OR REPLACE VIEW``
+    (owner-rights, explicit columns via ``view_name``/``VIEW_COLUMNS``); and issue
+    the RO grants from *grant* so a first-create view is readable atomically with
+    publication. The current-pointer unique index enforces the single-current
+    invariant. Design-lock stub: assembly lands in Slice 2.
     """
     raise NotImplementedError("version activation is built in Slice 2")
 

--- a/packages/castform/src/castform/rag/corpus/neon/search.py
+++ b/packages/castform/src/castform/rag/corpus/neon/search.py
@@ -31,7 +31,10 @@ monotonicity, and the dedup rule are frozen here.
 Multi-query dedup mirrors the Corpora path (``postgres/source.py``): a chunk hit
 by several queries keeps the **max** reciprocal rank across those queries as its
 ``max_score``, and results sort by the 3-tuple
-``(len(queries), not same_file, max_score)`` all descending.
+``(len(queries), not same_file, max_score)`` all descending. The surfaced
+``native_score`` is taken from **the same winning hit that supplied
+``max_score``** (the best-ranked occurrence), not averaged or retained per query,
+so the diagnostic score always corresponds to the surfaced rank.
 """
 
 from __future__ import annotations

--- a/packages/castform/src/castform/rag/corpus/neon/search.py
+++ b/packages/castform/src/castform/rag/corpus/neon/search.py
@@ -19,10 +19,14 @@ where ``rank`` is the 0-based position of a chunk in a single query's result
 list ordered better-first in that mode's native scorer (bm25 ascending ``<@>``,
 vector ascending distance, hybrid the fused ordering). This is monotonically
 decreasing in rank by construction, so relevance-descending is guaranteed
-independent of the raw scorer's range. The raw native score is retained
-internally for debugging but is *not* the surfaced number. Empirical validation
-of the raw ``<@>`` range is deferred to the Slice 3 live smoke; the surfaced
-formula, its monotonicity, and the dedup rule are frozen here.
+independent of the raw scorer's range.
+
+The raw native score is **preserved as a separate field** (``QueryHit.native_score``
+/ the ``native_score`` result key), never overloaded onto ``max_score`` (NB1): it
+carries the mode's real backend number (bm25 ``<@>``, vector distance, or fused
+RRF) for diagnostics and calibration. Empirical validation of the raw ``<@>``
+range is deferred to the Slice 3 live smoke; the surfaced formula, its
+monotonicity, and the dedup rule are frozen here.
 
 Multi-query dedup mirrors the Corpora path (``postgres/source.py``): a chunk hit
 by several queries keeps the **max** reciprocal rank across those queries as its
@@ -46,6 +50,24 @@ from castform.rag.corpus.search_schema.search_types import (
 
 SURFACED_RANK_K = 60
 """Reciprocal-rank constant (the standard RRF ``k``). ``score = 1/(K + rank)``."""
+
+
+@dataclass(frozen=True)
+class QueryHit:
+    """One per-query hit carrying both the surfaced and the raw native score.
+
+    Args:
+        chunk_id: The chunk hash.
+        surfaced_score: Ordinal ``1/(K + rank)`` — the public relevance number.
+        native_score: The mode's raw backend score (bm25 ``<@>``, vector
+            distance, or fused RRF), kept for diagnostics/calibration (NB1).
+        rank: 0-based rank in this query's native ordering.
+    """
+
+    chunk_id: str
+    surfaced_score: float
+    native_score: float
+    rank: int
 
 
 def surfaced_score(rank: int) -> float:
@@ -135,10 +157,11 @@ class NeonSearch:
         self.__dict__.update(state)
         self._conn = None
 
-    def query(self, request: NeonQueryRequest) -> list[tuple[str, float]]:
-        """Run one query, returning ``(chunk_id, surfaced_score)`` best-first.
+    def query(self, request: NeonQueryRequest) -> list[QueryHit]:
+        """Run one query, returning ``QueryHit`` rows best-first.
 
-        Design-lock stub: SQL execution is built in Slice 1.
+        Each hit carries both the surfaced ordinal score and the raw native
+        score (NB1). Design-lock stub: SQL execution is built in Slice 1.
         """
         raise NotImplementedError("Neon query execution is built in Slice 1")
 

--- a/packages/castform/src/castform/rag/corpus/neon/search.py
+++ b/packages/castform/src/castform/rag/corpus/neon/search.py
@@ -1,0 +1,150 @@
+"""NeonSearch — pickle-safe search client + the surfaced-score contract.
+
+Contract-freeze artifact (Slice A). The query execution, RRF fusion, and dedup
+are built in Slices 1/4 — the methods here are stubs. What *is* frozen: the
+internal query-request shape, the single-owner hybrid-fusion seam, and the exact
+public score formula.
+
+Surfaced-score contract (Contract #4)
+-------------------------------------
+The three native scorers disagree on direction: bm25 ``<@>`` is negative /
+lower-better, vector cosine distance is lower-better, RRF is higher-better.
+Rather than surface three incomparable scales, the public score is a single
+**rank-based reciprocal rank**, uniform across all modes and always
+higher-better::
+
+    surfaced_score(rank) = 1 / (SURFACED_RANK_K + rank)      # rank is 0-based
+
+where ``rank`` is the 0-based position of a chunk in a single query's result
+list ordered better-first in that mode's native scorer (bm25 ascending ``<@>``,
+vector ascending distance, hybrid the fused ordering). This is monotonically
+decreasing in rank by construction, so relevance-descending is guaranteed
+independent of the raw scorer's range. The raw native score is retained
+internally for debugging but is *not* the surfaced number. Empirical validation
+of the raw ``<@>`` range is deferred to the Slice 3 live smoke; the surfaced
+formula, its monotonicity, and the dedup rule are frozen here.
+
+Multi-query dedup mirrors the Corpora path (``postgres/source.py``): a chunk hit
+by several queries keeps the **max** reciprocal rank across those queries as its
+``max_score``, and results sort by the 3-tuple
+``(len(queries), not same_file, max_score)`` all descending.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from castform.platform.credentials import TokenProvider
+from castform.rag.corpus.neon.credentials import resolve_read_dsn_provider
+from castform.rag.corpus.search_schema.search_types import (
+    FilterPredicate,
+    HybridOptions,
+    SearchMode,
+)
+
+SURFACED_RANK_K = 60
+"""Reciprocal-rank constant (the standard RRF ``k``). ``score = 1/(K + rank)``."""
+
+
+def surfaced_score(rank: int) -> float:
+    """Return the public relevance score for a 0-based result rank.
+
+    Uniform across lexical/vector/hybrid, always higher-better, strictly
+    decreasing in ``rank``. This *is* implemented (it is the frozen formula, not
+    backend logic) so tests can pin exact numeric values.
+    """
+    if rank < 0:
+        raise ValueError("rank must be non-negative")
+    return 1.0 / (SURFACED_RANK_K + rank)
+
+
+@dataclass(frozen=True)
+class NeonQueryRequest:
+    """Internal query request handed to the Neon query layer.
+
+    Filtering is orthogonal to mode: any of the three modes runs filtered or
+    unfiltered (3 modes x filtered/unfiltered), so ``filter`` is a field, not a
+    fourth mode. Hybrid RRF fusion has a single owner — this query layer — so no
+    other component blends lexical and vector scores.
+
+    Args:
+        mode: Retrieval mode.
+        top_k: Maximum results requested.
+        text: Query text; required for lexical/hybrid.
+        vector: Query embedding; required for vector/hybrid.
+        filter: Optional metadata predicate (orthogonal to mode).
+        hybrid: Optional hybrid blending knobs.
+    """
+
+    mode: SearchMode
+    top_k: int = 5
+    text: str | None = None
+    vector: tuple[float, ...] | None = None
+    filter: FilterPredicate | None = None
+    hybrid: HybridOptions | None = None
+
+
+def fuse_rrf(
+    ranked_lists: list[list[str]], k: int = SURFACED_RANK_K
+) -> list[tuple[str, float]]:
+    """Fuse multiple ranked id-lists into one RRF ordering (single owner).
+
+    The one place lexical and vector rankings are combined for hybrid mode.
+    Design-lock stub: fusion is built in Slice 1.
+    """
+    raise NotImplementedError("RRF fusion is built in Slice 1")
+
+
+class NeonSearch:
+    """Pickle-safe Neon corpus search client for RL environments.
+
+    Mirrors ``TpufSearch``: no psycopg import at module load, connection resolved
+    per call via a read-only DSN provider, ``_conn`` nulled across pickling. The
+    DSN rides the ``str | TokenProvider | None`` seam and resolves to a
+    *read-only* grant (search never writes).
+
+    Args:
+        table: Logical corpus name to query (the active-version view).
+        embed_fn: Embedding function for vector/hybrid modes. Same interface as
+            every provider: ``Callable[[list[str]], list[list[float]]]``.
+        dsn_provider: Read-only DSN, a provider callable, or ``None`` to read
+            ``NEON_CORPUS_DSN_RO`` from the environment at query time.
+    """
+
+    def __init__(
+        self,
+        table: str,
+        *,
+        embed_fn: Callable[[list[str]], list[list[float]]] | None = None,
+        dsn_provider: str | TokenProvider | None = None,
+    ) -> None:
+        self._table = table
+        self._embed_fn = embed_fn
+        self._dsn_provider = resolve_read_dsn_provider  # bound in Slice 4
+        self._dsn_provider_arg = dsn_provider
+        self._conn: Any = None
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state["_conn"] = None
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self._conn = None
+
+    def query(self, request: NeonQueryRequest) -> list[tuple[str, float]]:
+        """Run one query, returning ``(chunk_id, surfaced_score)`` best-first.
+
+        Design-lock stub: SQL execution is built in Slice 1.
+        """
+        raise NotImplementedError("Neon query execution is built in Slice 1")
+
+    def search_content(self, request: NeonQueryRequest) -> list[str]:
+        """Return content strings only (cloudpickle-safe rollout path).
+
+        Design-lock stub: built in Slice 1.
+        """
+        raise NotImplementedError("Neon query execution is built in Slice 1")

--- a/packages/castform/src/castform/rag/corpus/neon/source.py
+++ b/packages/castform/src/castform/rag/corpus/neon/source.py
@@ -1,0 +1,157 @@
+"""NeonChunkSource — ChunkSource implementation over a Neon corpus.
+
+Contract-freeze artifact (Slice A). All methods are stubs; ingest and search
+land in Slices 1/2/4. This module freezes two surface commitments:
+
+- ``search_related`` obeys the shared ``ChunkSource`` contract (relevance
+  descending, a ``max_score`` per result) using the surfaced reciprocal-rank
+  score from ``search.py`` (Contract #4).
+- ``scan_chunks`` is a *stable* full-corpus iterator ordered by
+  ``(file, index, id)`` so qa-gen full-corpus materialization is deterministic
+  (Contract #5). It is a Neon extension to the surface — promoting it onto the
+  shared ``ChunkSource`` protocol is deferred to a later slice.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from typing import TYPE_CHECKING
+
+from castform.platform.credentials import TokenProvider
+from castform.rag.corpus.search_schema.search_types import (
+    FilterPredicate,
+    HybridOptions,
+    SearchCapabilities,
+    SearchMode,
+    SearchSpec,
+)
+
+if TYPE_CHECKING:
+    from castform.rag.chunkers.models import Chunk, ChunkCollection
+
+# Order key that makes scan_chunks deterministic. ``file`` and ``index`` are read
+# from chunk metadata; ``id`` (the chunk hash) is the final tiebreak.
+SCAN_ORDER_METADATA_FILE_KEY = "source_file"
+SCAN_ORDER_METADATA_INDEX_KEY = "chunk_index"
+SCAN_ORDER_BY = (SCAN_ORDER_METADATA_FILE_KEY, SCAN_ORDER_METADATA_INDEX_KEY, "id")
+
+
+class NeonChunkSource:
+    """Corpus backend backed by a versioned Neon (Postgres + pgvector) table.
+
+    Args:
+        logical_name: Stable logical corpus name (the active-version view).
+        embed_fn: Embedding function for vector/hybrid modes.
+        read_dsn_provider: Read-only DSN seam for search.
+        write_dsn_provider: Read-write DSN seam for ingest. Separate from the
+            read provider so a search-only handle cannot mutate the corpus.
+    """
+
+    def __init__(
+        self,
+        logical_name: str,
+        *,
+        embed_fn: Callable[[list[str]], list[list[float]]] | None = None,
+        read_dsn_provider: str | TokenProvider | None = None,
+        write_dsn_provider: str | TokenProvider | None = None,
+    ) -> None:
+        self._logical_name = logical_name
+        self._embed_fn = embed_fn
+        self._read_dsn_provider = read_dsn_provider
+        self._write_dsn_provider = write_dsn_provider
+
+    # --- ingest --------------------------------------------------------------
+
+    def populate_from_folder(
+        self,
+        docs_path: str,
+        min_chars: int = 1024,
+        max_chars: int = 2048,
+        overlap_chars: int = 128,
+        file_extensions: list[str] | None = None,
+        batch_size: int = 100,
+        show_summary: bool = True,
+    ) -> None:
+        """Chunk a folder and ingest as a new corpus version. Built in Slice 2."""
+        raise NotImplementedError("Neon ingest is built in Slice 2")
+
+    def populate_from_chunks(
+        self,
+        collection: ChunkCollection,
+        batch_size: int = 100,
+        show_summary: bool = True,
+    ) -> None:
+        """Ingest a pre-built collection as a new corpus version. Built in Slice 2."""
+        raise NotImplementedError("Neon ingest is built in Slice 2")
+
+    # --- read / sample -------------------------------------------------------
+
+    def sample_chunks(self, n: int, min_chars: int = 0) -> list[Chunk]:
+        """Return n randomly sampled chunks. Built in Slice 1."""
+        raise NotImplementedError("Neon read is built in Slice 1")
+
+    def scan_chunks(self, batch_size: int = 1000) -> Iterator[Chunk]:
+        """Yield every chunk in a stable order for deterministic materialization.
+
+        Ordered by ``(file, index, id)`` (see ``SCAN_ORDER_BY``) via keyset
+        pagination so qa-gen full-corpus reads are reproducible run to run.
+        Design-lock stub: built in Slice 1.
+        """
+        raise NotImplementedError("scan_chunks is built in Slice 1")
+
+    def get_chunk_with_context(self, chunk: Chunk, max_chars: int = 200) -> dict:
+        """Return a chunk with neighboring-context previews. Built in Slice 1."""
+        raise NotImplementedError("Neon read is built in Slice 1")
+
+    def get_top_level_chunks(self) -> list[Chunk]:
+        """Return top-level-file chunks (empty if unsupported). Built in Slice 1."""
+        raise NotImplementedError("Neon read is built in Slice 1")
+
+    # --- search --------------------------------------------------------------
+
+    def search_related(
+        self,
+        source: Chunk,
+        queries: list[str],
+        top_k: int = 5,
+        mode: SearchMode | None = None,
+        hybrid: HybridOptions | None = None,
+    ) -> list[dict]:
+        """Search related chunks; relevance-descending with a ``max_score``.
+
+        Returns dicts keyed ``{chunk, queries, same_file, max_score}`` sorted by
+        ``(len(queries), not same_file, max_score)`` descending, using the
+        surfaced reciprocal-rank score. Built in Slice 1.
+        """
+        raise NotImplementedError("Neon search is built in Slice 1")
+
+    def search(self, spec: SearchSpec) -> list[Chunk]:
+        """Structured search. Built in Slice 1."""
+        raise NotImplementedError("Neon search is built in Slice 1")
+
+    def search_content(self, spec: SearchSpec) -> list[str]:
+        """Cloudpickle-safe content-only search. Built in Slice 1."""
+        raise NotImplementedError("Neon search is built in Slice 1")
+
+    def search_text(
+        self,
+        text_query: str,
+        top_k: int = 10,
+        filter: FilterPredicate | None = None,
+    ) -> list[Chunk]:
+        """Text search with optional filter. Built in Slice 1."""
+        raise NotImplementedError("Neon search is built in Slice 1")
+
+    def embed_query(self, text: str) -> list[float] | None:
+        """Embed a query, or ``None`` if no embed_fn. Built in Slice 1."""
+        raise NotImplementedError("Neon search is built in Slice 1")
+
+    # --- capabilities --------------------------------------------------------
+
+    def get_chunk_count(self) -> int:
+        """Total chunk count for the active version. Built in Slice 1."""
+        raise NotImplementedError("Neon read is built in Slice 1")
+
+    def get_search_capabilities(self) -> SearchCapabilities:
+        """Report Neon backend capabilities. Built in Slice 1."""
+        raise NotImplementedError("Neon capabilities are built in Slice 1")

--- a/packages/castform/src/castform/rag/corpus/neon/source.py
+++ b/packages/castform/src/castform/rag/corpus/neon/source.py
@@ -6,10 +6,11 @@ land in Slices 1/2/4. This module freezes two surface commitments:
 - ``search_related`` obeys the shared ``ChunkSource`` contract (relevance
   descending, a ``max_score`` per result) using the surfaced reciprocal-rank
   score from ``search.py`` (Contract #4).
-- ``scan_chunks`` is a *stable* full-corpus iterator ordered by
-  ``(file, index, id)`` so qa-gen full-corpus materialization is deterministic
-  (Contract #5). It is a Neon extension to the surface — promoting it onto the
-  shared ``ChunkSource`` protocol is deferred to a later slice.
+- ``scan_chunks`` is a *stable*, pageable full-corpus iterator ordered by the
+  typed non-null columns ``(source_file, chunk_index, id)`` so qa-gen full-corpus
+  materialization is deterministic (Contract #5). It is a Neon extension to the
+  surface — promoting it onto the shared ``ChunkSource`` protocol is deferred to
+  a later slice.
 """
 
 from __future__ import annotations
@@ -29,11 +30,14 @@ from castform.rag.corpus.search_schema.search_types import (
 if TYPE_CHECKING:
     from castform.rag.chunkers.models import Chunk, ChunkCollection
 
-# Order key that makes scan_chunks deterministic. ``file`` and ``index`` are read
-# from chunk metadata; ``id`` (the chunk hash) is the final tiebreak.
-SCAN_ORDER_METADATA_FILE_KEY = "source_file"
-SCAN_ORDER_METADATA_INDEX_KEY = "chunk_index"
-SCAN_ORDER_BY = (SCAN_ORDER_METADATA_FILE_KEY, SCAN_ORDER_METADATA_INDEX_KEY, "id")
+# Total, pageable scan order (B6). These are TYPED, NOT NULL physical columns —
+# ``source_file text`` and ``chunk_index integer`` (populated at ingest from
+# metadata) plus ``id`` (the chunk hash) as the final tiebreak — backed by the
+# ``scan`` btree. Using real columns (not JSONB extraction) avoids lexical
+# ``chunk_index`` sorting (1,10,2), NULL-break keysets, and collation ambiguity;
+# the keyset cursor is the row-tuple predicate ``(source_file, chunk_index, id) >
+# (%s, %s, %s)``.
+SCAN_ORDER_BY = ("source_file", "chunk_index", "id")
 
 
 class NeonChunkSource:
@@ -119,9 +123,10 @@ class NeonChunkSource:
     ) -> list[dict]:
         """Search related chunks; relevance-descending with a ``max_score``.
 
-        Returns dicts keyed ``{chunk, queries, same_file, max_score}`` sorted by
-        ``(len(queries), not same_file, max_score)`` descending, using the
-        surfaced reciprocal-rank score. Built in Slice 1.
+        Returns dicts keyed ``{chunk, queries, same_file, max_score, native_score}``
+        sorted by ``(len(queries), not same_file, max_score)`` descending, using
+        the surfaced reciprocal-rank score for ``max_score``; ``native_score``
+        carries the raw backend score for diagnostics (NB1). Built in Slice 1.
         """
         raise NotImplementedError("Neon search is built in Slice 1")
 

--- a/packages/castform/src/castform/rag/corpus/neon/source.py
+++ b/packages/castform/src/castform/rag/corpus/neon/source.py
@@ -126,7 +126,8 @@ class NeonChunkSource:
         Returns dicts keyed ``{chunk, queries, same_file, max_score, native_score}``
         sorted by ``(len(queries), not same_file, max_score)`` descending, using
         the surfaced reciprocal-rank score for ``max_score``; ``native_score``
-        carries the raw backend score for diagnostics (NB1). Built in Slice 1.
+        carries the raw backend score from the SAME winning hit that supplied
+        ``max_score`` (NB1). Built in Slice 1.
         """
         raise NotImplementedError("Neon search is built in Slice 1")
 

--- a/packages/castform/tests/conftest.py
+++ b/packages/castform/tests/conftest.py
@@ -23,6 +23,7 @@ _HAS_RAG_EXTRA = all(
     )
 )
 _HAS_CHROMA_EXTRA = _has_module("chromadb")
+_HAS_NEON_EXTRA = _has_module("psycopg") and _has_module("pydantic")
 _RAG_EXTRA_TESTS = {
     Path("tests/unit/rag/qa_generation"),
     Path("tests/unit/rag/test_auto_tune.py"),
@@ -54,6 +55,14 @@ def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool 
         "rag",
         "corpus",
         "chroma",
+    ):
+        return True
+    if not _HAS_NEON_EXTRA and rel.parts[:5] == (
+        "tests",
+        "unit",
+        "rag",
+        "corpus",
+        "neon",
     ):
         return True
     return None

--- a/packages/castform/tests/conftest.py
+++ b/packages/castform/tests/conftest.py
@@ -23,7 +23,19 @@ _HAS_RAG_EXTRA = all(
     )
 )
 _HAS_CHROMA_EXTRA = _has_module("chromadb")
-_HAS_NEON_EXTRA = _has_module("psycopg") and _has_module("pydantic")
+_HAS_PYDANTIC = _has_module("pydantic")
+_HAS_PSYCOPG = _has_module("psycopg")
+# Neon test files that genuinely need a heavy dep. Pure-python contract tests
+# (naming, filter truth table, score formula) are NOT listed, so they collect
+# even without the neon extra installed.
+_NEON_DIR = Path("tests/unit/rag/corpus/neon")
+_NEON_PYDANTIC_TESTS = {
+    _NEON_DIR / "test_eval_schema.py",
+    _NEON_DIR / "test_search_related.py",
+}
+_NEON_PSYCOPG_TESTS = {
+    _NEON_DIR / "test_transaction_lifecycle.py",
+}
 _RAG_EXTRA_TESTS = {
     Path("tests/unit/rag/qa_generation"),
     Path("tests/unit/rag/test_auto_tune.py"),
@@ -57,13 +69,9 @@ def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool 
         "chroma",
     ):
         return True
-    if not _HAS_NEON_EXTRA and rel.parts[:5] == (
-        "tests",
-        "unit",
-        "rag",
-        "corpus",
-        "neon",
-    ):
+    if not _HAS_PYDANTIC and rel in _NEON_PYDANTIC_TESTS:
+        return True
+    if not _HAS_PSYCOPG and rel in _NEON_PSYCOPG_TESTS:
         return True
     return None
 

--- a/packages/castform/tests/unit/rag/corpus/neon/test_credentials_seam.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_credentials_seam.py
@@ -1,7 +1,7 @@
 """Contract #2: separate read vs write DSN provider surfaces.
 
 Env-var names + separation are frozen here (pass); lazy resolution is an xfail
-skeleton filled by Slice 4.
+skeleton that must raise NotImplementedError until Slice 4.
 """
 
 from __future__ import annotations
@@ -22,13 +22,11 @@ def test_read_and_write_env_vars_distinct() -> None:
     assert READ_DSN_ENV_VAR != WRITE_DSN_ENV_VAR
 
 
-@pytest.mark.xfail(reason="DSN resolution built in Slice 4", strict=False)
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 4")
 def test_read_provider_resolves_lazily() -> None:
-    provider = resolve_read_dsn_provider("postgresql://ro@host/db")
-    assert callable(provider)
+    resolve_read_dsn_provider("postgresql://ro@host/db")
 
 
-@pytest.mark.xfail(reason="DSN resolution built in Slice 4", strict=False)
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 4")
 def test_write_provider_resolves_lazily() -> None:
-    provider = resolve_write_dsn_provider("postgresql://rw@host/db")
-    assert callable(provider)
+    resolve_write_dsn_provider("postgresql://rw@host/db")

--- a/packages/castform/tests/unit/rag/corpus/neon/test_credentials_seam.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_credentials_seam.py
@@ -1,0 +1,34 @@
+"""Contract #2: separate read vs write DSN provider surfaces.
+
+Env-var names + separation are frozen here (pass); lazy resolution is an xfail
+skeleton filled by Slice 4.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from castform.rag.corpus.neon.credentials import (
+    READ_DSN_ENV_VAR,
+    WRITE_DSN_ENV_VAR,
+    resolve_read_dsn_provider,
+    resolve_write_dsn_provider,
+)
+
+
+def test_read_and_write_env_vars_distinct() -> None:
+    assert READ_DSN_ENV_VAR == "NEON_CORPUS_DSN_RO"
+    assert WRITE_DSN_ENV_VAR == "NEON_CORPUS_DSN_RW"
+    assert READ_DSN_ENV_VAR != WRITE_DSN_ENV_VAR
+
+
+@pytest.mark.xfail(reason="DSN resolution built in Slice 4", strict=False)
+def test_read_provider_resolves_lazily() -> None:
+    provider = resolve_read_dsn_provider("postgresql://ro@host/db")
+    assert callable(provider)
+
+
+@pytest.mark.xfail(reason="DSN resolution built in Slice 4", strict=False)
+def test_write_provider_resolves_lazily() -> None:
+    provider = resolve_write_dsn_provider("postgresql://rw@host/db")
+    assert callable(provider)

--- a/packages/castform/tests/unit/rag/corpus/neon/test_eval_schema.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_eval_schema.py
@@ -1,0 +1,53 @@
+"""Contract #6: eval JSONL schema (frozen; validates today)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from castform.rag.corpus.neon.eval_schema import (
+    DEFAULT_THRESHOLDS,
+    LEXICAL_ABLATION_MIN_DELTA,
+    NeonEvalRecord,
+)
+
+
+def test_record_carries_gold_hashes_explicitly() -> None:
+    rec = NeonEvalRecord(
+        capability="filter_eq",
+        search_mode="hybrid",
+        query="who wrote it",
+        filter_dsl={"field": "year", "op": "eq", "value": 2026},
+        gold_chunk_hashes=["abc123"],
+        decoy_chunk_hashes=["def456"],
+    )
+    assert rec.gold_chunk_hashes == ["abc123"]
+    assert rec.decoy_chunk_hashes == ["def456"]
+
+
+def test_record_requires_at_least_one_gold() -> None:
+    with pytest.raises(ValidationError):
+        NeonEvalRecord(
+            capability="c",
+            search_mode="lexical",
+            query="q",
+            gold_chunk_hashes=[],
+        )
+
+
+def test_filter_dsl_optional() -> None:
+    rec = NeonEvalRecord(
+        capability="c",
+        search_mode="vector",
+        query="q",
+        gold_chunk_hashes=["h"],
+    )
+    assert rec.filter_dsl is None
+
+
+def test_default_thresholds_ordered_by_mode() -> None:
+    assert DEFAULT_THRESHOLDS["hybrid"].hit_at_k > DEFAULT_THRESHOLDS["vector"].hit_at_k
+    assert (
+        DEFAULT_THRESHOLDS["vector"].hit_at_k > DEFAULT_THRESHOLDS["lexical"].hit_at_k
+    )
+    assert LEXICAL_ABLATION_MIN_DELTA == 0.05

--- a/packages/castform/tests/unit/rag/corpus/neon/test_filter_truth_table.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_filter_truth_table.py
@@ -1,8 +1,8 @@
-"""Contract #3: type-directed, indexable 9-op filter truth table.
+"""Contract #3: type-directed, indexable, correctly-negating filter truth table.
 
-The frozen table (canonical SQL, edge outcomes, indexability) is asserted here
-and passes; the SQL emission via ``predicate_to_sql`` is an xfail skeleton that
-must raise NotImplementedError until Slice 4 fills it.
+The frozen table (positive SQL, three-valued negated leaves, edge outcomes,
+indexability, typed contains shapes) is asserted here and passes; SQL emission via
+``predicate_to_sql`` is an xfail skeleton that must raise NotImplementedError.
 """
 
 from __future__ import annotations
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from castform.rag.corpus.neon.filter_mapper import (
+    CONTAINS_ATOM_BY_TYPE,
     FILTER_TRUTH_TABLE_BY_OP,
     LIST_OPS,
     NEGATION_TEMPLATE,
@@ -19,9 +20,7 @@ from castform.rag.corpus.neon.filter_mapper import (
 )
 from castform.rag.corpus.search_schema.search_types import FieldPredicate
 
-# Frozen canonical value-present SQL per op (containment for eq/ne/in/contains_*,
-# guarded numeric cast for ranges). Slice 4 must emit exactly these.
-EXPECTED_CANONICAL_SQL: dict[str, str] = {
+EXPECTED_POSITIVE_SQL: dict[str, str] = {
     "eq": "metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))",
     "ne": (
         "(metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))) IS NOT TRUE"
@@ -31,20 +30,20 @@ EXPECTED_CANONICAL_SQL: dict[str, str] = {
         "metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v1)s::numeric)))"
     ),
     "gt": (
-        "jsonb_typeof(metadata -> %(k)s) = 'number' "
-        "AND (metadata ->> %(k)s)::numeric > %(v)s::numeric"
+        "CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number' "
+        "THEN (metadata ->> %(k)s)::numeric > %(v)s::numeric ELSE NULL END"
     ),
     "gte": (
-        "jsonb_typeof(metadata -> %(k)s) = 'number' "
-        "AND (metadata ->> %(k)s)::numeric >= %(v)s::numeric"
+        "CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number' "
+        "THEN (metadata ->> %(k)s)::numeric >= %(v)s::numeric ELSE NULL END"
     ),
     "lt": (
-        "jsonb_typeof(metadata -> %(k)s) = 'number' "
-        "AND (metadata ->> %(k)s)::numeric < %(v)s::numeric"
+        "CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number' "
+        "THEN (metadata ->> %(k)s)::numeric < %(v)s::numeric ELSE NULL END"
     ),
     "lte": (
-        "jsonb_typeof(metadata -> %(k)s) = 'number' "
-        "AND (metadata ->> %(k)s)::numeric <= %(v)s::numeric"
+        "CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number' "
+        "THEN (metadata ->> %(k)s)::numeric <= %(v)s::numeric ELSE NULL END"
     ),
     "contains_any": (
         "(metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v0)s::text))) OR "
@@ -56,7 +55,7 @@ EXPECTED_CANONICAL_SQL: dict[str, str] = {
     ),
 }
 
-# op -> (missing_key, json_null, wrong_type, empty_operand) outcomes.
+# op -> (missing_key, json_null, wrong_type, empty_operand) POSITIVE-leaf outcomes.
 EXPECTED_EDGE_OUTCOMES: dict[str, tuple[str, str, str, str]] = {
     "eq": ("exclude", "exclude", "exclude", "na"),
     "ne": ("include", "include", "include", "na"),
@@ -69,7 +68,6 @@ EXPECTED_EDGE_OUTCOMES: dict[str, tuple[str, str, str, str]] = {
     "contains_all": ("exclude", "exclude", "exclude", "include"),
 }
 
-# Only containment forms are GIN-indexable; ne (negation) and ranges are not.
 EXPECTED_INDEXABLE = {
     "eq": True,
     "ne": False,
@@ -82,7 +80,6 @@ EXPECTED_INDEXABLE = {
     "contains_all": True,
 }
 
-# Valid per-op fixtures — list ops get lists, ranges get numbers, eq/ne a scalar.
 VALID_FIXTURES: dict[str, object] = {
     "eq": 2026,
     "ne": 2026,
@@ -97,22 +94,21 @@ VALID_FIXTURES: dict[str, object] = {
 
 
 def test_nine_operators_frozen() -> None:
-    assert set(NEON_FIELD_OPERATORS) == set(EXPECTED_CANONICAL_SQL)
+    assert set(NEON_FIELD_OPERATORS) == set(EXPECTED_POSITIVE_SQL)
     assert len(NEON_FIELD_OPERATORS) == 9
     assert {"ne", "gt", "lt"} <= set(NEON_FIELD_OPERATORS)
     assert RANGE_OPS == {"gt", "gte", "lt", "lte"}
     assert LIST_OPS == {"in", "contains_any", "contains_all"}
 
 
-@pytest.mark.parametrize("op", list(EXPECTED_CANONICAL_SQL))
-def test_canonical_sql_frozen(op: str) -> None:
-    assert FILTER_TRUTH_TABLE_BY_OP[op].canonical_sql == EXPECTED_CANONICAL_SQL[op]
+@pytest.mark.parametrize("op", list(EXPECTED_POSITIVE_SQL))
+def test_positive_sql_frozen(op: str) -> None:
+    assert FILTER_TRUTH_TABLE_BY_OP[op].positive_sql == EXPECTED_POSITIVE_SQL[op]
 
 
 @pytest.mark.parametrize("op", list(EXPECTED_EDGE_OUTCOMES))
 def test_edge_outcomes_frozen(op: str) -> None:
-    spec = FILTER_TRUTH_TABLE_BY_OP[op]
-    o = spec.outcomes
+    o = FILTER_TRUTH_TABLE_BY_OP[op].outcomes
     assert (
         o["missing_key"],
         o["json_null"],
@@ -126,14 +122,51 @@ def test_indexability_frozen(op: str) -> None:
     assert FILTER_TRUTH_TABLE_BY_OP[op].indexable == EXPECTED_INDEXABLE[op]
 
 
+@pytest.mark.parametrize("op", ["eq", "in", "contains_any", "contains_all"])
+def test_negated_leaf_is_three_valued(op: str) -> None:
+    # A NotPredicate wraps this; it must yield NULL (not FALSE) for
+    # missing/null/wrong-type so NOT(NULL)=NULL keeps them excluded.
+    neg = FILTER_TRUTH_TABLE_BY_OP[op].negated_leaf_sql
+    assert neg.startswith("CASE WHEN NOT jsonb_exists(metadata, %(k)s) THEN NULL")
+    assert "THEN NULL" in neg and neg.rstrip().endswith("END")
+    # and it is NOT just the bare (two-valued) positive containment.
+    assert neg != FILTER_TRUTH_TABLE_BY_OP[op].positive_sql
+
+
+@pytest.mark.parametrize("op", ["gt", "gte", "lt", "lte"])
+def test_range_cast_is_inside_case_not_bare_and(op: str) -> None:
+    spec = FILTER_TRUTH_TABLE_BY_OP[op]
+    assert spec.positive_sql.startswith(
+        "CASE WHEN jsonb_typeof(metadata -> %(k)s) = 'number'"
+    )
+    assert "ELSE NULL END" in spec.positive_sql
+    # the unsafe `guard AND (...)::numeric` form must NOT appear.
+    assert "' AND (metadata ->>" not in spec.positive_sql
+
+
+def test_typed_contains_shapes_frozen() -> None:
+    # numeric and boolean contains shapes are frozen explicitly, not only text.
+    assert CONTAINS_ATOM_BY_TYPE["number"].endswith("to_jsonb(%(v)s::numeric)))")
+    assert CONTAINS_ATOM_BY_TYPE["boolean"].endswith("to_jsonb(%(v)s::boolean)))")
+    assert CONTAINS_ATOM_BY_TYPE["text"].endswith("to_jsonb(%(v)s::text)))")
+
+
+def test_empty_operand_indexability() -> None:
+    # contains_all [] is @> '[]' which jsonb_path_ops cannot accelerate.
+    assert FILTER_TRUTH_TABLE_BY_OP["contains_all"].empty_operand_indexable is False
+    # in [] / contains_any [] collapse to constant FALSE (no scan).
+    assert FILTER_TRUTH_TABLE_BY_OP["in"].empty_operand_indexable is True
+    assert FILTER_TRUTH_TABLE_BY_OP["contains_any"].empty_operand_indexable is True
+
+
 def test_negation_template_frozen() -> None:
     assert NEGATION_TEMPLATE == "NOT ({inner})"
 
 
 @pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 4")
-@pytest.mark.parametrize("op", list(EXPECTED_CANONICAL_SQL))
-def test_predicate_to_sql_emits_canonical(op: str) -> None:
+@pytest.mark.parametrize("op", list(EXPECTED_POSITIVE_SQL))
+def test_predicate_to_sql_emits_positive(op: str) -> None:
     pred = FieldPredicate(field="year", op=op, value=VALID_FIXTURES[op])  # type: ignore[arg-type]
     sql, params = predicate_to_sql(pred)
-    assert sql == EXPECTED_CANONICAL_SQL[op]
+    assert sql == EXPECTED_POSITIVE_SQL[op]
     assert params["k"] == "year"

--- a/packages/castform/tests/unit/rag/corpus/neon/test_filter_truth_table.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_filter_truth_table.py
@@ -1,0 +1,76 @@
+"""Contract #3: 9-op filter truth table.
+
+The frozen table shape is asserted here (passes); the SQL emission via
+``predicate_to_sql`` is an xfail skeleton filled by Slice 4. Expected value-present
+SQL per op lives in ``EXPECTED_VALUE_PRESENT_SQL`` so Slice 4 has exact targets.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from castform.rag.corpus.neon.filter_mapper import (
+    FILTER_TRUTH_TABLE_BY_OP,
+    NEGATION_TEMPLATE,
+    NEON_FIELD_OPERATORS,
+    predicate_to_sql,
+)
+from castform.rag.corpus.search_schema.search_types import FieldPredicate
+
+EXPECTED_VALUE_PRESENT_SQL: dict[str, str] = {
+    "eq": "(metadata ->> %(k)s) = %(v)s",
+    "ne": "(metadata ->> %(k)s) IS DISTINCT FROM %(v)s",
+    "in": "(metadata ->> %(k)s) = ANY(%(v)s)",
+    "gt": "(metadata ->> %(k)s)::numeric > %(v)s",
+    "gte": "(metadata ->> %(k)s)::numeric >= %(v)s",
+    "lt": "(metadata ->> %(k)s)::numeric < %(v)s",
+    "lte": "(metadata ->> %(k)s)::numeric <= %(v)s",
+    "contains_any": "(metadata -> %(k)s) ?| %(v)s",
+    "contains_all": "(metadata -> %(k)s) ?& %(v)s",
+}
+
+# op -> (null/missing-key semantic, empty-array-operand semantic).
+EXPECTED_EDGE_SEMANTICS: dict[str, tuple[str, str | None]] = {
+    "eq": ("exclude", None),
+    "ne": ("include", None),
+    "in": ("exclude", "exclude"),
+    "gt": ("exclude", None),
+    "gte": ("exclude", None),
+    "lt": ("exclude", None),
+    "lte": ("exclude", None),
+    "contains_any": ("exclude", "exclude"),
+    "contains_all": ("exclude", "include"),
+}
+
+
+def test_nine_operators_frozen() -> None:
+    assert set(NEON_FIELD_OPERATORS) == set(EXPECTED_VALUE_PRESENT_SQL)
+    assert len(NEON_FIELD_OPERATORS) == 9
+    # ne/gt/lt are the three added on top of the shared six.
+    assert {"ne", "gt", "lt"} <= set(NEON_FIELD_OPERATORS)
+
+
+@pytest.mark.parametrize("op", list(EXPECTED_VALUE_PRESENT_SQL))
+def test_truth_table_sql_shape_frozen(op: str) -> None:
+    assert FILTER_TRUTH_TABLE_BY_OP[op].sql_template == EXPECTED_VALUE_PRESENT_SQL[op]
+
+
+@pytest.mark.parametrize("op", list(EXPECTED_EDGE_SEMANTICS))
+def test_truth_table_edge_semantics_frozen(op: str) -> None:
+    spec = FILTER_TRUTH_TABLE_BY_OP[op]
+    null_sem, empty_sem = EXPECTED_EDGE_SEMANTICS[op]
+    assert spec.null_or_missing == null_sem
+    assert spec.empty_array == empty_sem
+
+
+def test_negation_template_frozen() -> None:
+    assert NEGATION_TEMPLATE == "NOT ({inner})"
+
+
+@pytest.mark.xfail(reason="filter SQL emission built in Slice 4", strict=False)
+@pytest.mark.parametrize("op", list(EXPECTED_VALUE_PRESENT_SQL))
+def test_predicate_to_sql_emits_expected(op: str) -> None:
+    pred = FieldPredicate(field="year", op=op, value=2026)  # type: ignore[arg-type]
+    sql, params = predicate_to_sql(pred)
+    assert sql == EXPECTED_VALUE_PRESENT_SQL[op]
+    assert params["k"] == "year"

--- a/packages/castform/tests/unit/rag/corpus/neon/test_filter_truth_table.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_filter_truth_table.py
@@ -1,8 +1,8 @@
-"""Contract #3: 9-op filter truth table.
+"""Contract #3: type-directed, indexable 9-op filter truth table.
 
-The frozen table shape is asserted here (passes); the SQL emission via
-``predicate_to_sql`` is an xfail skeleton filled by Slice 4. Expected value-present
-SQL per op lives in ``EXPECTED_VALUE_PRESENT_SQL`` so Slice 4 has exact targets.
+The frozen table (canonical SQL, edge outcomes, indexability) is asserted here
+and passes; the SQL emission via ``predicate_to_sql`` is an xfail skeleton that
+must raise NotImplementedError until Slice 4 fills it.
 """
 
 from __future__ import annotations
@@ -11,66 +11,129 @@ import pytest
 
 from castform.rag.corpus.neon.filter_mapper import (
     FILTER_TRUTH_TABLE_BY_OP,
+    LIST_OPS,
     NEGATION_TEMPLATE,
     NEON_FIELD_OPERATORS,
+    RANGE_OPS,
     predicate_to_sql,
 )
 from castform.rag.corpus.search_schema.search_types import FieldPredicate
 
-EXPECTED_VALUE_PRESENT_SQL: dict[str, str] = {
-    "eq": "(metadata ->> %(k)s) = %(v)s",
-    "ne": "(metadata ->> %(k)s) IS DISTINCT FROM %(v)s",
-    "in": "(metadata ->> %(k)s) = ANY(%(v)s)",
-    "gt": "(metadata ->> %(k)s)::numeric > %(v)s",
-    "gte": "(metadata ->> %(k)s)::numeric >= %(v)s",
-    "lt": "(metadata ->> %(k)s)::numeric < %(v)s",
-    "lte": "(metadata ->> %(k)s)::numeric <= %(v)s",
-    "contains_any": "(metadata -> %(k)s) ?| %(v)s",
-    "contains_all": "(metadata -> %(k)s) ?& %(v)s",
+# Frozen canonical value-present SQL per op (containment for eq/ne/in/contains_*,
+# guarded numeric cast for ranges). Slice 4 must emit exactly these.
+EXPECTED_CANONICAL_SQL: dict[str, str] = {
+    "eq": "metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))",
+    "ne": (
+        "(metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v)s::numeric))) IS NOT TRUE"
+    ),
+    "in": (
+        "(metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v0)s::numeric)) OR "
+        "metadata @> jsonb_build_object(%(k)s, to_jsonb(%(v1)s::numeric)))"
+    ),
+    "gt": (
+        "jsonb_typeof(metadata -> %(k)s) = 'number' "
+        "AND (metadata ->> %(k)s)::numeric > %(v)s::numeric"
+    ),
+    "gte": (
+        "jsonb_typeof(metadata -> %(k)s) = 'number' "
+        "AND (metadata ->> %(k)s)::numeric >= %(v)s::numeric"
+    ),
+    "lt": (
+        "jsonb_typeof(metadata -> %(k)s) = 'number' "
+        "AND (metadata ->> %(k)s)::numeric < %(v)s::numeric"
+    ),
+    "lte": (
+        "jsonb_typeof(metadata -> %(k)s) = 'number' "
+        "AND (metadata ->> %(k)s)::numeric <= %(v)s::numeric"
+    ),
+    "contains_any": (
+        "(metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v0)s::text))) OR "
+        "metadata @> jsonb_build_object(%(k)s, jsonb_build_array(to_jsonb(%(v1)s::text))))"
+    ),
+    "contains_all": (
+        "metadata @> jsonb_build_object(%(k)s, "
+        "jsonb_build_array(to_jsonb(%(v0)s::text), to_jsonb(%(v1)s::text)))"
+    ),
 }
 
-# op -> (null/missing-key semantic, empty-array-operand semantic).
-EXPECTED_EDGE_SEMANTICS: dict[str, tuple[str, str | None]] = {
-    "eq": ("exclude", None),
-    "ne": ("include", None),
-    "in": ("exclude", "exclude"),
-    "gt": ("exclude", None),
-    "gte": ("exclude", None),
-    "lt": ("exclude", None),
-    "lte": ("exclude", None),
-    "contains_any": ("exclude", "exclude"),
-    "contains_all": ("exclude", "include"),
+# op -> (missing_key, json_null, wrong_type, empty_operand) outcomes.
+EXPECTED_EDGE_OUTCOMES: dict[str, tuple[str, str, str, str]] = {
+    "eq": ("exclude", "exclude", "exclude", "na"),
+    "ne": ("include", "include", "include", "na"),
+    "in": ("exclude", "exclude", "exclude", "exclude"),
+    "gt": ("exclude", "exclude", "exclude", "na"),
+    "gte": ("exclude", "exclude", "exclude", "na"),
+    "lt": ("exclude", "exclude", "exclude", "na"),
+    "lte": ("exclude", "exclude", "exclude", "na"),
+    "contains_any": ("exclude", "exclude", "exclude", "exclude"),
+    "contains_all": ("exclude", "exclude", "exclude", "include"),
+}
+
+# Only containment forms are GIN-indexable; ne (negation) and ranges are not.
+EXPECTED_INDEXABLE = {
+    "eq": True,
+    "ne": False,
+    "in": True,
+    "gt": False,
+    "gte": False,
+    "lt": False,
+    "lte": False,
+    "contains_any": True,
+    "contains_all": True,
+}
+
+# Valid per-op fixtures — list ops get lists, ranges get numbers, eq/ne a scalar.
+VALID_FIXTURES: dict[str, object] = {
+    "eq": 2026,
+    "ne": 2026,
+    "in": [2025, 2026],
+    "gt": 2026,
+    "gte": 2026,
+    "lt": 2026,
+    "lte": 2026,
+    "contains_any": ["a", "b"],
+    "contains_all": ["a", "b"],
 }
 
 
 def test_nine_operators_frozen() -> None:
-    assert set(NEON_FIELD_OPERATORS) == set(EXPECTED_VALUE_PRESENT_SQL)
+    assert set(NEON_FIELD_OPERATORS) == set(EXPECTED_CANONICAL_SQL)
     assert len(NEON_FIELD_OPERATORS) == 9
-    # ne/gt/lt are the three added on top of the shared six.
     assert {"ne", "gt", "lt"} <= set(NEON_FIELD_OPERATORS)
+    assert RANGE_OPS == {"gt", "gte", "lt", "lte"}
+    assert LIST_OPS == {"in", "contains_any", "contains_all"}
 
 
-@pytest.mark.parametrize("op", list(EXPECTED_VALUE_PRESENT_SQL))
-def test_truth_table_sql_shape_frozen(op: str) -> None:
-    assert FILTER_TRUTH_TABLE_BY_OP[op].sql_template == EXPECTED_VALUE_PRESENT_SQL[op]
+@pytest.mark.parametrize("op", list(EXPECTED_CANONICAL_SQL))
+def test_canonical_sql_frozen(op: str) -> None:
+    assert FILTER_TRUTH_TABLE_BY_OP[op].canonical_sql == EXPECTED_CANONICAL_SQL[op]
 
 
-@pytest.mark.parametrize("op", list(EXPECTED_EDGE_SEMANTICS))
-def test_truth_table_edge_semantics_frozen(op: str) -> None:
+@pytest.mark.parametrize("op", list(EXPECTED_EDGE_OUTCOMES))
+def test_edge_outcomes_frozen(op: str) -> None:
     spec = FILTER_TRUTH_TABLE_BY_OP[op]
-    null_sem, empty_sem = EXPECTED_EDGE_SEMANTICS[op]
-    assert spec.null_or_missing == null_sem
-    assert spec.empty_array == empty_sem
+    o = spec.outcomes
+    assert (
+        o["missing_key"],
+        o["json_null"],
+        o["wrong_type"],
+        o["empty_operand"],
+    ) == EXPECTED_EDGE_OUTCOMES[op]
+
+
+@pytest.mark.parametrize("op", list(EXPECTED_INDEXABLE))
+def test_indexability_frozen(op: str) -> None:
+    assert FILTER_TRUTH_TABLE_BY_OP[op].indexable == EXPECTED_INDEXABLE[op]
 
 
 def test_negation_template_frozen() -> None:
     assert NEGATION_TEMPLATE == "NOT ({inner})"
 
 
-@pytest.mark.xfail(reason="filter SQL emission built in Slice 4", strict=False)
-@pytest.mark.parametrize("op", list(EXPECTED_VALUE_PRESENT_SQL))
-def test_predicate_to_sql_emits_expected(op: str) -> None:
-    pred = FieldPredicate(field="year", op=op, value=2026)  # type: ignore[arg-type]
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 4")
+@pytest.mark.parametrize("op", list(EXPECTED_CANONICAL_SQL))
+def test_predicate_to_sql_emits_canonical(op: str) -> None:
+    pred = FieldPredicate(field="year", op=op, value=VALID_FIXTURES[op])  # type: ignore[arg-type]
     sql, params = predicate_to_sql(pred)
-    assert sql == EXPECTED_VALUE_PRESENT_SQL[op]
+    assert sql == EXPECTED_CANONICAL_SQL[op]
     assert params["k"] == "year"

--- a/packages/castform/tests/unit/rag/corpus/neon/test_protocol_conformance.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_protocol_conformance.py
@@ -1,0 +1,11 @@
+"""NeonChunkSource conforms to the ChunkSource protocol (structural check)."""
+
+from __future__ import annotations
+
+from castform.rag.corpus.neon.source import NeonChunkSource
+from castform.rag.corpus.source import ChunkSource
+
+
+def test_neon_source_is_chunk_source() -> None:
+    source = NeonChunkSource.__new__(NeonChunkSource)
+    assert isinstance(source, ChunkSource)

--- a/packages/castform/tests/unit/rag/corpus/neon/test_scan_chunks_determinism.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_scan_chunks_determinism.py
@@ -1,7 +1,9 @@
-"""Contract #5: scan_chunks stable ordering.
+"""Contract #5: scan_chunks total, pageable, deterministic ordering.
 
-The order key is frozen here (pass); the iterator itself is an xfail skeleton
-filled by Slice 1.
+The typed order key is frozen here (pass); the iterator is an xfail skeleton
+that must raise NotImplementedError until Slice 1. The skeleton forces a
+multi-page scan (batch_size < corpus size) and asserts run-to-run determinism,
+so Slice 1 cannot satisfy it with a single-page or empty read.
 """
 
 from __future__ import annotations
@@ -12,12 +14,14 @@ from castform.rag.corpus.neon.source import SCAN_ORDER_BY, NeonChunkSource
 
 
 def test_scan_order_key_frozen() -> None:
+    # Typed non-null columns, not JSONB extraction.
     assert SCAN_ORDER_BY == ("source_file", "chunk_index", "id")
 
 
-@pytest.mark.xfail(reason="scan_chunks built in Slice 1", strict=False)
-def test_scan_chunks_is_deterministic() -> None:
-    source = NeonChunkSource("mycorpus")
-    first = [c.hash for c in source.scan_chunks()]
-    second = [c.hash for c in source.scan_chunks()]
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 1")
+def test_scan_chunks_deterministic_across_pages() -> None:
+    source = NeonChunkSource.__new__(NeonChunkSource)
+    first = [c.hash for c in source.scan_chunks(batch_size=2)]
+    second = [c.hash for c in source.scan_chunks(batch_size=2)]
     assert first == second
+    assert len(first) > 2  # more than one page materialized

--- a/packages/castform/tests/unit/rag/corpus/neon/test_scan_chunks_determinism.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_scan_chunks_determinism.py
@@ -1,9 +1,9 @@
 """Contract #5: scan_chunks total, pageable, deterministic ordering.
 
-The typed order key is frozen here (pass); the iterator is an xfail skeleton
-that must raise NotImplementedError until Slice 1. The skeleton forces a
-multi-page scan (batch_size < corpus size) and asserts run-to-run determinism,
-so Slice 1 cannot satisfy it with a single-page or empty read.
+The typed order key is frozen here (pass). The iterator is an xfail skeleton that
+must raise NotImplementedError until Slice 1. It is backed by a fake reader with
+THREE seeded rows and ``batch_size=2`` so the filled-in test genuinely exercises
+multi-page ordering — not an empty/single-page read.
 """
 
 from __future__ import annotations
@@ -13,6 +13,21 @@ import pytest
 from castform.rag.corpus.neon.source import SCAN_ORDER_BY, NeonChunkSource
 
 
+class _FakeReader:
+    """Minimal paging backend: rows pre-sorted by (source_file, chunk_index, id)."""
+
+    def __init__(self, rows: list[tuple[str, int, str]]) -> None:
+        self.rows = sorted(rows, key=lambda r: (r[0], r[1], r[2]))
+
+    def page(self, after: tuple[str, int, str] | None, limit: int) -> list[tuple]:
+        start = 0
+        if after is not None:
+            start = next(
+                (i for i, r in enumerate(self.rows) if r > after), len(self.rows)
+            )
+        return self.rows[start : start + limit]
+
+
 def test_scan_order_key_frozen() -> None:
     # Typed non-null columns, not JSONB extraction.
     assert SCAN_ORDER_BY == ("source_file", "chunk_index", "id")
@@ -20,8 +35,12 @@ def test_scan_order_key_frozen() -> None:
 
 @pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 1")
 def test_scan_chunks_deterministic_across_pages() -> None:
-    source = NeonChunkSource.__new__(NeonChunkSource)
+    source = NeonChunkSource("mycorpus")
+    # Seed three rows spanning >1 page at batch_size=2, out of natural order.
+    source._reader = _FakeReader(  # type: ignore[attr-defined]
+        [("b.md", 2, "h3"), ("a.md", 10, "h2"), ("a.md", 2, "h1")]
+    )
     first = [c.hash for c in source.scan_chunks(batch_size=2)]
     second = [c.hash for c in source.scan_chunks(batch_size=2)]
     assert first == second
-    assert len(first) > 2  # more than one page materialized
+    assert first == ["h1", "h2", "h3"]  # (a.md,2) < (a.md,10) < (b.md,2)

--- a/packages/castform/tests/unit/rag/corpus/neon/test_scan_chunks_determinism.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_scan_chunks_determinism.py
@@ -1,0 +1,23 @@
+"""Contract #5: scan_chunks stable ordering.
+
+The order key is frozen here (pass); the iterator itself is an xfail skeleton
+filled by Slice 1.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from castform.rag.corpus.neon.source import SCAN_ORDER_BY, NeonChunkSource
+
+
+def test_scan_order_key_frozen() -> None:
+    assert SCAN_ORDER_BY == ("source_file", "chunk_index", "id")
+
+
+@pytest.mark.xfail(reason="scan_chunks built in Slice 1", strict=False)
+def test_scan_chunks_is_deterministic() -> None:
+    source = NeonChunkSource("mycorpus")
+    first = [c.hash for c in source.scan_chunks()]
+    second = [c.hash for c in source.scan_chunks()]
+    assert first == second

--- a/packages/castform/tests/unit/rag/corpus/neon/test_schema_versioning.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_schema_versioning.py
@@ -1,0 +1,67 @@
+"""Contract #1: physical table naming + versioned-replace model.
+
+Identifier helpers are frozen here (pass); DDL assembly and activate/rollback are
+xfail skeletons filled by Slice 2.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from castform.rag.corpus.neon.schema import (
+    DISTANCE_METRIC,
+    EMBEDDING_DIM,
+    NeonTableSpec,
+    activate_version_sql,
+    create_table_ddl,
+    index_names,
+    physical_table_name,
+    rollback_version_sql,
+)
+
+
+def test_embedding_dim_and_metric_frozen() -> None:
+    assert EMBEDDING_DIM == 3072
+    assert DISTANCE_METRIC == "cosine"
+
+
+def test_physical_table_name() -> None:
+    assert physical_table_name("mycorpus", 3) == "mycorpus__v3"
+
+
+def test_index_names_are_per_version() -> None:
+    names = index_names("mycorpus", 3)
+    assert names == {
+        "hnsw": "mycorpus__v3_hnsw",
+        "bm25": "mycorpus__v3_bm25",
+        "meta_gin": "mycorpus__v3_meta_gin",
+        "tsv_gin": "mycorpus__v3_tsv_gin",
+    }
+
+
+def test_table_spec_defaults() -> None:
+    spec = NeonTableSpec(logical_name="mycorpus", version=1)
+    assert spec.embedding_dim == 3072
+    assert spec.distance_metric == "cosine"
+    assert spec.text_search_config == "pg_catalog.english"
+
+
+@pytest.mark.xfail(reason="DDL assembly built in Slice 2", strict=False)
+def test_create_table_ddl() -> None:
+    spec = NeonTableSpec(logical_name="mycorpus", version=1)
+    ddl = create_table_ddl(spec)
+    assert "mycorpus__v1" in ddl
+    assert "vector(3072)" in ddl
+
+
+@pytest.mark.xfail(reason="version activation built in Slice 2", strict=False)
+def test_activate_is_single_transaction() -> None:
+    spec = NeonTableSpec(logical_name="mycorpus", version=2)
+    stmts = activate_version_sql(spec)
+    assert any("create or replace view" in s.lower() for s in stmts)
+
+
+@pytest.mark.xfail(reason="version rollback built in Slice 2", strict=False)
+def test_rollback_repoints_pointer() -> None:
+    stmts = rollback_version_sql("mycorpus", 1)
+    assert any("mycorpus__v1" in s for s in stmts)

--- a/packages/castform/tests/unit/rag/corpus/neon/test_schema_versioning.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_schema_versioning.py
@@ -1,7 +1,8 @@
-"""Contract #1: physical table naming + versioned-replace model.
+"""Contract #1: physical naming, DDL safety, and the versioned-replace lifecycle.
 
-Identifier helpers are frozen here (pass); DDL assembly and activate/rollback are
-xfail skeletons filled by Slice 2.
+Identifier helpers, validation, and length-safety are frozen here (pass); DDL
+assembly and activate/rollback are xfail skeletons that must raise
+NotImplementedError until Slice 2.
 """
 
 from __future__ import annotations
@@ -9,14 +10,22 @@ from __future__ import annotations
 import pytest
 
 from castform.rag.corpus.neon.schema import (
+    ALLOWED_TEXT_SEARCH_CONFIGS,
     DISTANCE_METRIC,
     EMBEDDING_DIM,
+    MAX_IDENTIFIER_BYTES,
+    PROVISIONAL_ANN_OPTIONS,
     NeonTableSpec,
+    NeonVersionRecord,
+    ReadGrantSpec,
     activate_version_sql,
     create_table_ddl,
     index_names,
     physical_table_name,
+    read_grant_sql,
     rollback_version_sql,
+    validate_text_search_config,
+    validate_version,
 )
 
 
@@ -31,37 +40,71 @@ def test_physical_table_name() -> None:
 
 def test_index_names_are_per_version() -> None:
     names = index_names("mycorpus", 3)
-    assert names == {
-        "hnsw": "mycorpus__v3_hnsw",
-        "bm25": "mycorpus__v3_bm25",
-        "meta_gin": "mycorpus__v3_meta_gin",
-        "tsv_gin": "mycorpus__v3_tsv_gin",
-    }
+    assert set(names) == {"ann", "bm25", "meta_gin", "scan", "tsv_gin"}
+    assert names["scan"] == "mycorpus__v3_scan"
+    assert names["meta_gin"] == "mycorpus__v3_meta_gin"
+
+
+def test_long_names_are_length_safe() -> None:
+    long_name = "corpus_" + "x" * 80
+    table = physical_table_name(long_name, 12)
+    assert len(table.encode()) <= MAX_IDENTIFIER_BYTES
+    for name in index_names(long_name, 12).values():
+        assert len(name.encode()) <= MAX_IDENTIFIER_BYTES
+    # distinct long logical names must not collide after truncation.
+    other = physical_table_name("corpus_" + "y" * 80, 12)
+    assert table != other
+
+
+def test_validate_version_rejects_nonpositive_and_bool() -> None:
+    assert validate_version(1) == 1
+    for bad in (0, -1, True):
+        with pytest.raises(ValueError):
+            validate_version(bad)  # type: ignore[arg-type]
+
+
+def test_validate_text_search_config_allowlist() -> None:
+    assert validate_text_search_config("pg_catalog.english") == "pg_catalog.english"
+    assert "pg_catalog.english" in ALLOWED_TEXT_SEARCH_CONFIGS
+    with pytest.raises(ValueError):
+        validate_text_search_config("english; DROP TABLE x")
 
 
 def test_table_spec_defaults() -> None:
     spec = NeonTableSpec(logical_name="mycorpus", version=1)
     assert spec.embedding_dim == 3072
-    assert spec.distance_metric == "cosine"
     assert spec.text_search_config == "pg_catalog.english"
 
 
-@pytest.mark.xfail(reason="DDL assembly built in Slice 2", strict=False)
+def test_version_record_states() -> None:
+    rec = NeonVersionRecord(
+        logical_name="mycorpus", version=2, state="ready", created_at=1.0
+    )
+    assert rec.state == "ready"
+    assert rec.activated_at is None
+
+
+def test_ann_options_are_provisional() -> None:
+    statuses = {opt["status"] for opt in PROVISIONAL_ANN_OPTIONS}
+    assert statuses == {"provisional-primary", "provisional-fallback"}
+    assert PROVISIONAL_ANN_OPTIONS[0]["access_method"] == "lakebase_ann"
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 2")
 def test_create_table_ddl() -> None:
-    spec = NeonTableSpec(logical_name="mycorpus", version=1)
-    ddl = create_table_ddl(spec)
-    assert "mycorpus__v1" in ddl
-    assert "vector(3072)" in ddl
+    create_table_ddl(NeonTableSpec(logical_name="mycorpus", version=1))
 
 
-@pytest.mark.xfail(reason="version activation built in Slice 2", strict=False)
-def test_activate_is_single_transaction() -> None:
-    spec = NeonTableSpec(logical_name="mycorpus", version=2)
-    stmts = activate_version_sql(spec)
-    assert any("create or replace view" in s.lower() for s in stmts)
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 2")
+def test_activate_version_sql() -> None:
+    activate_version_sql(NeonTableSpec(logical_name="mycorpus", version=2))
 
 
-@pytest.mark.xfail(reason="version rollback built in Slice 2", strict=False)
-def test_rollback_repoints_pointer() -> None:
-    stmts = rollback_version_sql("mycorpus", 1)
-    assert any("mycorpus__v1" in s for s in stmts)
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 2")
+def test_rollback_version_sql() -> None:
+    rollback_version_sql("mycorpus", 1)
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 2")
+def test_read_grant_sql() -> None:
+    read_grant_sql(ReadGrantSpec(schema="corpora", view="mycorpus", ro_role="ro"))

--- a/packages/castform/tests/unit/rag/corpus/neon/test_schema_versioning.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_schema_versioning.py
@@ -1,8 +1,8 @@
 """Contract #1: physical naming, DDL safety, and the versioned-replace lifecycle.
 
-Identifier helpers, validation, and length-safety are frozen here (pass); DDL
-assembly and activate/rollback are xfail skeletons that must raise
-NotImplementedError until Slice 2.
+Identifier helpers, validation, length-safety, and lifecycle invariants are
+frozen here (pass); DDL assembly and activate/rollback are xfail skeletons that
+must raise NotImplementedError until Slice 2.
 """
 
 from __future__ import annotations
@@ -11,21 +11,26 @@ import pytest
 
 from castform.rag.corpus.neon.schema import (
     ALLOWED_TEXT_SEARCH_CONFIGS,
+    CREATE_CURRENT_POINTER_INDEX,
     DISTANCE_METRIC,
     EMBEDDING_DIM,
     MAX_IDENTIFIER_BYTES,
     PROVISIONAL_ANN_OPTIONS,
+    VERSION_STATE_TRANSITIONS,
     NeonTableSpec,
     NeonVersionRecord,
     ReadGrantSpec,
+    RetentionPolicy,
     activate_version_sql,
     create_table_ddl,
     index_names,
     physical_table_name,
     read_grant_sql,
     rollback_version_sql,
+    validate_logical_name,
     validate_text_search_config,
     validate_version,
+    view_name,
 )
 
 
@@ -42,7 +47,6 @@ def test_index_names_are_per_version() -> None:
     names = index_names("mycorpus", 3)
     assert set(names) == {"ann", "bm25", "meta_gin", "scan", "tsv_gin"}
     assert names["scan"] == "mycorpus__v3_scan"
-    assert names["meta_gin"] == "mycorpus__v3_meta_gin"
 
 
 def test_long_names_are_length_safe() -> None:
@@ -51,9 +55,21 @@ def test_long_names_are_length_safe() -> None:
     assert len(table.encode()) <= MAX_IDENTIFIER_BYTES
     for name in index_names(long_name, 12).values():
         assert len(name.encode()) <= MAX_IDENTIFIER_BYTES
-    # distinct long logical names must not collide after truncation.
-    other = physical_table_name("corpus_" + "y" * 80, 12)
-    assert table != other
+    assert table != physical_table_name("corpus_" + "y" * 80, 12)
+
+
+def test_view_name_is_length_safe_and_stable() -> None:
+    assert view_name("mycorpus") == "mycorpus"
+    long_name = "corpus_" + "z" * 80
+    assert len(view_name(long_name).encode()) <= MAX_IDENTIFIER_BYTES
+    assert view_name(long_name) == view_name(long_name)  # deterministic
+
+
+def test_validate_logical_name_rejects_bad() -> None:
+    assert validate_logical_name("mycorpus") == "mycorpus"
+    for bad in ("", "café", "a\tb"):
+        with pytest.raises(ValueError):
+            validate_logical_name(bad)
 
 
 def test_validate_version_rejects_nonpositive_and_bool() -> None:
@@ -76,12 +92,31 @@ def test_table_spec_defaults() -> None:
     assert spec.text_search_config == "pg_catalog.english"
 
 
-def test_version_record_states() -> None:
+def test_version_record_current_flag() -> None:
     rec = NeonVersionRecord(
-        logical_name="mycorpus", version=2, state="ready", created_at=1.0
+        logical_name="mycorpus", version=2, state="activated", is_current=True
     )
-    assert rec.state == "ready"
-    assert rec.activated_at is None
+    assert rec.is_current is True
+    assert rec.retired_at is None
+
+
+def test_state_transitions_frozen() -> None:
+    assert VERSION_STATE_TRANSITIONS["building"] == ("ready",)
+    assert set(VERSION_STATE_TRANSITIONS["ready"]) == {"activated", "retired"}
+    assert VERSION_STATE_TRANSITIONS["retired"] == ()
+
+
+def test_current_pointer_invariant_is_partial_unique() -> None:
+    assert "UNIQUE INDEX" in CREATE_CURRENT_POINTER_INDEX
+    assert "WHERE is_current" in CREATE_CURRENT_POINTER_INDEX
+
+
+def test_retention_validates_minimum() -> None:
+    assert RetentionPolicy().keep_activated >= 2
+    with pytest.raises(ValueError):
+        RetentionPolicy(keep_activated=1)
+    with pytest.raises(ValueError):
+        RetentionPolicy(keep_ready=0)
 
 
 def test_ann_options_are_provisional() -> None:
@@ -96,8 +131,11 @@ def test_create_table_ddl() -> None:
 
 
 @pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 2")
-def test_activate_version_sql() -> None:
-    activate_version_sql(NeonTableSpec(logical_name="mycorpus", version=2))
+def test_activate_version_sql_takes_grant() -> None:
+    activate_version_sql(
+        NeonTableSpec(logical_name="mycorpus", version=2),
+        ReadGrantSpec(schema="corpora", view="mycorpus", ro_role="ro"),
+    )
 
 
 @pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 2")

--- a/packages/castform/tests/unit/rag/corpus/neon/test_search_related.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_search_related.py
@@ -1,10 +1,10 @@
 """Contract #4: multi-query search_related dedup + full 3-tuple ordering.
 
-These belong to the multi-query ``NeonChunkSource.search_related`` surface (not
-single-query ``NeonSearch.query``). Skeleton: must raise NotImplementedError
-until Slice 1 fills it. The scenario + assertions encode the frozen contract so
-Slice 1 has an exact target: dedup keeps the max reciprocal rank, and results
-sort by ``(query_count, cross_file, max_score)`` all descending.
+Belongs to the multi-query ``NeonChunkSource.search_related`` surface. Skeleton:
+must raise NotImplementedError until Slice 1. Controlled hits are injected (chunk
+C hit by BOTH queries at ranks 0 and 2, chunk D by one query) so the filled-in
+test asserts the full ``(query_count, cross_file, max_score)`` tuple order and the
+max-reciprocal-rank dedup unconditionally — no vacuous ``if``.
 """
 
 from __future__ import annotations
@@ -12,6 +12,7 @@ from __future__ import annotations
 import pytest
 
 from castform.rag.chunkers.models import Chunk
+from castform.rag.corpus.neon.search import QueryHit
 from castform.rag.corpus.neon.source import NeonChunkSource
 
 
@@ -22,22 +23,45 @@ def _chunk(content: str, source_file: str, chunk_index: int) -> Chunk:
     )
 
 
+class _FakeSearch:
+    """Returns canned per-query hits keyed by query text."""
+
+    def __init__(self, by_query: dict[str, list[QueryHit]]) -> None:
+        self.by_query = by_query
+
+    def query_hits(self, query: str) -> list[QueryHit]:
+        return self.by_query.get(query, [])
+
+
 @pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 1")
 def test_search_related_dedup_and_full_tuple_order() -> None:
-    source = NeonChunkSource.__new__(NeonChunkSource)
     origin = _chunk("origin", "a.md", 0)
+    c = _chunk("cross-file hit", "b.md", 4)  # hit by q1 (rank 0) and q2 (rank 2)
+    d = _chunk("same-file hit", "a.md", 9)  # hit by q1 only (rank 1)
+
+    source = NeonChunkSource("mycorpus")
+    source._search = _FakeSearch(  # type: ignore[attr-defined]
+        {
+            "q1": [
+                QueryHit(c.hash, 1 / 60, -2.0, 0),
+                QueryHit(d.hash, 1 / 61, -2.5, 1),
+            ],
+            "q2": [QueryHit(c.hash, 1 / 62, -3.0, 2)],
+        }
+    )
 
     results = source.search_related(origin, ["q1", "q2"], top_k=5)
 
-    # Every result exposes both scores (NB1) and the dedup/ordering keys.
     for r in results:
         assert set(r) >= {"chunk", "queries", "same_file", "max_score", "native_score"}
 
-    # Full 3-tuple sort: (len(queries) desc, cross-file-first, max_score desc).
     keys = [(len(r["queries"]), not r["same_file"], r["max_score"]) for r in results]
     assert keys == sorted(keys, reverse=True)
 
-    # A chunk hit by both queries dedups to the MAX reciprocal rank.
-    multi = [r for r in results if len(r["queries"]) > 1]
-    if multi:
-        assert multi[0]["max_score"] == max(r["max_score"] for r in results)
+    # C: hit by both queries, dedups to max reciprocal rank 1/60, ranks first.
+    top = results[0]
+    assert top["chunk"].hash == c.hash
+    assert top["max_score"] == 1 / 60
+    assert len(top["queries"]) == 2
+    # native_score comes from the winning hit (rank 0 in q1).
+    assert top["native_score"] == -2.0

--- a/packages/castform/tests/unit/rag/corpus/neon/test_search_related.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_search_related.py
@@ -1,0 +1,43 @@
+"""Contract #4: multi-query search_related dedup + full 3-tuple ordering.
+
+These belong to the multi-query ``NeonChunkSource.search_related`` surface (not
+single-query ``NeonSearch.query``). Skeleton: must raise NotImplementedError
+until Slice 1 fills it. The scenario + assertions encode the frozen contract so
+Slice 1 has an exact target: dedup keeps the max reciprocal rank, and results
+sort by ``(query_count, cross_file, max_score)`` all descending.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from castform.rag.chunkers.models import Chunk
+from castform.rag.corpus.neon.source import NeonChunkSource
+
+
+def _chunk(content: str, source_file: str, chunk_index: int) -> Chunk:
+    return Chunk(
+        content=content,
+        metadata=(("source_file", source_file), ("chunk_index", chunk_index)),
+    )
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 1")
+def test_search_related_dedup_and_full_tuple_order() -> None:
+    source = NeonChunkSource.__new__(NeonChunkSource)
+    origin = _chunk("origin", "a.md", 0)
+
+    results = source.search_related(origin, ["q1", "q2"], top_k=5)
+
+    # Every result exposes both scores (NB1) and the dedup/ordering keys.
+    for r in results:
+        assert set(r) >= {"chunk", "queries", "same_file", "max_score", "native_score"}
+
+    # Full 3-tuple sort: (len(queries) desc, cross-file-first, max_score desc).
+    keys = [(len(r["queries"]), not r["same_file"], r["max_score"]) for r in results]
+    assert keys == sorted(keys, reverse=True)
+
+    # A chunk hit by both queries dedups to the MAX reciprocal rank.
+    multi = [r for r in results if len(r["queries"]) > 1]
+    if multi:
+        assert multi[0]["max_score"] == max(r["max_score"] for r in results)

--- a/packages/castform/tests/unit/rag/corpus/neon/test_surfaced_score.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_surfaced_score.py
@@ -1,0 +1,61 @@
+"""Contract #4: public surfaced-score formula + dedup/order.
+
+The formula itself is frozen in Slice A (these assertions pass); the dedup and
+3-tuple ordering are xfail skeletons filled by Slice 1.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from castform.rag.corpus.neon.search import (
+    SURFACED_RANK_K,
+    NeonSearch,
+    surfaced_score,
+)
+
+
+@pytest.mark.parametrize(
+    ("rank", "expected"),
+    [
+        (0, 1 / 60),
+        (1, 1 / 61),
+        (2, 1 / 62),
+    ],
+)
+def test_surfaced_score_exact_values(rank: int, expected: float) -> None:
+    assert surfaced_score(rank) == expected
+
+
+def test_surfaced_score_constant() -> None:
+    assert SURFACED_RANK_K == 60
+    assert surfaced_score(0) == 1 / 60
+
+
+def test_surfaced_score_strictly_decreasing() -> None:
+    scores = [surfaced_score(r) for r in range(10)]
+    assert scores == sorted(scores, reverse=True)
+    assert len(set(scores)) == len(scores)
+
+
+def test_surfaced_score_rejects_negative_rank() -> None:
+    with pytest.raises(ValueError):
+        surfaced_score(-1)
+
+
+@pytest.mark.xfail(reason="multi-query dedup built in Slice 1", strict=False)
+def test_multi_query_dedup_keeps_max_rank() -> None:
+    # chunk C: rank 0 in query a, rank 2 in query b -> max_score = 1/60.
+    search = NeonSearch("corpus")
+    results = search.query(...)  # type: ignore[arg-type]
+    by_id = {r[0]: r[1] for r in results}
+    assert by_id["C"] == pytest.approx(1 / 60)
+
+
+@pytest.mark.xfail(reason="3-tuple ordering built in Slice 1", strict=False)
+def test_results_sorted_by_query_count_then_score() -> None:
+    # (len(queries), not same_file, max_score) all descending.
+    search = NeonSearch("corpus")
+    results = search.query(...)  # type: ignore[arg-type]
+    scores = [r[1] for r in results]
+    assert scores == sorted(scores, reverse=True)

--- a/packages/castform/tests/unit/rag/corpus/neon/test_surfaced_score.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_surfaced_score.py
@@ -1,18 +1,14 @@
-"""Contract #4: public surfaced-score formula + dedup/order.
+"""Contract #4 / NB1: the surfaced-score formula and the native-score split.
 
-The formula itself is frozen in Slice A (these assertions pass); the dedup and
-3-tuple ordering are xfail skeletons filled by Slice 1.
+The formula and QueryHit shape are frozen in Slice A (these pass). Multi-query
+dedup + ordering live in test_search_related.py (they belong to search_related).
 """
 
 from __future__ import annotations
 
 import pytest
 
-from castform.rag.corpus.neon.search import (
-    SURFACED_RANK_K,
-    NeonSearch,
-    surfaced_score,
-)
+from castform.rag.corpus.neon.search import SURFACED_RANK_K, QueryHit, surfaced_score
 
 
 @pytest.mark.parametrize(
@@ -29,7 +25,6 @@ def test_surfaced_score_exact_values(rank: int, expected: float) -> None:
 
 def test_surfaced_score_constant() -> None:
     assert SURFACED_RANK_K == 60
-    assert surfaced_score(0) == 1 / 60
 
 
 def test_surfaced_score_strictly_decreasing() -> None:
@@ -43,19 +38,8 @@ def test_surfaced_score_rejects_negative_rank() -> None:
         surfaced_score(-1)
 
 
-@pytest.mark.xfail(reason="multi-query dedup built in Slice 1", strict=False)
-def test_multi_query_dedup_keeps_max_rank() -> None:
-    # chunk C: rank 0 in query a, rank 2 in query b -> max_score = 1/60.
-    search = NeonSearch("corpus")
-    results = search.query(...)  # type: ignore[arg-type]
-    by_id = {r[0]: r[1] for r in results}
-    assert by_id["C"] == pytest.approx(1 / 60)
-
-
-@pytest.mark.xfail(reason="3-tuple ordering built in Slice 1", strict=False)
-def test_results_sorted_by_query_count_then_score() -> None:
-    # (len(queries), not same_file, max_score) all descending.
-    search = NeonSearch("corpus")
-    results = search.query(...)  # type: ignore[arg-type]
-    scores = [r[1] for r in results]
-    assert scores == sorted(scores, reverse=True)
+def test_query_hit_keeps_native_score_separate() -> None:
+    # NB1: raw native score is a distinct field, not overloaded onto the ordinal.
+    hit = QueryHit(chunk_id="C", surfaced_score=1 / 60, native_score=-3.14, rank=0)
+    assert hit.surfaced_score == surfaced_score(0)
+    assert hit.native_score == -3.14

--- a/packages/castform/tests/unit/rag/corpus/neon/test_transaction_lifecycle.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_transaction_lifecycle.py
@@ -1,23 +1,40 @@
 """Contract #1/#7 (B5): version-lifecycle transaction seam + retention.
 
-Retention defaults are frozen here (pass). The transaction seam and RRF fusion
+Retention validation is frozen here (pass). The transaction seam and RRF fusion
 are xfail skeletons that must raise NotImplementedError. The transaction test
-encodes the atomicity contract: the ledger update and the view replacement must
-commit or roll back together, so a failing statement leaves neither applied.
+passes real ``Composable`` statements (not raw strings) and a fake connection
+that raises on the SECOND statement, encoding the atomicity contract: the ledger
+update and view replacement must roll back together, leaving no partial state.
 """
 
 from __future__ import annotations
 
 import pytest
+from psycopg import sql
 
 from castform.rag.corpus.neon.client import NeonClient
 from castform.rag.corpus.neon.schema import DEFAULT_RETENTION, RetentionPolicy
 from castform.rag.corpus.neon.search import fuse_rrf
 
 
+class _FailingConn:
+    """Fake conn that commits nothing and raises on the second statement."""
+
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+        self.rolled_back = False
+
+    def execute(self, statement: sql.Composable) -> None:
+        self.executed.append(str(statement))
+        if len(self.executed) == 2:
+            raise RuntimeError("view swap failed mid-transaction")
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+
+
 def test_retention_keeps_rollback_target() -> None:
     assert isinstance(DEFAULT_RETENTION, RetentionPolicy)
-    # >= 2 activated retained so rollback always has a prior version.
     assert DEFAULT_RETENTION.keep_activated >= 2
     assert DEFAULT_RETENTION.keep_ready >= 1
 
@@ -25,9 +42,21 @@ def test_retention_keeps_rollback_target() -> None:
 @pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 4")
 def test_activation_rolls_back_atomically() -> None:
     client = NeonClient(lambda: "postgresql://rw@host/db")
-    # Second statement fails; the whole transaction (ledger + view swap) must
-    # roll back together. Slice 4 injects the failure and asserts no partial.
-    client.execute_in_transaction(["<upsert ledger active row>", "<bad view swap>"])  # type: ignore[list-item]
+    conn = _FailingConn()
+    client._conn = conn  # type: ignore[attr-defined]
+    statements = [
+        sql.SQL(
+            "UPDATE neon_corpus_versions SET is_current = true "
+            "WHERE logical_name = {} AND version = {}"
+        ).format(sql.Literal("mycorpus"), sql.Literal(2)),
+        sql.SQL("CREATE OR REPLACE VIEW {} AS SELECT id FROM {}").format(
+            sql.Identifier("mycorpus"), sql.Identifier("mycorpus__v2")
+        ),
+    ]
+    client.execute_in_transaction(statements)
+    # Post-impl contract (Slice 4): the failing second statement rolls the whole
+    # transaction back, so no is_current is set — no partial state.
+    assert conn.rolled_back is True
 
 
 @pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 1")

--- a/packages/castform/tests/unit/rag/corpus/neon/test_transaction_lifecycle.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_transaction_lifecycle.py
@@ -1,0 +1,35 @@
+"""Contract #1/#7 (B5): version-lifecycle transaction seam + retention.
+
+Retention defaults are frozen here (pass). The transaction seam and RRF fusion
+are xfail skeletons that must raise NotImplementedError. The transaction test
+encodes the atomicity contract: the ledger update and the view replacement must
+commit or roll back together, so a failing statement leaves neither applied.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from castform.rag.corpus.neon.client import NeonClient
+from castform.rag.corpus.neon.schema import DEFAULT_RETENTION, RetentionPolicy
+from castform.rag.corpus.neon.search import fuse_rrf
+
+
+def test_retention_keeps_rollback_target() -> None:
+    assert isinstance(DEFAULT_RETENTION, RetentionPolicy)
+    # >= 2 activated retained so rollback always has a prior version.
+    assert DEFAULT_RETENTION.keep_activated >= 2
+    assert DEFAULT_RETENTION.keep_ready >= 1
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 4")
+def test_activation_rolls_back_atomically() -> None:
+    client = NeonClient(lambda: "postgresql://rw@host/db")
+    # Second statement fails; the whole transaction (ledger + view swap) must
+    # roll back together. Slice 4 injects the failure and asserts no partial.
+    client.execute_in_transaction(["<upsert ledger active row>", "<bad view swap>"])  # type: ignore[list-item]
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 1")
+def test_fuse_rrf_single_owner() -> None:
+    fuse_rrf([["a", "b"], ["b", "c"]])

--- a/packages/castform/tests/unit/rag/corpus/neon/test_transaction_lifecycle.py
+++ b/packages/castform/tests/unit/rag/corpus/neon/test_transaction_lifecycle.py
@@ -18,16 +18,20 @@ from castform.rag.corpus.neon.search import fuse_rrf
 
 
 class _FailingConn:
-    """Fake conn that commits nothing and raises on the second statement."""
+    """Fake conn that raises on the second statement and records rollback/commit."""
 
     def __init__(self) -> None:
         self.executed: list[str] = []
         self.rolled_back = False
+        self.committed = False
 
     def execute(self, statement: sql.Composable) -> None:
         self.executed.append(str(statement))
         if len(self.executed) == 2:
             raise RuntimeError("view swap failed mid-transaction")
+
+    def commit(self) -> None:
+        self.committed = True
 
     def rollback(self) -> None:
         self.rolled_back = True
@@ -39,7 +43,6 @@ def test_retention_keeps_rollback_target() -> None:
     assert DEFAULT_RETENTION.keep_ready >= 1
 
 
-@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 4")
 def test_activation_rolls_back_atomically() -> None:
     client = NeonClient(lambda: "postgresql://rw@host/db")
     conn = _FailingConn()
@@ -53,10 +56,12 @@ def test_activation_rolls_back_atomically() -> None:
             sql.Identifier("mycorpus"), sql.Identifier("mycorpus__v2")
         ),
     ]
-    client.execute_in_transaction(statements)
-    # Post-impl contract (Slice 4): the failing second statement rolls the whole
-    # transaction back, so no is_current is set — no partial state.
+    # The failing second statement rolls the whole transaction back and re-raises;
+    # nothing is committed, so no partial state (is_current) survives.
+    with pytest.raises(RuntimeError):
+        client.execute_in_transaction(statements)
     assert conn.rolled_back is True
+    assert conn.committed is False
 
 
 @pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="Slice 1")

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -784,34 +784,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1769,7 +1769,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1808,7 +1808,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1820,7 +1820,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1850,9 +1850,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1864,7 +1864,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },

--- a/uv.lock
+++ b/uv.lock
@@ -494,6 +494,12 @@ chroma = [
     { name = "chromadb" },
     { name = "snowballstemmer" },
 ]
+neon = [
+    { name = "openai" },
+    { name = "pgvector" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "pydantic" },
+]
 pinecone = [
     { name = "pinecone" },
 ]
@@ -531,8 +537,12 @@ requires-dist = [
     { name = "keybert", marker = "extra == 'rag'", specifier = ">=0.8" },
     { name = "langchain-text-splitters", marker = "extra == 'rag'", specifier = ">=0.3.0" },
     { name = "nest-asyncio", marker = "extra == 'rag'", specifier = ">=1.5.0" },
+    { name = "openai", marker = "extra == 'neon'", specifier = ">=2.15.0" },
     { name = "openai", marker = "extra == 'rag'", specifier = ">=2.15.0" },
+    { name = "pgvector", marker = "extra == 'neon'", specifier = ">=0.3.0" },
     { name = "pinecone", marker = "extra == 'pinecone'", specifier = ">=5.0.0" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'neon'", specifier = ">=3.2.0" },
+    { name = "pydantic", marker = "extra == 'neon'", specifier = ">=2.0.0" },
     { name = "pydantic", marker = "extra == 'rag'", specifier = ">=2.0.0" },
     { name = "ruamel-yaml", marker = "extra == 'rag'", specifier = ">=0.19.1" },
     { name = "scikit-learn", marker = "extra == 'rag'", specifier = ">=1.8.0" },
@@ -542,7 +552,7 @@ requires-dist = [
     { name = "tqdm", marker = "extra == 'traces'", specifier = ">=4.66.0" },
     { name = "turbopuffer", marker = "extra == 'turbopuffer'", specifier = ">=1.16.2" },
 ]
-provides-extras = ["rag", "traces", "chroma", "pinecone", "turbopuffer"]
+provides-extras = ["rag", "traces", "chroma", "pinecone", "turbopuffer", "neon"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -749,7 +759,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -774,34 +784,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1759,7 +1769,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1798,7 +1808,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1810,7 +1820,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1840,9 +1850,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1854,7 +1864,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2105,6 +2115,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pgvector"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/ec/6eb80aebc728200f95229219882994c1b0585b956ca47da5edb9d062627a/pgvector-0.5.0.tar.gz", hash = "sha256:07a9dcf735696879406983afc6eba9a787cef7c0cf6c367ca1a5779f036dee74", size = 35170, upload-time = "2026-07-06T18:27:27.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e4/a5573f2c579ca9ad133293bfb624148ba0893674ca4a6eeec85ced9a6a09/pgvector-0.5.0-py3-none-any.whl", hash = "sha256:fedc9800894e6da2be51358d7b7c574bf34f247ca741a5a09513622135f5964f", size = 30958, upload-time = "2026-07-06T18:27:26.797Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2237,6 +2256,42 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
     { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
     { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/7d/03818e13ba7f36de93573c93ee3482006d3dfa8b0f8d28df511bad0a1a92/psycopg_binary-3.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5ab28a2a7649df3b72e6b674b4c190e448e8e77cf496a65bd846472048de2089", size = 4591122, upload-time = "2026-05-01T23:27:56.162Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/11b341edf8d54e2694726b273fe9652b254d989f4f63e3ac6816ad6b55f4/psycopg_binary-3.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6402a9d8146cf4b3974ded3fd28a971e83dc6a0333eb7822524a3aa20b546578", size = 4669943, upload-time = "2026-05-01T23:28:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/4665bacd65e7865b4372fcd8abb8b9186ada4b0025f8c2ca691b364a556c/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:580ae30a5f95ccd90008ec697d3ed6a4a2047a516407ad904283fa42086936e9", size = 5469697, upload-time = "2026-05-01T23:28:11.337Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b1/b83136c6e510593d9b0c759ba5384337bc4ad82d19fda675adc4b2703c84/psycopg_binary-3.3.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7510c37550f91a187e3660a8cc50d4b760f8c3b8b2f89ebc5698cd2c7f2c85d", size = 5152995, upload-time = "2026-05-01T23:28:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8d/a9821e2a648afe6091989929982a3b0f00b2631a859cb81379728f08fb75/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77df19583501ea288eaf15ac0fe7ad01e6d8091a91d5c41df5c718f307d8e31b", size = 6738180, upload-time = "2026-05-01T23:28:30.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/58/2e349e8d23905dc2317b80ac65f48fb6f821a4777a4e994a60da91c4850f/psycopg_binary-3.3.4-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:018fbed325936da502feb546642c982dcc4b9ffdea32dfef78dbf3b7f7ad4070", size = 4978828, upload-time = "2026-05-01T23:28:37.277Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/57b00d03b4721878326122a1f1e6b0a90b85bcaec56b5b2f8ea6cfa45235/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17a21953a9e5ff3a16dab692625a3676e2f101db5e40072f39dbee2250194d68", size = 4509757, upload-time = "2026-05-01T23:28:43.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/37/33b47d8c007df69aec500df5889767c4d313748e8e9e27a2fef8a6dabcee/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:eb05ee1c2b817d27c537333224c9e83c7afb86fe7296ba970990068baf819b16", size = 4190546, upload-time = "2026-05-01T23:28:50.016Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c6/32b0835dbc2122617902b649d76a91c1e75406e76bf3d595b0c3bb5ffad6/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:773d573e11f437ce0bdb95b7c18dc58390494f96d43f8b45b9760436114f7652", size = 3926197, upload-time = "2026-05-01T23:28:55.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/68/d190ef0c0c5b16ded07831dabc8ddd412f4cdab07ec6e30ed38d9bda0e1f/psycopg_binary-3.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e55ccbdfae79a2ed9c6369c3008a3025817ff9d7e27b32a2d84e2a4267e66e", size = 4236627, upload-time = "2026-05-01T23:29:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/81dcbc2e8454b74d14881275ea45f00791052dac531a9fa8be1730d1685b/psycopg_binary-3.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:494ca54901be8cf9eb7e02c25b731f2317c378efa44f43e8f9bd0e1184ae7be4", size = 3560782, upload-time = "2026-05-01T23:29:11.967Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## what

Slice A (schema & internal-contract freeze / design-lock) of the Neon Lakebase corpus provider. **Typed stubs + a contract doc + parametrized `xfail` test skeletons only** — no real SQL/client/filter/search logic (those are Slices 1/2/4; the live raw-score smoke is Slice 3). Stubs import and ruff-clean; the skeletons `xfail` on not-yet-built behavior and pass on the frozen constants/formula.

All code lives under `packages/castform/src/castform/rag/corpus/neon/` and `packages/castform/tests/unit/rag/corpus/neon/`. Templated on the turbopuffer credential/pickle-safe-search-client shape and the postgres file layout.

## the seven frozen contracts

1. **physical table + versioned-replace** — managed table `(id, content, metadata jsonb, embedding vector(3072), content_tsv tsvector)` with a **configurable** text-search config baked per version; stable logical name -> per-version physical table `<logical>__v<N>` + per-version indexes -> active-version pointer (`neon_corpus_versions` registry row + `CREATE OR REPLACE VIEW`); atomic activate + non-destructive rollback. Frozen decision: 3072-dim ANN indexed on a `halfvec(3072)` cast (`halfvec_cosine_ops`) since pgvector `vector` HNSW caps at 2000 dims.
2. **credential signature** — `dsn_provider: str | TokenProvider | None`, resolved lazily; **separate** read (`NEON_CORPUS_DSN_RO`, SELECT-only) vs write (`NEON_CORPUS_DSN_RW`, DDL+DML) surfaces, mirroring turbopuffer `as_token_provider`/`env_token`.
3. **9-op filter truth table** — `eq/ne/in/gt/gte/lt/lte/contains_any/contains_all` (adds `ne/gt/lt` to the shared six). Bound JSON paths (`metadata ->> %(k)s`), never `psycopg.sql.Identifier` on caller keys. Numeric-vs-text cast rule; `contains_any/all` -> JSONB `?|`/`?&` (typed-array `&&`/`@>` deferred). Edge rules frozen: `ne` null-safe via `IS DISTINCT FROM` (includes missing key); `contains_all []` vacuously true; negation = plain `NOT (...)` (3-valued). Full table in `CONTRACT.md` + `filter_mapper.FILTER_TRUTH_TABLE`.
4. **public score = one formula per mode** — uniform rank-based `surfaced_score(rank) = 1/(60+rank)`, always higher-better, monotonic by construction (so `search_related` relevance-descending holds regardless of raw `<@>`/distance/RRF direction). Multi-query dedup = **max** reciprocal rank; sort by `(len(queries), not same_file, max_score)` desc (mirrors `postgres/source.py`). Exact numerics pinned in the test skeleton (`1/60`, `1/61`, `1/62`).
5. **scan_chunks determinism** — stable `(source_file, chunk_index, id)` full-corpus iterator for qa-gen materialization.
6. **eval JSONL schema** — `capability, search_mode, query, filter_dsl, gold_chunk_hashes, decoy_chunk_hashes` (hashes carried explicitly since `Chunk.to_dict` omits `hash`) + per-mode hit@5/MRR + lexical-ablation delta (`LEXICAL_ABLATION_MIN_DELTA = 0.05`).
7. **embedding dim/metric (3072, cosine) + internal query request** — filtering orthogonal (3 modes x filtered/unfiltered), RRF single-owned by the query layer.

## gate

- `uv run --extra neon ruff check packages/castform/src/castform/rag/corpus/neon` -> **All checks passed**
- neon extra added (`psycopg[binary]`, `pgvector`, `openai`, `pydantic`); all neon modules import cleanly; connection/driver imports are lazy-guarded
- `uv run --extra neon pytest packages/castform/tests/unit/rag/corpus/neon` -> **37 passed, 17 xfailed**

The **17 xfails are Slice 1/2/4 placeholders** (SQL emission, query execution, DSN resolution, DDL assembly, scan iterator); the 37 passes are the frozen constants/formula/schema.

## deviations (surfaced, not silently re-planned)

- **No in-repo SQL template exists** — the `postgres` provider is an HTTP client to the Corpora API (client-side dict-merge dedup), and no provider imports psycopg. Neon is the first SQL-emitting backend, so the SQL seam is frozen from first principles; turbopuffer remains the template for the credential seam + pickle-safe search client. Score dedup/order still mirrors `postgres/source.py`'s 3-tuple.
- **New local test convention** — `corpus/` tests are class-grouped fake-injection with no `parametrize`/`xfail`; this slice introduces parametrized `xfail` skeletons because the brief mandates testable truth-table/score skeletons. Flagged in `CONTRACT.md`.
- **Shared operator enum untouched** — `ne/gt/lt` live in a neon-local `NeonFieldOperator` superset; promotion into `search_schema/search_types.py` is deferred to Slice 4 to keep this slice inside the `neon/` package.