### PR TITLE
add trainer ref to launch client

### DIFF
--- a/packages/castform/src/castform/platform/client.py
+++ b/packages/castform/src/castform/platform/client.py
@@ -363,6 +363,7 @@ class TrainerClient:
         dataset_path: str | None = None,
         name: str | None = None,
         launcher_args: dict[str, Any] | None = None,
+        trainer_ref: str | None = None,
     ) -> str:
         """Launch a new training run.
 
@@ -377,6 +378,8 @@ class TrainerClient:
             launcher_args: Extra launcher args forwarded to the server
                 (e.g. {"max_rollout_len": 4000}). Bundle and optional dataset
                 path parameters always take precedence over this mapping.
+            trainer_ref: Optional immutable trainer source reference. Sent as a
+                top-level launch field rather than as a trainer argument.
         Returns:
             The training run ID.
 
@@ -388,6 +391,7 @@ class TrainerClient:
             "env_cls_path",
             "env_metadata_path",
             "dataset_path",
+            "trainer_ref",
         }
         args: dict[str, Any] = {
             key: value
@@ -406,6 +410,8 @@ class TrainerClient:
             "name": name,
             "args": args,
         }
+        if trainer_ref is not None:
+            body["trainer_ref"] = trainer_ref
         response = self._http_client.post(
             "/v1/train/runs/launch",
             json=body,

--- a/packages/castform/tests/unit/platform/test_client.py
+++ b/packages/castform/tests/unit/platform/test_client.py
@@ -80,6 +80,29 @@ def test_launch_training_run_omits_dataset_path_when_not_uploaded():
         "env_cls_path": "x/env-cls.pkl",
         "env_metadata_path": "x/env-metadata.json",
     }
+    assert "trainer_ref" not in captured["body"]
+    assert "trainer_ref" not in captured["body"]["args"]
+
+
+def test_launch_training_run_sends_trainer_ref_at_top_level():
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        captured["body"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"runId": "run-pinned"})
+
+    trainer = _make_trainer_with_transport(handler)
+    run_id = trainer.launch_training_run(
+        env_cls_path="x/env-cls.pkl",
+        env_metadata_path="x/env-metadata.json",
+        trainer_ref="15b22afde1983a3c2a287aed088f3ed1fcdfde0a",
+    )
+
+    assert run_id == "run-pinned"
+    assert captured["body"]["trainer_ref"] == "15b22afde1983a3c2a287aed088f3ed1fcdfde0a"
+    assert "trainer_ref" not in captured["body"]["args"]
 
 
 def test_launch_training_run_surfaces_server_warnings():
@@ -144,13 +167,17 @@ def test_launch_training_run_filters_reserved_paths_from_launcher_args():
         launcher_args={
             "env_cls_path": "sneaky",
             "dataset_path": "sneaky",
+            "trainer_ref": "sneaky",
             "max_rollout_len": 4000,
         },
+        trainer_ref="pinned",
     )
 
     # dataset_path was not supplied as a kwarg, so it must not appear at all.
     assert "dataset_path" not in captured["body"]["args"]
     assert captured["body"]["args"]["env_cls_path"] == "a"
+    assert "trainer_ref" not in captured["body"]["args"]
+    assert captured["body"]["trainer_ref"] == "pinned"
     assert captured["body"]["args"]["max_rollout_len"] == 4000
 
 
@@ -162,20 +189,6 @@ def test_launch_training_run_rejects_training_run_type_kwarg():
     with pytest.raises(TypeError, match="training_run_type"):
         trainer.launch_training_run(
             training_run_type="simple-cpu",
-            env_cls_path="a",
-            env_metadata_path="b",
-            dataset_path="c",
-        )
-
-
-def test_launch_training_run_rejects_trainer_ref_kwarg():
-    trainer = _make_trainer_with_transport(
-        lambda request: httpx.Response(200, json={"runId": "unused"})
-    )
-
-    with pytest.raises(TypeError, match="trainer_ref"):
-        trainer.launch_training_run(
-            trainer_ref="main",
             env_cls_path="a",
             env_metadata_path="b",
             dataset_path="c",


### PR DESCRIPTION
## what changed

- add an optional trainer_ref parameter to TrainerClient.launch_training_run
- send the value as the launch request's top-level trainer_ref field
- prevent launcher_args from nesting or overriding the reserved field
- preserve omission and existing behavior when no trainer ref is supplied

## why

The platform launch route already accepts a top-level trainer ref, but the public Python client could not send it. This prevented callers from pinning a training run to an immutable trainer commit without using private HTTP internals.

## validation

- 27 focused client tests
- 95 platform unit tests
- Ruff lint and format checks
- compileall
- locked package sync
- git diff --check