### PR TITLE
Score budget-exhausted rollouts

### DIFF
--- a/packages/benchmax/src/benchmax/envs/base/env.py
+++ b/packages/benchmax/src/benchmax/envs/base/env.py
@@ -97,7 +97,7 @@ class BaseEnv(Environment[JsonRow, BaseRollout], ABC):
         self,
         rollout: BaseRollout,
     ) -> RewardMap | None:
-        """Optionally score one completed rollout.
+        """Optionally score one reward-eligible terminal rollout.
 
         Raise :class:`RolloutFailure` for expected runtime failures to settle
         this rollout under that reason. Any other exception settles it as
@@ -256,7 +256,7 @@ class BaseEnv(Environment[JsonRow, BaseRollout], ABC):
                     example_args=example_args,
                     split=request.split,
                 )
-                if termination_reason not in ("finished", "context_exceeded"):
+                if termination_reason not in self.scorable_termination_reasons:
                     return replace(
                         rollout,
                         rewards={key: 0.0 for key in self.reward_keys},

--- a/packages/benchmax/src/benchmax/envs/environment.py
+++ b/packages/benchmax/src/benchmax/envs/environment.py
@@ -25,6 +25,16 @@ logger = logging.getLogger(__name__)
 class Environment[Payload, Attempt: RolloutAttempt](ABC):
     """Group-native environment with one-attempt implementation hooks."""
 
+    scorable_termination_reasons: frozenset[str] = frozenset(
+        {
+            "finished",
+            "context_exceeded",
+            "max_turns_exceeded",
+            "tool_budget_exceeded",
+        }
+    )
+    """Terminal reasons whose partial attempts remain eligible for rewards."""
+
     @property
     @abstractmethod
     def reward_keys(self) -> Sequence[str]:
@@ -113,7 +123,7 @@ class Environment[Payload, Attempt: RolloutAttempt](ABC):
                 )
             elif isinstance(result, BaseException):
                 contract_errors.append(result)
-            elif result.termination_reason not in ("finished", "context_exceeded"):
+            elif result.termination_reason not in self.scorable_termination_reasons:
                 _validate_failure_rewards(result, reward_keys)
                 _log_terminal_attempt(result)
                 outcomes[result.rollout_id] = RolloutOutcome(

--- a/packages/benchmax/tests/unit/envs/test_base_env_group.py
+++ b/packages/benchmax/tests/unit/envs/test_base_env_group.py
@@ -674,6 +674,86 @@ async def test_tool_budget_termination_is_scored_without_executing_tools() -> No
     assert outcome.rewards == {"correctness": 0.0}
     assert len(server.requests) == 1
     assert env.tool_calls == []
+    assert [call[3] for call in env.reward_calls] == ["tool_budget_exceeded"]
+
+
+@pytest.mark.parametrize(
+    ("max_turns", "max_tool_calls", "termination_reason", "executed_tool_calls"),
+    [
+        (1, 1, "max_turns_exceeded", 1),
+        (2, 0, "tool_budget_exceeded", 0),
+    ],
+)
+async def test_budget_exhaustion_runs_individual_and_group_scoring(
+    max_turns: int,
+    max_tool_calls: int,
+    termination_reason: str,
+    executed_tool_calls: int,
+) -> None:
+    class BudgetScoringEnv(_ToolMathEnv):
+        reward_keys = ("partial", "group")
+
+        def __init__(self) -> None:
+            super().__init__(max_tool_calls=max_tool_calls)
+            self.max_turns = max_turns
+            self.group_termination_reasons: list[str] = []
+
+        async def compute_reward(self, rollout: BaseRollout) -> RewardMap:
+            self.reward_calls.append(
+                (
+                    rollout.rollout_id,
+                    rollout.messages,
+                    rollout.example_args,
+                    rollout.termination_reason,
+                )
+            )
+            return {"partial": 0.75}
+
+        async def compute_group_rewards(
+            self,
+            rollouts: Sequence[BaseRollout],
+        ) -> Mapping[str, RewardMap]:
+            self.group_termination_reasons = [
+                rollout.termination_reason for rollout in rollouts
+            ]
+            return {rollout.rollout_id: {"group": 0.25} for rollout in rollouts}
+
+    example = Example(
+        id="math-budget-exhaustion",
+        payload={
+            "prompt_messages": [{"role": "user", "content": "What is 6 × 7?"}],
+            "answer": "42",
+        },
+    )
+    env = BudgetScoringEnv()
+
+    with LocalModelServer(
+        lambda session_id, call_index, body: (
+            200,
+            completion_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "multiply",
+                            "arguments": '{"left":6,"right":7}',
+                        },
+                    }
+                ],
+            ),
+        )
+    ) as server:
+        outcomes = await env.run_group(_requests(server, example, ["rollout-1"]))
+
+    outcome = outcomes["rollout-1"]
+    assert outcome.termination_reason == termination_reason
+    assert outcome.rewards == {"partial": 0.75, "group": 0.25}
+    assert [call[3] for call in env.reward_calls] == [termination_reason]
+    assert env.group_termination_reasons == [termination_reason]
+    assert len(env.tool_calls) == executed_tool_calls
 
 
 async def test_base_env_group_only_reward_receives_complete_rollouts() -> None:

