### PR TITLE
Score context-exceeded partial rollouts

### DIFF
--- a/packages/benchmax/src/benchmax/envs/base/env.py
+++ b/packages/benchmax/src/benchmax/envs/base/env.py
@@ -256,7 +256,7 @@ class BaseEnv(Environment[JsonRow, BaseRollout], ABC):
                     example_args=example_args,
                     split=request.split,
                 )
-                if termination_reason != "finished":
+                if termination_reason not in ("finished", "context_exceeded"):
                     return replace(
                         rollout,
                         rewards={key: 0.0 for key in self.reward_keys},

--- a/packages/benchmax/src/benchmax/envs/environment.py
+++ b/packages/benchmax/src/benchmax/envs/environment.py
@@ -113,7 +113,7 @@ class Environment[Payload, Attempt: RolloutAttempt](ABC):
                 )
             elif isinstance(result, BaseException):
                 contract_errors.append(result)
-            elif result.termination_reason != "finished":
+            elif result.termination_reason not in ("finished", "context_exceeded"):
                 _validate_failure_rewards(result, reward_keys)
                 _log_terminal_attempt(result)
                 outcomes[result.rollout_id] = RolloutOutcome(
@@ -121,6 +121,8 @@ class Environment[Payload, Attempt: RolloutAttempt](ABC):
                     termination_reason=result.termination_reason,
                 )
             else:
+                if result.termination_reason != "finished":
+                    _log_terminal_attempt(result)
                 rollouts.append(result)
 
         if contract_errors:


### PR DESCRIPTION
## Summary

- Let `context_exceeded` BaseEnv attempts reach the environment's individual reward hook.
- Include those scored partial attempts in group reward calculation while preserving `termination_reason=context_exceeded` and terminal logging.
- Keep the existing zero-settlement behavior for model, tool, and reward failures.

## Root cause

BenchMax treated every non-`finished` termination as an operational failure. A rollout that exhausted the gateway context budget after successful model/tool turns therefore skipped `compute_reward`, bypassed group rewards, and received fabricated zeros for every declared reward key despite having a valid partial transcript.

## Impact

The environment now decides how to score a context-exhausted partial rollout. It may still assign zero when the partial result deserves zero, but BenchMax no longer forces that outcome. Other non-finished failure paths and normally finished rollouts are unchanged.

## Validation

- `uv run --project packages/benchmax ruff check packages/benchmax/src/benchmax/envs/base/env.py packages/benchmax/src/benchmax/envs/environment.py`
- Direct second-turn `context_budget_exceeded` smoke run confirmed that individual and group reward hooks both receive the partial rollout and that its termination reason is preserved.
- No test files changed, per requested scope. The existing zero-behavior test remains unchanged.