--- a/packages/benchmax/tests/unit/envs/test_environment_group.py
+++ b/packages/benchmax/tests/unit/envs/test_environment_group.py
@@ -145,6 +145,49 @@ async def test_group_scorer_receives_every_attempt_once() -> None:
     assert outcomes["rollout-2"].rewards == {"group_rank": 1.0}
 
 
+@pytest.mark.parametrize(
+    "termination_reason",
+    ["max_turns_exceeded", "tool_budget_exceeded"],
+)
+async def test_group_scorer_receives_budget_exhausted_attempts(
+    termination_reason: str,
+) -> None:
+    class BudgetScoredEnv(Environment[dict[str, Any], RolloutAttempt]):
+        reward_keys = ("individual", "group")
+
+        def __init__(self) -> None:
+            self.group_termination_reasons: list[str] = []
+
+        async def create_dataset(self, split, base_dir):
+            return Dataset([])
+
+        async def run_rollout(self, request):
+            return RolloutAttempt(
+                rollout_id=request.rollout_id,
+                termination_reason=termination_reason,
+                rewards={"individual": 0.75},
+            )
+
+        async def compute_group_rewards(
+            self,
+            rollouts: Sequence[RolloutAttempt],
+        ) -> Mapping[str, RewardMap]:
+            self.group_termination_reasons = [
+                rollout.termination_reason for rollout in rollouts
+            ]
+            return {rollout.rollout_id: {"group": 0.25} for rollout in rollouts}
+
+    request = _request("rollout-1", Example(id="example-1", payload={}))
+    env = BudgetScoredEnv()
+
+    outcomes = await env.run_group([request])
+
+    outcome = outcomes["rollout-1"]
+    assert outcome.termination_reason == termination_reason
+    assert outcome.rewards == {"individual": 0.75, "group": 0.25}
+    assert env.group_termination_reasons == [termination_reason]
+
+
 async def test_one_operational_failure_does_not_cancel_or_shape_from_siblings(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
## Summary

- treat `max_turns_exceeded` and `tool_budget_exceeded` as scorable terminal reasons
- run both individual and group reward hooks for those partial attempts
- preserve the original termination reason and retain zero-only handling for other failures

## Root cause

The BaseEnv rollout loop assigned explicit budget-exhaustion reasons, but both BaseEnv and the group runner only considered `finished` and `context_exceeded` eligible for scoring. As a result, valid partial work was replaced with all-zero rewards before environment reward hooks could evaluate it.

## Impact

Environments can now award partial or full task credit when a rollout exhausts its turn or tool-call budget. Output-length, model, tool-execution, sandbox, verifier, and other operational failures keep their existing zero-reward behavior.

## Validation

- `uv run --project packages/benchmax pytest -c packages/benchmax/pytest.ini packages/benchmax/tests -q` — 214 passed
- `uv run pytest tests/architecture -q` — 8 passed
- focused environment tests — 41 passed
- Ruff checks passed
