### PR TITLE
docs(sft): make onboarding template-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ workflow: bare `python main.py` prepares data and validates the environment
 locally (no launch), and `python main.py launch` bundles, uploads and starts a
 training run after an explicit confirmation.
 
+`castform setup --template sft` scaffolds the env-less variant instead:
+supervised fine-tuning over `{"messages": [...]}` rows, where
+`python main.py validate` is a purely local dataset check and there is no
+environment or reward to write.
+
 Working examples live under [`examples/`](examples/), from a single-turn math
 env to multimodal tool use and third-party Harbor harnesses. For the API,
 see the [BenchMax guide](packages/benchmax/README.md) and the
@@ -39,7 +44,11 @@ do not collide during collection:
 ```bash
 uv run --project packages/benchmax pytest -c packages/benchmax/pytest.ini packages/benchmax/tests
 uv run --project packages/castform pytest -c packages/castform/pytest.ini packages/castform/tests
-uv run pytest tests/architecture
+uv run --project packages/benchmax pytest tests/architecture
 ```
 
-The final command runs the workspace-level package-boundary tests.
+The final command runs the workspace-level package-boundary tests. Keep every
+invocation `--project`-scoped and pass the paths explicitly: a bare `uv run`
+syncs every workspace member, including the heavyweight `examples/*` ones, and
+`pytest` with no path argument picks up the root `pytest.ini` and silently runs
+only the architecture tests.

--- a/packages/benchmax/README.md
+++ b/packages/benchmax/README.md
@@ -116,6 +116,36 @@ The rewards package follows a deep-module design:
 - A new public abstraction should hide substantially more complexity than it
   adds to the interface.
 
+## Define an SFT dataset
+
+Supervised fine-tuning needs no environment at all: the dataset is the training
+signal. `benchmax.sft` owns that contract — OpenAI fine-tuning chat rows
+(`{"messages": [...]}`, with an optional top-level `tools` list and an optional
+per-assistant-message `weight` for turn masking) and nothing about how a run is
+submitted:
+
+```python
+from benchmax.sft import canonical_jsonl, load_sft_dataset, validate_sft_dataset
+
+train = load_sft_dataset("train.jsonl")
+report = validate_sft_dataset(train)
+if report.ok:
+    payload = canonical_jsonl(train)
+```
+
+`load_sft_dataset` is the only reader and `canonical_jsonl` the only serializer.
+Legacy shapes — a bare `prompt`/`completion` pair, a `prompt_messages`/
+`completion_messages` split, flat tool-call entries — are normalized into
+`messages` rows on load. The boundary is enforced rather than documented:
+`canonical_jsonl` raises `SftSerializationError` on a dataset that did not load
+and validate cleanly, so a caller that skips `validate_sft_dataset` still cannot
+serialize partial or invalid data.
+
+A user message's `content` may be a list of parts rather than a string, so an
+`image_url` part survives load, validation and canonicalization byte-for-byte.
+`benchmax.envs.base.content` reads and builds that content — `message_text`,
+`content_preview`, `iter_image_refs` and `image_to_data_uri`.
+
 ## Bundle an environment
 
 Declare remote runtime dependencies at the script boundary:

--- a/packages/castform/README.md
+++ b/packages/castform/README.md
@@ -58,6 +58,41 @@ The CLI does not duplicate that orchestration. Use it for `login`, `setup`,
 `doctor`, `guide`, `runs` inspection and cancelling a run with `castform stop`.
 `castform whoami` and `castform logout` manage the active session.
 
+## Supervised fine-tuning
+
+`castform setup --template sft` scaffolds an env-less project: no environment
+class, no reward, no rollout. Its data is `{"messages": [...]}` rows owned by
+`benchmax.sft`, so `python main.py validate` is a purely local schema check, and
+its launch stage replaces bundling with a dataset upload:
+
+```python
+from benchmax.sft import load_sft_dataset, validate_sft_dataset
+from castform.platform import TrainerClient, upload_sft_run
+
+train = load_sft_dataset("train.jsonl")
+report = validate_sft_dataset(train)
+
+uploaded = upload_sft_run(train=train, run_name="my-sft-run")
+with TrainerClient() as client:
+    run_id = client.launch_sft_run(
+        name="my-sft-run",
+        train_dataset_path=uploaded.train_dataset_path,
+    )
+```
+
+`upload_sft_run` re-validates the pair and raises before any storage call, so a
+refused run cannot leave a half-uploaded dataset behind. `launch_sft_run` nests
+`training_mode` and the dataset paths inside `args`, which is where the platform
+reads them.
+
+The platform does not accept env-less SFT launch args yet:
+`castform.platform.client.SFT_LAUNCH_SUPPORTED` is `False`, and the scaffolded
+`main.py` checks it before uploading anything. Direct SDK callers such as the
+snippet above are not gated by that flag and will be rejected by the server at
+launch. Multimodal rows — a user message whose content is a list of `text` and
+`image_url` parts — validate and canonicalize correctly today, but trainer-side
+image support is not implemented.
+
 ## Optional libraries
 
 Add only the features the project uses:

--- a/packages/castform/src/castform/cli/scaffold/CLAUDE.md
+++ b/packages/castform/src/castform/cli/scaffold/CLAUDE.md
@@ -1,8 +1,29 @@
-# Castform environment project
+# Castform training project
 
 This is a standalone Python 3.12 project. Treat `main.py` as the reviewed,
 reproducible workflow for data preparation, validation, bundling, upload and
 launch. Do not recreate those stages with hidden CLI state.
+
+## RL project, or SFT project?
+
+Read `main.py` before following anything below — not every scaffolded project is
+a reinforcement-learning environment:
+
+- **`LAUNCH_CONFIG["training_mode"] == "sft"`, no `BaseEnv` subclass** → an
+  env-less supervised fine-tuning project (`castform setup --template sft`).
+  Skip environment design entirely: there is no reward function, no rollout and
+  no rollout budget to tune. Data is `{"messages": [...]}` rows (see
+  generate-data's SFT section), `python main.py validate` is a local
+  no-rollout dataset check (see verify-environment's SFT section), and
+  `python main.py launch` currently stops before uploading because
+  `castform.platform.client.SFT_LAUNCH_SUPPORTED` is `False` (see launch-run's
+  SFT section).
+- **No `training_mode`, a `BaseEnv` subclass present** → a reinforcement-learning
+  project. The rest of this file describes that path.
+
+The two do not mix: SFT rows may still carry a `tools` list and tool-call
+demonstrations, but there is no rollout-time tool execution and no reward, so an
+SFT project has no environment class to design.
 
 ## Required loop
 
@@ -72,6 +93,14 @@ reviewing a bundle.
 
 Dataset uploads are optional. Omit a split argument when the environment resolves
 that data at runtime. Passing `[]` explicitly uploads an empty JSONL file.
+
+An SFT project has no bundle, so its launch stage is ordered differently:
+validate the dataset, clear the `allow_experimental_weights` gate if any row
+carries a per-message `weight`, check
+`castform.platform.client.SFT_LAUNCH_SUPPORTED`, confirm the cost, then
+`upload_sft_run` followed by `TrainerClient.launch_sft_run`. The capability
+check sits ahead of the upload deliberately, so a launch that cannot succeed
+leaves nothing behind in storage.
 
 ## Reward review
 

--- a/packages/castform/src/castform/cli/scaffold/CLAUDE.md
+++ b/packages/castform/src/castform/cli/scaffold/CLAUDE.md
@@ -94,13 +94,13 @@ reviewing a bundle.
 Dataset uploads are optional. Omit a split argument when the environment resolves
 that data at runtime. Passing `[]` explicitly uploads an empty JSONL file.
 
-An SFT project has no bundle, so its launch stage is ordered differently:
-validate the dataset, clear the `allow_experimental_weights` gate if any row
-carries a per-message `weight`, check
-`castform.platform.client.SFT_LAUNCH_SUPPORTED`, confirm the cost, then
-`upload_sft_run` followed by `TrainerClient.launch_sft_run`. The capability
-check sits ahead of the upload deliberately, so a launch that cannot succeed
-leaves nothing behind in storage.
+An SFT project has no bundle, so its launch stage is ordered differently: check
+`castform.platform.client.SFT_LAUNCH_SUPPORTED` first, then validate the
+dataset, clear the `allow_experimental_weights` gate if any row carries a
+per-message `weight`, confirm the cost, and finally call `upload_sft_run`
+followed by `TrainerClient.launch_sft_run`. The capability check sits ahead of
+every side effect deliberately, so a launch that cannot succeed leaves nothing
+behind in storage.
 
 ## Reward review
 

--- a/packages/castform/src/castform/cli/scaffold/STARTER.md
+++ b/packages/castform/src/castform/cli/scaffold/STARTER.md
@@ -1,5 +1,6 @@
 # Get started
 
+<!-- rl:start -->
 `castform setup` created a standalone Python 3.12 project. The project script,
 not the CLI, owns the reproducible training workflow:
 
@@ -14,17 +15,44 @@ Bare `uv run python main.py` (the `all` stage) runs data preparation followed by
 validation and then stops. A launch is always a separate, confirmed action.
 `--force` regenerates data that already exists; `-y`/`--yes` skips launch
 confirmation prompts.
+<!-- rl:end -->
 
+<!-- sft:start -->
+`castform setup --template sft` created a standalone Python 3.12 project for an
+env-less supervised fine-tuning dataset. The project script, not the CLI, owns
+the reproducible workflow:
+
+```bash
+uv sync
+uv run python main.py data       # prepare or refresh chat-format rows
+uv run python main.py validate   # local dataset scorecard; no gpu or rollouts
+uv run python main.py launch     # capability check; currently stops before upload
+```
+
+Bare `uv run python main.py` (the `all` stage) runs data preparation followed by
+local validation and then stops. Launch is a separate action whose first step is
+the platform capability check. While env-less SFT launch support is disabled,
+that check stops before credentials, confirmation or upload.
+<!-- sft:end -->
+
+<!-- rl:start -->
 Unit tests live in `tests/` next to `main.py` (a `conftest.py` there pins the
 import path so `from main import ...` works). Run them with
 `uv run pytest tests`, and grow them alongside the reward: cover empty, wrong,
 partial and correct answers.
+<!-- rl:end -->
+<!-- sft:start -->
+Add unit tests in `tests/` next to `main.py` and run them with
+`uv run pytest tests`. Grow them alongside the data workflow so malformed,
+empty and representative chat rows stay covered.
+<!-- sft:end -->
 
 ## Work with your agent
 
 Point your coding agent at the real task and ask it to load the matching skill in
 `.claude/skills/` before each stage.
 
+<!-- rl:start -->
 **General environment:**
 
 ```
@@ -40,7 +68,9 @@ Build a Castform search environment over <corpus>. Keep corpus preparation in th
 data stage, test retrieval and reward behavior locally, and show me validation
 results before proposing a launch.
 ```
+<!-- rl:end -->
 
+<!-- rl:start -->
 **SFT dataset** (`castform setup --template sft` — no environment, no reward):
 
 ```
@@ -48,7 +78,18 @@ Build a Castform SFT dataset for <task> from these demonstrations. Keep the rows
 in the OpenAI fine-tuning chat format, validate them locally, and show me the
 scorecard before proposing a launch.
 ```
+<!-- rl:end -->
+<!-- sft:start -->
+**SFT dataset** (`castform setup --template sft` — supervised fine-tuning only):
 
+```
+Build a Castform SFT dataset for <task> from these demonstrations. Keep the rows
+in the OpenAI fine-tuning chat format, validate them locally, and show me the
+scorecard before proposing a launch.
+```
+<!-- sft:end -->
+
+<!-- rl:start -->
 Use these skills in order:
 
 | Stage | Skill |
@@ -63,9 +104,21 @@ An SFT project has no environment to design and no reward to score, so
 `design-environment` only tells you to skip it. Its stages are `generate-data`
 (the `messages` row format), `verify-environment` (a local, no-rollout dataset
 check) and `launch-run` — read each skill's SFT section.
+<!-- rl:end -->
+
+<!-- sft:start -->
+Use these skills in order:
+
+| Stage | Skill |
+|---|---|
+| chat-format data preparation | `generate-data` |
+| local dataset validation | `verify-environment` |
+| capability check and launch gate | `launch-run` |
+<!-- sft:end -->
 
 ## A green baseline
 
+<!-- rl:start -->
 A green baseline means both validation siblings finished, returned the declared
 reward keys, and produced believable task-specific scores. A zero score can be a
 valid completed result. An operational failure instead has a non-`finished`
@@ -74,9 +127,16 @@ log entry.
 
 For an SFT project there are no siblings: a green baseline is a `validate` that
 exits `0` — no error-severity issues and at least one train row.
+<!-- rl:end -->
+
+<!-- sft:start -->
+For an SFT project, a green baseline is a local `validate` that exits `0`: the
+scorecard has no error-severity issues and includes at least one train row.
+<!-- sft:end -->
 
 After a green baseline, decide deliberately:
 
+<!-- rl:start -->
 - iterate on the environment, data or reward and validate again; or
 - inspect the bundle dependencies and run `uv run python main.py launch`.
 
@@ -84,6 +144,12 @@ The seed script uploads its JSONL splits. If the environment instead resolves a
 split at runtime—through Harbor, Git, or another provider—omit that split from
 `upload_training_run`. Use `None`/omission for no upload; `[]` uploads an empty
 JSONL deliberately.
+<!-- rl:end -->
+<!-- sft:start -->
+- iterate on the chat rows or validation settings and validate again; or
+- keep `uv run python main.py launch` as a separate capability check, which
+  currently stops before credentials or upload.
+<!-- sft:end -->
 
 ## Useful CLI commands
 

--- a/packages/castform/src/castform/cli/scaffold/STARTER.md
+++ b/packages/castform/src/castform/cli/scaffold/STARTER.md
@@ -41,6 +41,14 @@ data stage, test retrieval and reward behavior locally, and show me validation
 results before proposing a launch.
 ```
 
+**SFT dataset** (`castform setup --template sft` — no environment, no reward):
+
+```
+Build a Castform SFT dataset for <task> from these demonstrations. Keep the rows
+in the OpenAI fine-tuning chat format, validate them locally, and show me the
+scorecard before proposing a launch.
+```
+
 Use these skills in order:
 
 | Stage | Skill |
@@ -51,6 +59,11 @@ Use these skills in order:
 | explicit GPU launch | `launch-run` |
 | monitoring and diagnosis | `view-progress` |
 
+An SFT project has no environment to design and no reward to score, so
+`design-environment` only tells you to skip it. Its stages are `generate-data`
+(the `messages` row format), `verify-environment` (a local, no-rollout dataset
+check) and `launch-run` — read each skill's SFT section.
+
 ## A green baseline
 
 A green baseline means both validation siblings finished, returned the declared
@@ -58,6 +71,9 @@ reward keys, and produced believable task-specific scores. A zero score can be a
 valid completed result. An operational failure instead has a non-`finished`
 `termination_reason`, the same reward keys all set to zero, and a corresponding
 log entry.
+
+For an SFT project there are no siblings: a green baseline is a `validate` that
+exits `0` — no error-severity issues and at least one train row.
 
 After a green baseline, decide deliberately:
 

--- a/packages/castform/src/castform/cli/scaffold/sft_eval_dataset.jsonl
+++ b/packages/castform/src/castform/cli/scaffold/sft_eval_dataset.jsonl
@@ -1,0 +1,2 @@
+{"messages": [{"role": "user", "content": "What is the capital of Japan?"}, {"role": "assistant", "content": "The capital of Japan is Tokyo."}]}
+{"messages": [{"role": "user", "content": "What is 10 minus 3?"}, {"role": "assistant", "content": "10 minus 3 equals 7."}]}

--- a/packages/castform/src/castform/cli/scaffold/sft_main.py
+++ b/packages/castform/src/castform/cli/scaffold/sft_main.py
@@ -1,0 +1,429 @@
+"""Env-less SFT dataset project (written by `castform setup --template sft`).
+
+Post-trains a model via supervised fine-tuning on `{"messages": [...]}` rows —
+the OpenAI fine-tuning chat format, with optional `tools` and per-assistant-
+message `weight` (0/1) for turn masking. There is no environment, no rollout
+and no reward: the dataset IS the training signal, so `validate` here is a
+purely local check of the data (no GPU, no network), unlike the RL templates'
+real-rollout baseline.
+
+The whole run is reproducible from this file: the seed dataset is below, and
+the `VALIDATE_CONFIG` / `LAUNCH_CONFIG` blocks bake in the dataset/launch
+knobs. `python main.py` drives the loop: data → validate, then STOP
+(`launch` is an explicit, confirmed step — it spends GPU credits).
+
+Multimodal: a user message may carry a content-part list (e.g. a `text` part
+plus an `image_url` part) instead of a plain string — see `_SEED_MULTIMODAL`
+below for a demonstration row. It is opt-in only: a vision base model is
+required, so `generate_data()` does not write it by default.
+
+Two launch gates sit in front of the wire, and they are independent:
+
+* Weight/masking is experimental — trainer support for per-message `weight`
+  is unconfirmed, so `launch()` blocks a weight-bearing dataset unless
+  `LAUNCH_CONFIG["allow_experimental_weights"]` is true.
+* Live launch is gated on `castform.platform.client.SFT_LAUNCH_SUPPORTED`
+  (False as of writing — the platform does not accept env-less sft launch
+  args yet). The check runs BEFORE any upload, so nothing is orphaned in
+  storage behind an API that cannot succeed. The upload→launch path below is
+  fully implemented and unit-tested; it just cannot reach a real platform yet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from benchmax.sft import (
+    SftConfigError,
+    SftDataset,
+    SftValidationReport,
+    load_sft_dataset,
+    sft_config_bool,
+    sft_validate_kwargs,
+    validate_sft_dataset,
+)
+
+# The module is imported alongside the class so the capability flag is read
+# live (`platform_client.SFT_LAUNCH_SUPPORTED`) rather than copied into this
+# namespace at import time, which would freeze it at False forever.
+from castform.platform import client as platform_client
+from castform.platform.client import TrainerClient
+from castform.platform.login import ensure_session
+from castform.platform.training_run import upload_sft_run
+
+# ── Run config — validate/launch read these so the run reproduces from this
+#    file alone. See `python main.py validate --help` / `launch --help`.
+VALIDATE_CONFIG = {
+    # "max_seq_len": 8192,       # char/4-heuristic token budget flagged as a notice
+    # "max_row_bytes": 1 << 20,  # per-row serialized-size notice threshold (1 MiB)
+}
+
+LAUNCH_CONFIG = {
+    # The mode marker for this run. `launch_sft_run` nests it inside `args`,
+    # which is where the platform reads it; a top-level one is ignored and
+    # would silently fall through to an RL run.
+    "training_mode": "sft",
+    "num_epochs": 2,  # eval tends to peak before the overfit tail; keep epochs modest
+    # "model": "Qwen/Qwen3.5-4B",  # base checkpoint for THIS run; omit for the
+    #   platform default. A config key, not a flag — the run stays reproducible
+    #   from this file rather than from the shell history that launched it.
+    # "allow_experimental_weights": False,  # set True to launch a weight-bearing
+    #   dataset anyway — trainer masking support is unconfirmed (see the docstring).
+    # "type": "simple",  # GPU pool (gpu4 for 4B / gpu8 for 35B); "simple-cpu" = smoke
+}
+
+# The only mode this template can launch. LAUNCH_CONFIG carries the value that
+# actually goes on the wire; this is what it is checked against.
+_TRAINING_MODE = "sft"
+
+# Resolved locally; never forwarded to the server as a launch arg. `training_mode`
+# and `model` are deliberately absent — both are real wire args the server reads.
+_LAUNCH_CONFIG_RESERVED = frozenset({"type", "name", "allow_experimental_weights"})
+
+
+# ── Runnable entrypoint ──────────────────────────────────────────────────────
+# `python main.py [data|validate|launch|all]` drives the whole loop SDK-directly —
+# no CLI needed, and this file stays the reproducible record of the run. Stages are
+# isolable and skip work whose output already exists (`--force` to redo):
+#
+#   python main.py data       generate/refresh the datasets (skip if present)
+#   python main.py validate   check the dataset locally (no GPU, no launch)
+#   python main.py launch     validate-gate, then train on GPUs (spends credits)
+#   python main.py  (or all)  data → validate, then STOP (never auto-launches)
+#
+# Import-safe: stages run only from the ``if __name__ == "__main__"`` block below,
+# so importing this file for tests or dataset inspection has no side effects.
+
+TRAIN_FILE = "train.jsonl"
+EVAL_FILE = "eval.jsonl"
+
+# A tiny hardcoded 1x1 red-pixel PNG data URI (no pillow/PIL dependency — just a
+# literal base64 string). Used only by the opt-in `_SEED_MULTIMODAL` row below.
+_TINY_PNG_DATA_URI = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR42mP4z8AAAAMBAQD3A0FDAAAAAElFTkSuQmCC"
+)
+
+# The tiny seed dataset — synthetic, reproducible, text-only. `castform setup`
+# also commits these as train.jsonl / eval.jsonl so validate runs on day one;
+# regenerate them any time with `python main.py data --force`.
+_SEED_TRAIN = [
+    {
+        "messages": [
+            {"role": "user", "content": "What is the capital of France?"},
+            {"role": "assistant", "content": "The capital of France is Paris."},
+        ]
+    },
+    {
+        "messages": [
+            {"role": "user", "content": "What is 2 + 2?"},
+            {"role": "assistant", "content": "2 + 2 equals 4."},
+        ]
+    },
+    {
+        "messages": [
+            {"role": "user", "content": "What color is a clear daytime sky?"},
+            {"role": "assistant", "content": "A clear daytime sky is blue."},
+        ]
+    },
+]
+_SEED_EVAL = [
+    {
+        "messages": [
+            {"role": "user", "content": "What is the capital of Japan?"},
+            {"role": "assistant", "content": "The capital of Japan is Tokyo."},
+        ]
+    },
+    {
+        "messages": [
+            {"role": "user", "content": "What is 10 minus 3?"},
+            {"role": "assistant", "content": "10 minus 3 equals 7."},
+        ]
+    },
+]
+
+# Opt-in multimodal demonstration — NOT written by `generate_data()` by default.
+# Enable it only against a VISION base model (undefined trainer behavior otherwise)
+# by changing `generate_data()`'s `_create_seed_jsonl(TRAIN_FILE, _SEED_TRAIN)` call
+# below to `_create_seed_jsonl(TRAIN_FILE, _SEED_TRAIN + [_SEED_MULTIMODAL])`, then
+# re-run with `python main.py data --force`.
+_SEED_MULTIMODAL = {
+    "messages": [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What color is the square in this image?"},
+                {"type": "image_url", "image_url": {"url": _TINY_PNG_DATA_URI}},
+            ],
+        },
+        {"role": "assistant", "content": "The square is red."},
+    ]
+}
+
+
+class SftScaffoldError(Exception):
+    """`generate_data()` found a project state it refuses to touch automatically."""
+
+
+def _create_seed_jsonl(path: str, rows: list[dict[str, Any]]) -> bool:
+    """Atomically create `path` with `rows` iff nothing is there yet.
+
+    An exclusive ``O_CREAT | O_EXCL`` open (not exists()-then-write) closes the
+    check/write race, and — since O_EXCL never follows a symlink at `path`, even
+    a dangling one — a stray symlink is refused the same as a real file rather
+    than silently followed. Returns True iff this call wrote the file.
+    """
+    payload = "".join(json.dumps(r) + "\n" for r in rows)
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    except FileExistsError:
+        return False
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(payload)
+    return True
+
+
+def _run_name() -> str:
+    return str(LAUNCH_CONFIG.get("name") or "sft-run")
+
+
+def generate_data(force: bool = False) -> bool:
+    """Produce `train.jsonl` / `eval.jsonl`.
+
+    Provenance: a tiny synthetic seed, generated inline above (reproducible,
+    text-only). Replace it with your real task's data — hand-write the jsonl in
+    the OpenAI fine-tuning chat format, or generate it and inline the gen code
+    here so the dataset stays reproducible from this file. See `_SEED_MULTIMODAL`
+    above to opt into a multimodal demonstration row (vision base models only).
+
+    State machine (no `--force`):
+      - neither file exists -> create both (the normal first-run case)
+      - both exist -> skip both, unchanged
+      - train exists, eval doesn't -> skip both; a train-only project is a valid,
+        intentional state (eval is optional in SFT) — eval is never fabricated
+      - eval exists, train doesn't -> refuse: there's no legitimate reason to have
+        eval without train, so this looks like a corrupted project, not a first
+        run — raises instead of guessing
+    `--force` regenerates both unconditionally, regardless of prior state.
+    """
+    # lexists, not exists — a symlink (even dangling) counts as "there".
+    train_exists = os.path.lexists(TRAIN_FILE)
+    eval_exists = os.path.lexists(EVAL_FILE)
+
+    if not force and eval_exists and not train_exists:
+        raise SftScaffoldError(
+            f"{EVAL_FILE} exists but {TRAIN_FILE} does not — refusing to guess "
+            "what to do here (this looks like a corrupted project, not a first "
+            f"run). fix {TRAIN_FILE} manually, or re-run with --force to "
+            "regenerate both from the seed."
+        )
+
+    if force:
+        Path(TRAIN_FILE).unlink(missing_ok=True)
+    if _create_seed_jsonl(TRAIN_FILE, _SEED_TRAIN):
+        print(f"data: wrote {len(_SEED_TRAIN)} train rows to {TRAIN_FILE}")
+    else:
+        print(f"data: {TRAIN_FILE} present — skipping (--force to redo)")
+
+    if not force and train_exists and not eval_exists:
+        print(f"data: {EVAL_FILE} absent — leaving it that way (train-only project)")
+        return True
+
+    if force:
+        Path(EVAL_FILE).unlink(missing_ok=True)
+    if _create_seed_jsonl(EVAL_FILE, _SEED_EVAL):
+        print(f"data: wrote {len(_SEED_EVAL)} eval rows to {EVAL_FILE}")
+    else:
+        print(f"data: {EVAL_FILE} present — skipping (--force to redo)")
+    return True
+
+
+def _print_scorecard(report: SftValidationReport) -> None:
+    """Print row counts, the token-length heuristic, masking usage, and every
+    issue with its source line."""
+    print(f"  rows: train {report.train_row_count} · eval {report.eval_row_count}")
+    stats = report.token_length_stats
+    print(
+        f"  tokens (char/4 heuristic): min {stats.min_tokens}  max {stats.max_tokens}"
+        f"  mean {stats.mean_tokens:.1f}"
+    )
+    masking = report.masking_summary
+    if masking.rows_with_weight:
+        print(
+            f"  masking: {masking.rows_with_weight} row(s) use per-message weight "
+            "(experimental)"
+        )
+    for issue in report.issues:
+        loc = (
+            f"{issue.source_path}:{issue.physical_line}"
+            if issue.source_path
+            else "(dataset)"
+        )
+        symbol = "✗" if issue.severity == "error" else "⚠"
+        print(f"  {symbol} {loc}  {issue.message}")
+    print(f"validate: {'pass' if report.ok else 'fail'}")
+
+
+def _load_datasets() -> tuple[SftDataset, SftDataset | None]:
+    """Load the train/eval `SftDataset` pair once from disk. Eval is optional:
+    an absent `eval.jsonl` yields None, not an empty dataset."""
+    train = load_sft_dataset(TRAIN_FILE)
+    eval_dataset = load_sft_dataset(EVAL_FILE) if Path(EVAL_FILE).exists() else None
+    return train, eval_dataset
+
+
+def _validate_loaded(
+    train: SftDataset, eval_dataset: SftDataset | None
+) -> SftValidationReport:
+    """Validate an already-loaded train/eval pair (no disk I/O) and print the
+    scorecard."""
+    report = validate_sft_dataset(
+        train, eval_dataset, **sft_validate_kwargs(VALIDATE_CONFIG)
+    )
+    _print_scorecard(report)
+    return report
+
+
+def validate() -> SftValidationReport:
+    """Check the sft dataset pair locally — schema, token-length heuristic, and
+    masking usage. No GPU, no rollouts, no platform call. Returns the report."""
+    train, eval_dataset = _load_datasets()
+    return _validate_loaded(train, eval_dataset)
+
+
+def _launcher_args() -> dict[str, Any]:
+    """LAUNCH_CONFIG minus the locally-resolved keys, ready for the wire.
+
+    `training_mode` and `model` survive this filter deliberately — the server
+    reads both. A `training_mode` other than "sft" raises rather than being
+    quietly overwritten by `launch_sft_run`'s own value: this is the sft
+    template, and an RL run belongs in the generic one.
+    """
+    mode = LAUNCH_CONFIG.get("training_mode", _TRAINING_MODE)
+    if mode != _TRAINING_MODE:
+        raise SftConfigError(
+            f"'training_mode' must be {_TRAINING_MODE!r} in an sft project, got "
+            f"{mode!r}. use the generic template to launch an rl run."
+        )
+    return {k: v for k, v in LAUNCH_CONFIG.items() if k not in _LAUNCH_CONFIG_RESERVED}
+
+
+def launch(assume_yes: bool = False) -> str | None:
+    """Validate-gate, weight-gate, capability-gate, confirm, then upload + launch
+    an SFT training run (spends credits). Returns the run id, or None if
+    gated/aborted.
+
+    The train/eval pair is loaded ONCE, up front — the same objects that get
+    validated are the ones passed to `upload_sft_run`, so a file edit or swap
+    between validate and confirm cannot bypass the schema/weight gates.
+    """
+    train, eval_dataset = _load_datasets()
+    report = _validate_loaded(train, eval_dataset)  # never spend GPU on broken data
+    if report is None or not report.ok:
+        print(
+            "launch: validate gate failed — fix the dataset before launching.",
+            file=sys.stderr,
+        )
+        return None
+
+    # Weight gate: a separate capability from SFT_LAUNCH_SUPPORTED below — the
+    # validate notice alone does not clear it. Strict bool (not truthiness) —
+    # a typo'd string value must fail loudly, never silently clear the gate.
+    if report.masking_summary.rows_with_weight and not sft_config_bool(
+        LAUNCH_CONFIG, "allow_experimental_weights"
+    ):
+        print(
+            "launch: dataset uses per-message 'weight' (masking) — trainer support "
+            "is unconfirmed. set allow_experimental_weights=True in LAUNCH_CONFIG to "
+            "launch anyway.",
+            file=sys.stderr,
+        )
+        return None
+
+    launcher_args = _launcher_args()
+
+    # Capability gate before upload — no orphaned storage behind an API that
+    # cannot succeed yet.
+    if not platform_client.SFT_LAUNCH_SUPPORTED:
+        print(
+            "launch: the platform does not accept env-less sft runs yet "
+            "(castform.platform.client.SFT_LAUNCH_SUPPORTED is False).",
+            file=sys.stderr,
+        )
+        return None
+
+    if not assume_yes:
+        reply = (
+            input(
+                f"launch '{_run_name()}' on GPUs — this spends credits. continue? [y/N] "
+            )
+            .strip()
+            .lower()
+        )
+        if reply not in ("y", "yes"):
+            print("launch: aborted.")
+            return None
+
+    uploaded = upload_sft_run(train=train, eval=eval_dataset, run_name=_run_name())
+
+    with TrainerClient() as client:
+        run_id = client.launch_sft_run(
+            name=_run_name(),
+            train_dataset_path=uploaded.train_dataset_path,
+            eval_dataset_path=uploaded.eval_dataset_path,
+            launcher_args=launcher_args or None,
+        )
+    print(f"launch: started run {run_id}")
+    return run_id
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="main.py",
+        description="run the castform loop for this sft dataset: data → validate → launch.",
+    )
+    parser.add_argument(
+        "stage",
+        nargs="?",
+        default="all",
+        choices=["data", "validate", "launch", "all"],
+        help="stage to run (default: all = data → validate, then stop).",
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="regenerate datasets even if present."
+    )
+    parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="skip the launch confirmation (it spends GPU credits).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        ok = True
+        if args.stage in ("data", "all"):
+            generate_data(force=args.force)
+        # data and validate are local-only — launch is the one stage that talks
+        # to the platform, so it is the only one that needs a credential.
+        if args.stage in ("validate", "all"):
+            report = validate()
+            ok = report is not None and report.ok  # non-zero exit on a failed validate
+        if args.stage == "launch":
+            ensure_session()
+            ok = launch(assume_yes=args.yes) is not None  # None = gated/aborted/failed
+    except (SftScaffoldError, SftConfigError) as exc:
+        print(f"error: {exc}", file=sys.stderr)  # no raw traceback (local paths)
+        return 1
+    # `all` / bare `python main.py` STOPS after validate — launch is never automatic
+    # (it spends GPU credits); run `python main.py launch` to train.
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/castform/src/castform/cli/scaffold/sft_main.py
+++ b/packages/castform/src/castform/cli/scaffold/sft_main.py
@@ -24,9 +24,10 @@ Two launch gates sit in front of the wire, and they are independent:
   `LAUNCH_CONFIG["allow_experimental_weights"]` is true.
 * Live launch is gated on `castform.platform.client.SFT_LAUNCH_SUPPORTED`
   (False as of writing — the platform does not accept env-less sft launch
-  args yet). The check runs BEFORE any upload, so nothing is orphaned in
-  storage behind an API that cannot succeed. The upload→launch path below is
-  fully implemented and unit-tested; it just cannot reach a real platform yet.
+  args yet). It is the FIRST thing `launch()` checks, ahead of the login, the
+  confirmation prompt and the upload, so a run the platform cannot accept
+  costs nothing and orphans nothing. The upload→launch path below is fully
+  implemented and unit-tested; it just cannot reach a real platform yet.
 """
 
 from __future__ import annotations
@@ -314,14 +315,28 @@ def _launcher_args() -> dict[str, Any]:
 
 
 def launch(assume_yes: bool = False) -> str | None:
-    """Validate-gate, weight-gate, capability-gate, confirm, then upload + launch
-    an SFT training run (spends credits). Returns the run id, or None if
-    gated/aborted.
+    """Capability-gate, validate-gate, weight-gate, confirm, log in, then upload
+    + launch an SFT training run (spends credits). Returns the run id, or None
+    if gated/aborted.
+
+    Every side effect — the login, the prompt, the upload, the POST — lives
+    inside this function, behind the capability gate, so an importer calling
+    `launch()` directly is gated exactly like `main(["launch"])` is.
 
     The train/eval pair is loaded ONCE, up front — the same objects that get
     validated are the ones passed to `upload_sft_run`, so a file edit or swap
     between validate and confirm cannot bypass the schema/weight gates.
     """
+    # First, ahead of every side effect: no login, prompt or upload behind an
+    # API that cannot succeed yet.
+    if not platform_client.SFT_LAUNCH_SUPPORTED:
+        print(
+            "launch: the platform does not accept env-less sft runs yet "
+            "(castform.platform.client.SFT_LAUNCH_SUPPORTED is False).",
+            file=sys.stderr,
+        )
+        return None
+
     train, eval_dataset = _load_datasets()
     report = _validate_loaded(train, eval_dataset)  # never spend GPU on broken data
     if report is None or not report.ok:
@@ -331,7 +346,7 @@ def launch(assume_yes: bool = False) -> str | None:
         )
         return None
 
-    # Weight gate: a separate capability from SFT_LAUNCH_SUPPORTED below — the
+    # Weight gate: a separate capability from SFT_LAUNCH_SUPPORTED above — the
     # validate notice alone does not clear it. Strict bool (not truthiness) —
     # a typo'd string value must fail loudly, never silently clear the gate.
     if report.masking_summary.rows_with_weight and not sft_config_bool(
@@ -347,16 +362,6 @@ def launch(assume_yes: bool = False) -> str | None:
 
     launcher_args = _launcher_args()
 
-    # Capability gate before upload — no orphaned storage behind an API that
-    # cannot succeed yet.
-    if not platform_client.SFT_LAUNCH_SUPPORTED:
-        print(
-            "launch: the platform does not accept env-less sft runs yet "
-            "(castform.platform.client.SFT_LAUNCH_SUPPORTED is False).",
-            file=sys.stderr,
-        )
-        return None
-
     if not assume_yes:
         reply = (
             input(
@@ -369,6 +374,9 @@ def launch(assume_yes: bool = False) -> str | None:
             print("launch: aborted.")
             return None
 
+    # Credential last: every gate above is local, so nothing declined or blocked
+    # ever triggers a login.
+    ensure_session()
     uploaded = upload_sft_run(train=train, eval=eval_dataset, run_name=_run_name())
 
     with TrainerClient() as client:
@@ -409,13 +417,11 @@ def main(argv: list[str] | None = None) -> int:
         ok = True
         if args.stage in ("data", "all"):
             generate_data(force=args.force)
-        # data and validate are local-only — launch is the one stage that talks
-        # to the platform, so it is the only one that needs a credential.
         if args.stage in ("validate", "all"):
             report = validate()
             ok = report is not None and report.ok  # non-zero exit on a failed validate
+        # `launch` owns its own credential — see `launch()`, which gates before it.
         if args.stage == "launch":
-            ensure_session()
             ok = launch(assume_yes=args.yes) is not None  # None = gated/aborted/failed
     except (SftScaffoldError, SftConfigError) as exc:
         print(f"error: {exc}", file=sys.stderr)  # no raw traceback (local paths)

--- a/packages/castform/src/castform/cli/scaffold/sft_train_dataset.jsonl
+++ b/packages/castform/src/castform/cli/scaffold/sft_train_dataset.jsonl
@@ -1,0 +1,3 @@
+{"messages": [{"role": "user", "content": "What is the capital of France?"}, {"role": "assistant", "content": "The capital of France is Paris."}]}
+{"messages": [{"role": "user", "content": "What is 2 + 2?"}, {"role": "assistant", "content": "2 + 2 equals 4."}]}
+{"messages": [{"role": "user", "content": "What color is a clear daytime sky?"}, {"role": "assistant", "content": "A clear daytime sky is blue."}]}

--- a/packages/castform/src/castform/cli/scaffold/skills/design-environment/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/design-environment/SKILL.md
@@ -9,6 +9,22 @@ Use `BaseEnv` for the standard OpenAI-compatible chat and tool loop. Use
 `HarborEnv` when Harbor owns the complete agent/sandbox/verifier harness. Extend
 `Environment` directly only for another genuinely different rollout loop.
 
+## An environment, or no environment at all?
+
+Build an environment only when the task needs reward-scored rollouts: the model
+acts, optionally with tools, something scores each attempt, and training improves
+the policy from that reward. If the task is closer to "train the model to
+reproduce these input → output conversations" — supervised fine-tuning on
+existing demonstrations, no reward function involved — skip the environment
+entirely.
+
+Scaffold that layout with `castform setup --template sft`. The generated
+`main.py` defines no environment class; it carries `training_mode` in its
+`LAUNCH_CONFIG` and works directly on `{"messages": [...]}` rows through the
+`benchmax.sft` dataset boundary. Follow **generate-data**, **verify-environment**
+and **launch-run** for the SFT-specific part of each stage; the environment,
+reward and tool material below does not apply to it.
+
 ## Required BaseEnv shape
 
 ```python
@@ -70,6 +86,28 @@ async def run_tool(self, rollout_id: str, tool_name: str, **tool_args):
 
 Keep clients pickle-safe. Resolve rotating model/judge credentials per call with
 `InjectedAuth`; never read Castform credentials from BenchMax environment code.
+
+## Multimodal content (SFT datasets)
+
+A message's `content` does not have to be a plain string. A user message whose
+content is a list of parts — a `text` part alongside an
+`{"type": "image_url", "image_url": {"url": "data:..."}}` part — is already legal
+on the **SFT dataset pathway**: those rows are validated as-is and preserved
+byte-for-byte through canonicalization. Read and build that content with
+`benchmax.envs.base.content`:
+
+- `message_text` joins a message's text parts into one string;
+- `content_preview` renders a truncated single-line preview;
+- `iter_image_refs` walks image URLs across messages in order;
+- `image_to_data_uri` turns a local path or raw bytes into a `data:` URI.
+
+Two boundaries are worth stating plainly. Multimodal rows need a vision base
+model, and trainer-side image support is not implemented yet — the client and
+dataset layers preserve image content, training does not consume it. And this
+skill does not cover RL-side multimodal: a `BaseEnv` transporting image content
+through a rollout, or a `compute_reward` reading list-shaped content, is owned by
+Harbor's own multimodal environments. Do not build a custom multimodal `BaseEnv`
+here.
 
 ## Review before handoff
 

--- a/packages/castform/src/castform/cli/scaffold/skills/generate-data/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/generate-data/SKILL.md
@@ -34,6 +34,60 @@ decides what it uploads: omit a split when the environment resolves it at runtim
 and do not upload unrelated preparation artifacts. `None` means “do not upload”;
 an empty list deliberately uploads an empty JSONL.
 
+## SFT — the `messages` row format
+
+For an env-less SFT project (`castform setup --template sft`, see
+design-environment) each row is the OpenAI fine-tuning chat format, not
+`prompt`/`ground_truth`:
+
+```jsonl
+{"messages": [{"role": "user", "content": "Translate 'hello' to French."}, {"role": "assistant", "content": "Bonjour."}]}
+```
+
+`messages` is required and every row needs at least one assistant turn to train
+on. Two fields are optional: a top-level `tools` list in OpenAI tool-call format,
+and a per-assistant-message `weight` (`0` or `1`) that excludes that turn from
+the loss. `weight` is **experimental** — trainer support for it is unconfirmed,
+so the launch stage blocks a weight-bearing dataset unless
+`LAUNCH_CONFIG["allow_experimental_weights"]` is true (see launch-run).
+
+Load and validate rows through `benchmax.sft`, which owns the whole dataset
+boundary:
+
+```python
+from benchmax.sft import load_sft_dataset, validate_sft_dataset
+
+train = load_sft_dataset("train.jsonl")
+report = validate_sft_dataset(train)
+```
+
+`load_sft_dataset` is the only reader for SFT data and `canonical_jsonl` the only
+serializer; both upload and validation consume their output, and `canonical_jsonl`
+refuses a dataset that did not load and validate cleanly. Legacy shapes — a bare
+`prompt`/`completion` pair, a `prompt_messages`/`completion_messages` split, flat
+tool-call entries — are normalized into `messages` rows on load, so they are
+accepted as input without being a second row format to maintain.
+
+A user message's `content` may be a list of parts instead of a plain string, for
+a vision base model. Build the `image_url` value with
+`benchmax.envs.base.content.image_to_data_uri`, which turns a local path or raw
+bytes into a `data:` URI and passes an existing `data:`/`https:` string through
+unchanged:
+
+```python
+from benchmax.envs.base.content import image_to_data_uri
+
+image_url = image_to_data_uri("figure.png")  # -> "data:image/png;base64,..."
+```
+
+**Deriving SFT rows from traces**: `castform.traces.TracesPipeline` (below) emits
+RL-shaped rows and discards the model's actual completion. For SFT, keep the
+detected system prompt and tools, but append the completion as a trained
+`{"role": "assistant", ...}` message onto the detected prompt messages to get a
+canonical `messages` row. There is no dedicated traces-to-SFT converter yet —
+treat the detected prompt and tools as the starting point and assemble rows in
+the data stage.
+
 <!-- rag:start -->
 ## Hosted corpus and RAG
 

--- a/packages/castform/src/castform/cli/scaffold/skills/launch-run/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/launch-run/SKILL.md
@@ -72,6 +72,40 @@ the rollout bundle includes the runtime search client but not large local corpus
 preparation dependencies unless the environment imports them.
 <!-- rag:end -->
 
+## SFT launch (and why it cannot land yet)
+
+An env-less SFT project (see design-environment) launches with the same command
+and the same confirmation discipline, but there is no bundle to build. Confirm
+that its `launch()` does all of the following in order:
+
+1. loads the train/eval pair once and runs the local `validate()` gate on it;
+2. stops if any row carries a per-message `weight` and
+   `LAUNCH_CONFIG["allow_experimental_weights"]` is not true;
+3. stops if `castform.platform.client.SFT_LAUNCH_SUPPORTED` is `False`;
+4. asks the human to confirm a credit-spending GPU launch;
+5. calls `upload_sft_run(train=..., eval=..., run_name=...)`;
+6. passes the returned paths to `TrainerClient.launch_sft_run`.
+
+Steps 2 and 3 are independent gates, and both sit ahead of the upload on
+purpose: a refused launch must not leave a dataset orphaned in storage behind an
+API that cannot accept it.
+
+**The live platform does not accept env-less SFT launch args yet.**
+`SFT_LAUNCH_SUPPORTED` is `False` as of writing, so step 3 stops every SFT
+launch before it uploads. The upload and launch path is fully implemented and
+tested — it has nowhere to land until platform support ships. Do not tell a user
+an SFT project is launch-ready today; track `SFT_LAUNCH_SUPPORTED` for when that
+flips. Note that the flag gates the *scaffold*, not the SDK: code calling
+`upload_sft_run` directly can still upload and then be rejected by the server at
+launch. Keep the gate in the script.
+
+On the wire, `launch_sft_run` nests `training_mode` and the dataset paths inside
+`args`, which is where the platform reads them; a top-level `training_mode` is
+silently ignored and would fall through to an RL run. `LAUNCH_CONFIG` carries
+`training_mode` and an optional per-run `model` for that reason — they are wire
+args, not local knobs — while `name`, `type` and `allow_experimental_weights`
+are resolved locally and never forwarded.
+
 ## Credentials
 
 Model and judge credentials must resolve per request (`InjectedAuth` for named

--- a/packages/castform/src/castform/cli/scaffold/skills/launch-run/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/launch-run/SKILL.md
@@ -78,26 +78,27 @@ An env-less SFT project (see design-environment) launches with the same command
 and the same confirmation discipline, but there is no bundle to build. Confirm
 that its `launch()` does all of the following in order:
 
-1. loads the train/eval pair once and runs the local `validate()` gate on it;
-2. stops if any row carries a per-message `weight` and
+1. stops if `castform.platform.client.SFT_LAUNCH_SUPPORTED` is `False`;
+2. loads the train/eval pair once and runs the local `validate()` gate on it;
+3. stops if any row carries a per-message `weight` and
    `LAUNCH_CONFIG["allow_experimental_weights"]` is not true;
-3. stops if `castform.platform.client.SFT_LAUNCH_SUPPORTED` is `False`;
 4. asks the human to confirm a credit-spending GPU launch;
 5. calls `upload_sft_run(train=..., eval=..., run_name=...)`;
 6. passes the returned paths to `TrainerClient.launch_sft_run`.
 
-Steps 2 and 3 are independent gates, and both sit ahead of the upload on
-purpose: a refused launch must not leave a dataset orphaned in storage behind an
-API that cannot accept it.
+Steps 2 and 3 are local-only gates, and both sit ahead of the upload on
+purpose: a refused launch must not leave a dataset orphaned in storage behind
+an API that cannot accept it.
 
 **The live platform does not accept env-less SFT launch args yet.**
-`SFT_LAUNCH_SUPPORTED` is `False` as of writing, so step 3 stops every SFT
-launch before it uploads. The upload and launch path is fully implemented and
-tested — it has nowhere to land until platform support ships. Do not tell a user
-an SFT project is launch-ready today; track `SFT_LAUNCH_SUPPORTED` for when that
-flips. Note that the flag gates the *scaffold*, not the SDK: code calling
-`upload_sft_run` directly can still upload and then be rejected by the server at
-launch. Keep the gate in the script.
+`SFT_LAUNCH_SUPPORTED` is `False` as of writing, so step 1 stops every SFT
+launch before it validates or uploads. The upload and launch path is fully
+implemented and tested - it has nowhere to land until platform support ships.
+Do not tell a user an SFT project is launch-ready today; track
+`SFT_LAUNCH_SUPPORTED` for when that flips. Note that the flag gates the
+*scaffold*, not the SDK: code calling `upload_sft_run` directly can still upload
+and then be rejected by the server at launch. Keep the gate in the script and
+keep it ahead of every side effect.
 
 On the wire, `launch_sft_run` nests `training_mode` and the dataset paths inside
 `args`, which is where the platform reads them; a top-level `training_mode` is

--- a/packages/castform/src/castform/cli/scaffold/skills/verify-environment/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/verify-environment/SKILL.md
@@ -54,5 +54,33 @@ name to its call-time credential provider for the duration of the run. Rollout
 not silently override the other. A missing or unknown binding should fail visibly;
 the environment must not read a platform token itself.
 
+## SFT validate: local, no rollouts
+
+An env-less SFT project (see design-environment) runs the same command:
+
+```bash
+uv run python main.py validate
+```
+
+but takes a different path entirely. It loads `train.jsonl` and, when present,
+`eval.jsonl` through `benchmax.sft.load_sft_dataset`, then calls
+`validate_sft_dataset` on the pair. Nothing rolls out: no remote calls, no LLM,
+no GPU, so it is typically fast even on a large file and safe to run on every
+data edit. There is no reward table and no "rewards vary" check — row and schema
+correctness is the whole gate.
+
+The scorecard reports train/eval row counts, a char/4-heuristic token-length
+summary, masking usage when any row carries a per-message `weight`, and each
+issue as `path:line  message` tagged `✗` (error, gate-failing) or `⚠` (notice,
+informational). The stage exits `0` only when the report is `ok`: no
+error-severity issues and at least one train row. A missing or empty train
+dataset is an error; a missing eval dataset is not — a train-only SFT project is
+a legitimate state.
+
+`VALIDATE_CONFIG` in `main.py` holds the dataset knobs — `max_seq_len` for the
+token-budget notice and `max_row_bytes` for the per-row size notice. Both are
+notices, not errors: they tell you a row is likely to be truncated or rejected
+later without failing the gate on your behalf.
+
 When the baseline is green, report both outcomes and ask whether to iterate or load
 **launch-run**. Do not launch automatically.

--- a/packages/castform/src/castform/cli/setup.py
+++ b/packages/castform/src/castform/cli/setup.py
@@ -6,8 +6,9 @@ per-stage skills into each agent's skills dir (claude → ``.claude/skills/``,
 codex → ``.agents/skills/``, with the body's path references retargeted), a
 starter prompt, and a standalone ``pyproject.toml`` + runnable seed ``main.py`` +
 tiny seed datasets per template (``generic`` → a minimal single-turn env,
-``rag`` → a hosted-corpus search env) so ``python main.py validate`` runs on day
-one. ``--no-template`` skips the seed (docs + skills only; the agent writes
+``rag`` → a hosted-corpus search env, ``sft`` → an env-less supervised
+fine-tuning dataset) so ``python main.py validate`` runs on day one.
+``--no-template`` skips the seed (docs + skills only; the agent writes
 ``main.py`` from the design-environment skill). Does NOT open the agent.
 The scaffold prose duplicates the web-app generator (``buildAgentContextBody``)
 for now — accepted divergence debt; keep aligned.
@@ -60,6 +61,14 @@ _TEMPLATE_SEEDS = {
         "main": "rag_main.py",
         "train": "rag_train_dataset.jsonl",
         "eval": "rag_eval_dataset.jsonl",
+    },
+    # Env-less: no env class and no reward, hence no `tests` entry. Seeds are
+    # canonical text chat rows — the multimodal row stays opt-in inside
+    # `sft_main.py` (it needs a vision base model), never written as a seed.
+    "sft": {
+        "main": "sft_main.py",
+        "train": "sft_train_dataset.jsonl",
+        "eval": "sft_eval_dataset.jsonl",
     },
 }
 
@@ -389,11 +398,12 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p.add_argument(
         "--template",
-        choices=["generic", "rag"],
+        choices=["generic", "rag", "sft"],
         default="generic",
         help="Env seed: 'generic' = a minimal single-turn env, 'rag' = a hosted-"
-        "corpus search env (both ship a pyproject, runnable main.py, and tiny "
-        "datasets; default: generic)",
+        "corpus search env, 'sft' = an env-less supervised fine-tuning dataset "
+        "(all three ship a pyproject, runnable main.py, and tiny datasets; "
+        "default: generic)",
     )
     p.add_argument(
         "--no-template",

--- a/packages/castform/src/castform/cli/setup.py
+++ b/packages/castform/src/castform/cli/setup.py
@@ -108,31 +108,38 @@ def _retarget(text: str, agent: str) -> str:
     return text.replace(".claude/skills", _SKILLS_DIR[agent])
 
 
-# Env-conditional surfacing: content between ``<!-- rag:start -->`` and
-# ``<!-- rag:end -->`` (HTML comments, invisible when rendered) is RAG-specific —
-# a single-source doc that the setup mechanism tailors per template.
-_RAG_BLOCK_RE = re.compile(
-    r"^[ \t]*<!--\s*rag:start\s*-->.*?^[ \t]*<!--\s*rag:end\s*-->[ \t]*\n?",
-    re.DOTALL | re.MULTILINE | re.IGNORECASE,
-)
-_RAG_MARKER_RE = re.compile(
-    r"^[ \t]*<!--\s*rag:(?:start|end)\s*-->[ \t]*\n?",
-    re.MULTILINE | re.IGNORECASE,
-)
+# Template-conditional blocks keep the packaged docs as a single source while
+# setup emits only the guidance that matches the selected project.
+def _template_block_patterns(name: str) -> tuple[re.Pattern[str], re.Pattern[str]]:
+    """Return regexes for a named ``<!-- name:start/end -->`` block and markers."""
+    escaped = re.escape(name)
+    block = re.compile(
+        rf"^[ \t]*<!--\s*{escaped}:start\s*-->.*?"
+        rf"^[ \t]*<!--\s*{escaped}:end\s*-->[ \t]*\n?",
+        re.DOTALL | re.MULTILINE | re.IGNORECASE,
+    )
+    markers = re.compile(
+        rf"^[ \t]*<!--\s*{escaped}:(?:start|end)\s*-->[ \t]*\n?",
+        re.MULTILINE | re.IGNORECASE,
+    )
+    return block, markers
+
+
+def _apply_conditional(text: str, name: str, *, keep: bool) -> str:
+    """Keep a named conditional's body or remove its complete block."""
+    block, markers = _template_block_patterns(name)
+    return markers.sub("", text) if keep else block.sub("", text)
 
 
 def _apply_template_conditionals(text: str, template: str) -> str:
-    """Tailor a scaffold doc to the env template. ``--template rag`` KEEPS the
-    RAG-specific blocks (dropping just the delimiter comments); every other template
-    STRIPS them, so a generic scaffold carries no RAG-specific guidance."""
-    if template == "rag":
-        return _RAG_MARKER_RE.sub("", text)
-    return _RAG_BLOCK_RE.sub("", text)
+    """Tailor scaffold docs to the selected RL, RAG, or SFT template."""
+    text = _apply_conditional(text, "rag", keep=template == "rag")
+    text = _apply_conditional(text, "rl", keep=template != "sft")
+    return _apply_conditional(text, "sft", keep=template == "sft")
 
 
-# The one prompt we surface in-terminal — kept in sync with GETTING_STARTED.md's
-# generic variant and the web onboarding copy. The other variants (rag / traces)
-# stay in GETTING_STARTED.md so the terminal stays a single clear call to action.
+# The template prompt surfaced in-terminal stays aligned with GETTING_STARTED.md.
+# RAG and trace variants remain in the guide instead of adding terminal choices.
 _PRIMARY_PROMPT = (
     "i want to start a training run to improve a model on <your task>. create a "
     "reasonable environment with relevant tools, generate a small synthetic "
@@ -140,10 +147,23 @@ _PRIMARY_PROMPT = (
     "either iterate or launch."
 )
 
+_SFT_PRIMARY_PROMPT = (
+    "i want to prepare an sft dataset for <your task>. generate a small set of "
+    "openai fine-tuning chat rows, validate them locally, review the scorecard, "
+    "and stop at the platform capability check before proposing any upload."
+)
+
 # (command, what it does) — the few verbs worth surfacing right after setup.
 _QUICK_COMMANDS = (
     ("python main.py validate", "baseline · local group of 2 · no GPU"),
     ("python main.py launch", "train on GPUs · spends credits"),
+    ("castform runs status <id>", "monitor a launched run"),
+    ("castform guide", "full walkthrough + more prompts"),
+)
+
+_SFT_QUICK_COMMANDS = (
+    ("python main.py validate", "local dataset scorecard · no gpu or rollouts"),
+    ("python main.py launch", "capability check · currently stops before upload"),
     ("castform runs status <id>", "monitor a launched run"),
     ("castform guide", "full walkthrough + more prompts"),
 )
@@ -159,7 +179,7 @@ def _wrap(text: str, width: int) -> list[str]:
     return textwrap.wrap(text, width) or [""]
 
 
-def _print_get_started() -> None:
+def _print_get_started(template: str) -> None:
     """Render the get-started block: an ``ask your agent`` divider over the one
     prompt to paste (plain indented lines — no box, so it copy-pastes clean),
     then a ``helpful commands`` divider over an unboxed command list. Command and
@@ -167,16 +187,18 @@ def _print_get_started() -> None:
     Degrades to plain text without color/TTY.
     """
     width = min(term_width() - 2, 72)
+    prompt = _SFT_PRIMARY_PROMPT if template == "sft" else _PRIMARY_PROMPT
+    commands = _SFT_QUICK_COMMANDS if template == "sft" else _QUICK_COMMANDS
 
     print()
     print("  " + rule_label("ask your agent", ORANGE, width))
-    for ln in _wrap(_PRIMARY_PROMPT, width - 2):
+    for ln in _wrap(prompt, width - 2):
         print("    " + paint(ln, italic=True))
 
     print()
     print("  " + rule_label("helpful commands", BLUE, width))
-    cmd_w = max(len(c) for c, _ in _QUICK_COMMANDS)
-    for cmd, desc in _QUICK_COMMANDS:
+    cmd_w = max(len(c) for c, _ in commands)
+    for cmd, desc in commands:
         print("    " + cmd.ljust(cmd_w) + "   " + paint(desc, _GREY))
     print()
 
@@ -360,7 +382,7 @@ def _cmd_setup(args: argparse.Namespace) -> int:
         if env_writes:  # every template ships a seed main.py + datasets
             groups.append(
                 (
-                    "env template",
+                    "project template" if args.template == "sft" else "env template",
                     env_writes,
                     f"pyproject + main.py + datasets + tests ({args.template})",
                 )
@@ -376,7 +398,7 @@ def _cmd_setup(args: argparse.Namespace) -> int:
         )
     )
 
-    _print_get_started()
+    _print_get_started(args.template)
     return 0
 
 

--- a/packages/castform/src/castform/platform/__init__.py
+++ b/packages/castform/src/castform/platform/__init__.py
@@ -3,19 +3,28 @@
 from .client import RolloutClient, StorageClient, TrainerClient
 from .config import PlatformConfig
 from .credentials import platform_bearer
+from .exceptions import SftDatasetInvalidError
 from .login import ensure_session
-from .training_run import UploadedTrainingRun, upload_training_run
+from .training_run import (
+    UploadedSftRun,
+    UploadedTrainingRun,
+    upload_sft_run,
+    upload_training_run,
+)
 
 __all__ = [
     "RolloutClient",
     "PlatformConfig",
+    "SftDatasetInvalidError",
     "StorageClient",
     "TrainerClient",
+    "UploadedSftRun",
     "UploadedTrainingRun",
     # The seam token-getter: generated scripts pass it to a raw OpenAI client
     # (e.g. the traces pivot), so it's part of the public surface alongside
     # ensure_session — not just an internal credentials helper.
     "platform_bearer",
     "ensure_session",
+    "upload_sft_run",
     "upload_training_run",
 ]

--- a/packages/castform/src/castform/platform/client.py
+++ b/packages/castform/src/castform/platform/client.py
@@ -30,6 +30,15 @@ from .exceptions import (
 
 logger = logging.getLogger(__name__)
 
+# Whether the platform accepts env-less SFT runs yet — flip to True once
+# platform-service validates `args.training_mode` instead of rejecting it (see
+# TrainerClient.launch_sft_run). Deliberately not consumed by this module: the
+# SDK stays a thin wire, and the scaffold launch path gates its pre-upload
+# guard on this flag. Read it as a module attribute
+# (`client.SFT_LAUNCH_SUPPORTED`) rather than importing the value, so a test
+# can stub the capability.
+SFT_LAUNCH_SUPPORTED = False
+
 
 @dataclass(frozen=True)
 class LaunchArgSpec:
@@ -418,6 +427,77 @@ class TrainerClient:
         for warning in body.get("warnings", []) or []:
             warnings.warn(f"launch warning: {warning}", stacklevel=2)
         return body["runId"]
+
+    def launch_sft_run(
+        self,
+        name: str,
+        train_dataset_path: str,
+        eval_dataset_path: str | None = None,
+        launcher_args: dict[str, Any] | None = None,
+    ) -> str:
+        """Launch a new env-less SFT training run.
+
+        A dedicated method rather than a mode on
+        :meth:`launch_training_run`: an SFT run carries no environment bundle
+        at all, so there is no set of bundle paths to make optional.
+
+        ``training_mode`` and the dataset paths are nested inside ``args``,
+        which is where platform-service reads and validates them; a
+        **top-level** ``training_mode`` is silently ignored and would fall
+        through to an RL run.
+
+        As of writing ``SFT_LAUNCH_SUPPORTED`` is ``False`` — the live
+        platform does not recognize ``training_mode`` yet, so this call is
+        expected to fail against it. Callers should gate on that flag before
+        reaching this method (and before uploading anything).
+
+        Args:
+            name: Name for the training run.
+            train_dataset_path: Blob path of the uploaded training dataset
+                (see :func:`castform.platform.upload_sft_run`).
+            eval_dataset_path: Blob path of the uploaded eval dataset, or
+                ``None`` to omit eval entirely. ``None`` OMITS the field from
+                the payload — no empty string, no null — mirroring
+                ``upload_sft_run``'s optional-eval behavior.
+            launcher_args: Extra launcher args forwarded to the server (e.g.
+                ``{"learning_rate": 1e-5}``). The explicit parameters above
+                always take precedence: ``launcher_args`` can neither override
+                the training mode or train path, nor smuggle an eval path back
+                in once ``eval_dataset_path`` has decided the outcome.
+
+        Returns:
+            The training run ID.
+
+        Raises:
+            AuthenticationError: If the API key is invalid (HTTP 401).
+            JobLaunchError: Any other launch failure — including the
+                platform's rejection of ``training_mode`` while
+                ``SFT_LAUNCH_SUPPORTED`` is ``False``.
+        """
+        args: dict[str, Any] = {
+            **(launcher_args or {}),
+            "training_mode": "sft",
+            "train_dataset_path": train_dataset_path,
+        }
+        # Reconcile the reserved eval key against the explicit parameter last,
+        # so launcher_args cannot reintroduce an eval path the caller omitted.
+        if eval_dataset_path is None:
+            args.pop("eval_dataset_path", None)
+        else:
+            args["eval_dataset_path"] = eval_dataset_path
+        body: dict[str, Any] = {
+            "name": name,
+            "args": args,
+        }
+        response = self._http_client.post(
+            "/v1/train/runs/launch",
+            json=body,
+        )
+        self._handle_response_errors(response)
+        response_body = response.json()
+        for warning in response_body.get("warnings", []) or []:
+            warnings.warn(f"launch warning: {warning}", stacklevel=2)
+        return response_body["runId"]
 
     def list_launch_args(self) -> list[LaunchArgSpec]:
         """Fetch the schema of launch args this platform accepts.

--- a/packages/castform/src/castform/platform/exceptions.py
+++ b/packages/castform/src/castform/platform/exceptions.py
@@ -1,5 +1,12 @@
 """Exceptions for trainer API operations."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from benchmax.sft import SftValidationReport
+
 
 class TrainerError(Exception):
     """Base exception for trainer API errors."""
@@ -20,6 +27,28 @@ class JobLaunchError(TrainerError):
     """Failed to launch a training job."""
 
     pass
+
+
+class SftDatasetInvalidError(RuntimeError):
+    """:func:`castform.platform.upload_sft_run` refused to upload a dataset
+    pair that does not pass :func:`benchmax.sft.validate_sft_dataset`.
+
+    The upload path re-validates defensively rather than trusting that its
+    caller already did, and raises this **before** touching storage — so a
+    refused run leaves no partial upload behind. ``report`` is the full
+    :class:`benchmax.sft.SftValidationReport`, carrying every issue with its
+    source path and physical line, so a caller can report exactly what to fix
+    without re-running validation.
+
+    Not a :class:`TrainerError`: nothing was sent, so there is no HTTP status
+    to carry. A ``RuntimeError`` subclass — matching the data-side
+    :class:`benchmax.sft.SftSerializationError` — so a CLI's top-level error
+    handling prints it as one clean stderr line instead of a traceback.
+    """
+
+    def __init__(self, report: SftValidationReport, message: str) -> None:
+        self.report = report
+        super().__init__(message)
 
 
 class RolloutError(TrainerError):

--- a/packages/castform/src/castform/platform/training_run.py
+++ b/packages/castform/src/castform/platform/training_run.py
@@ -25,6 +25,7 @@ from typing import Any
 from benchmax.bundle import Bundle, bundle_digest
 from benchmax.sft import (
     SftDataset,
+    SftIssue,
     SftValidationReport,
     canonical_jsonl,
     validate_sft_dataset,
@@ -230,10 +231,15 @@ def upload_sft_run(
     """Validate an SFT train (+ optional eval) dataset pair and upload it.
 
     Default layout: ``datasets/<run_name>/<dataset_hash>/{train.jsonl,
-    eval.jsonl}``, where the hash is sha256 over the bytes actually uploaded,
-    truncated to 8 hex chars — so a train-only run and a train+eval run land
-    in different buckets. ``eval=None`` uploads nothing for eval and returns
-    ``None`` for ``eval_dataset_path``.
+    eval.jsonl}``. The hash is sha256 over a JSON fingerprint holding each
+    split's own sha256 under its own key, truncated to 8 hex chars.
+    Fingerprinting the splits separately keeps the train/eval boundary in the
+    digest — concatenating newline-terminated canonical JSONL would not, so
+    moving a row from eval to train, or supplying no eval at all versus an
+    empty one, would collide on a single prefix while uploading different
+    file sets. ``eval=None`` uploads nothing for eval and returns ``None``
+    for ``eval_dataset_path``; ``eval`` as an empty dataset still uploads an
+    empty ``eval.jsonl``, and the two get different prefixes.
 
     This is the upload side of the canonicalize -> validate -> upload
     boundary, and it enforces that boundary rather than documenting it. The
@@ -263,9 +269,10 @@ def upload_sft_run(
         UploadedSftRun with the train path and the optional eval path.
 
     Raises:
-        SftDatasetInvalidError: If the pair carries any error-severity issue
-            or the training split is empty. Carries the full validation
-            report; nothing has been uploaded.
+        SftDatasetInvalidError: If the training split is empty, if either
+            split carries a load issue of any severity, or if the pair
+            carries any error-severity validation issue. Carries the full
+            validation report; nothing has been uploaded.
     """
     report = validate_sft_dataset(train, eval)
     # Refuse before constructing a client or serializing anything. The empty
@@ -277,6 +284,18 @@ def upload_sft_run(
             report,
             f"refusing to upload SFT run {run_name!r}: the training dataset "
             f"{train.path!r} has no rows.",
+        )
+    load_issues = _load_issues(train, eval)
+    if load_issues:
+        # Any load issue blocks, whatever its severity — report.ok only counts
+        # error severity, so a notice-severity load issue would otherwise reach
+        # canonical_jsonl and surface as SftSerializationError after the client
+        # exists. Mirroring canonical_jsonl's contract keeps the refusal here,
+        # typed, and before any storage object is built.
+        raise SftDatasetInvalidError(
+            report,
+            f"refusing to upload SFT run {run_name!r}: the dataset pair did not "
+            f"load cleanly. {_issue_summary(load_issues)}",
         )
     if not report.ok:
         raise SftDatasetInvalidError(
@@ -297,8 +316,7 @@ def upload_sft_run(
     eval_jsonl = canonical_jsonl(eval) if eval is not None else None
 
     if dataset_prefix is None:
-        digest = hashlib.sha256(train_jsonl + (eval_jsonl or b"")).hexdigest()[:8]
-        dataset_prefix = f"datasets/{run_name}/{digest}"
+        dataset_prefix = f"datasets/{run_name}/{_dataset_digest(train_jsonl, eval_jsonl)}"
     _validate_blob_path(dataset_prefix, source="dataset_prefix/run_name")
 
     with tempfile.TemporaryDirectory() as tmp:
@@ -321,19 +339,58 @@ def upload_sft_run(
     return UploadedSftRun(train_dataset_path=train_path, eval_dataset_path=eval_path)
 
 
+def _dataset_digest(train_jsonl: bytes, eval_jsonl: bytes | None) -> str:
+    """The 8-hex-char prefix segment identifying this exact pair of splits.
+
+    Each split is hashed on its own and the per-split digests are combined
+    through a JSON object keyed by split name, so the digest depends on how
+    the rows are partitioned and not merely on their concatenation. An absent
+    eval split hashes as JSON ``null``, distinguishing it from an empty eval
+    split whose canonical JSONL is ``b""`` — the two upload different file
+    sets and so must never share a prefix.
+    """
+    fingerprint = json.dumps(
+        {
+            "train": hashlib.sha256(train_jsonl).hexdigest(),
+            "eval": (
+                hashlib.sha256(eval_jsonl).hexdigest() if eval_jsonl is not None else None
+            ),
+        },
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(fingerprint).hexdigest()[:8]
+
+
+def _load_issues(train: SftDataset, eval: SftDataset | None) -> list[SftIssue]:
+    """Every load issue carried by the pair, train split first."""
+    issues = list(train.load_issues)
+    if eval is not None:
+        issues.extend(eval.load_issues)
+    return issues
+
+
+def _issue_summary(issues: list[SftIssue]) -> str:
+    """``issues`` rendered as one actionable line, capped at ``_MAX_REPORTED_ISSUES``.
+
+    Callers pass an already-filtered list; this helper does not decide which
+    severities block, since that differs per gate.
+    """
+    shown = "; ".join(
+        f"{issue.source_path}:{issue.physical_line}: {issue.message}"
+        for issue in issues[:_MAX_REPORTED_ISSUES]
+    )
+    remaining = len(issues) - _MAX_REPORTED_ISSUES
+    if remaining > 0:
+        shown = f"{shown}; (+{remaining} more)"
+    return f"{len(issues)} blocking issue(s) — {shown}"
+
+
 def _error_summary(report: SftValidationReport) -> str:
     """The report's blocking issues, rendered for a one-line refusal message."""
     errors = [issue for issue in report.issues if issue.severity == "error"]
     if not errors:
         return "no error-severity issues were reported."
-    shown = "; ".join(
-        f"{issue.source_path}:{issue.physical_line}: {issue.message}"
-        for issue in errors[:_MAX_REPORTED_ISSUES]
-    )
-    remaining = len(errors) - _MAX_REPORTED_ISSUES
-    if remaining > 0:
-        shown = f"{shown}; (+{remaining} more)"
-    return f"{len(errors)} blocking issue(s) — {shown}"
+    return _issue_summary(errors)
 
 
 def _collect_dataset_files(

--- a/packages/castform/src/castform/platform/training_run.py
+++ b/packages/castform/src/castform/platform/training_run.py
@@ -1,12 +1,14 @@
-"""High-level helper for uploading a prepared training run.
+"""High-level helpers for uploading a prepared training run.
 
-Uploads a completed environment bundle and any caller-supplied datasets in a
-single call. The returned dataclass spreads into
-``TrainerClient.launch_training_run``.
+:func:`upload_training_run` uploads a completed environment bundle and any
+caller-supplied datasets in a single call; :func:`upload_sft_run` is its
+env-less counterpart, uploading only an SFT dataset pair. Each returned
+dataclass spreads into the matching ``TrainerClient`` launch method.
 
-Bundling remains a BenchMax concern. This helper deliberately accepts a
-``Bundle`` instead of environment construction inputs so Castform cannot
-silently rebuild or reinterpret the artifact selected by the caller.
+Bundling remains a BenchMax concern. These helpers deliberately accept a
+``Bundle`` / an already-loaded ``SftDataset`` instead of construction inputs,
+so Castform cannot silently rebuild or reinterpret the artifact the caller
+selected.
 """
 
 from __future__ import annotations
@@ -21,10 +23,17 @@ from pathlib import Path
 from typing import Any
 
 from benchmax.bundle import Bundle, bundle_digest
+from benchmax.sft import (
+    SftDataset,
+    SftValidationReport,
+    canonical_jsonl,
+    validate_sft_dataset,
+)
 
 from castform import config
 
 from .client import StorageClient
+from .exceptions import SftDatasetInvalidError
 
 
 @dataclass(frozen=True)
@@ -49,11 +58,37 @@ class UploadedTrainingRun:
     dataset_path: str | None = None
 
 
+@dataclass(frozen=True)
+class UploadedSftRun:
+    """Blob paths for an env-less SFT run's uploaded datasets.
+
+    Field names match ``TrainerClient.launch_sft_run`` kwargs so the result
+    spreads directly into the launch call::
+
+        uploaded = upload_sft_run(...)
+        run_id = trainer.launch_sft_run(
+            name="my-run",
+            **dataclasses.asdict(uploaded),
+        )
+
+    ``eval_dataset_path`` is ``None`` when no eval dataset was supplied to
+    :func:`upload_sft_run` — nothing is uploaded for eval in that case, and
+    ``launch_sft_run`` omits the field from the wire body.
+    """
+
+    train_dataset_path: str
+    eval_dataset_path: str | None = None
+
+
 # Mirrors the platform's blob-path guard (isSafeBlobPath): the upload endpoint
 # rejects keys whose segments fall outside this charset, since a stray
 # `?`/`#`/space breaks the trainer's SAS-URL parsing downstream. Fail loud here
 # with an actionable message instead of letting the user hit an opaque 400.
 _SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# How many blocking issues an upload refusal names before summarizing the rest,
+# matching benchmax.sft's serialization refusal — the message stays readable.
+_MAX_REPORTED_ISSUES = 5
 
 
 def _validate_blob_path(path: str, *, source: str) -> None:
@@ -180,6 +215,125 @@ def upload_training_run(
             env_metadata_path=env_metadata_path,
             dataset_path=dataset_prefix,
         )
+
+
+def upload_sft_run(
+    *,
+    train: SftDataset,
+    eval: SftDataset | None = None,
+    run_name: str,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    dataset_prefix: str | None = None,
+    storage_client: StorageClient | None = None,
+) -> UploadedSftRun:
+    """Validate an SFT train (+ optional eval) dataset pair and upload it.
+
+    Default layout: ``datasets/<run_name>/<dataset_hash>/{train.jsonl,
+    eval.jsonl}``, where the hash is sha256 over the bytes actually uploaded,
+    truncated to 8 hex chars — so a train-only run and a train+eval run land
+    in different buckets. ``eval=None`` uploads nothing for eval and returns
+    ``None`` for ``eval_dataset_path``.
+
+    This is the upload side of the canonicalize -> validate -> upload
+    boundary, and it enforces that boundary rather than documenting it. The
+    pair is re-validated here even when the caller already validated it, and
+    an invalid pair raises :class:`SftDatasetInvalidError` **before any
+    storage call**, so a refused run cannot leave a half-uploaded dataset
+    behind. Rows are then serialized through
+    :func:`benchmax.sft.canonical_jsonl` only — there is no raw-rows entry
+    point into storage.
+
+    Args:
+        train: Loaded training dataset (see
+            :func:`benchmax.sft.load_sft_dataset`).
+        eval: Loaded eval dataset, or ``None`` to skip eval entirely.
+        run_name: Training run identifier; used as the storage path segment.
+        api_key: Platform API key. Optional — when omitted (and no
+            ``storage_client`` is passed) the bearer resolves per request via
+            the credential seam (``ACT_AS_TOKEN_PATH`` / ``CASTFORM_API_KEY``).
+        base_url: Platform base URL. Defaults to ``config.platform_url()``.
+        dataset_prefix: Override the default dataset directory. When set,
+            JSONL files land at ``<dataset_prefix>/{train.jsonl, eval.jsonl}``.
+        storage_client: BYOC. Pass an existing client to reuse its connection
+            pool, custom timeouts, or test fakes. Otherwise constructed from
+            ``api_key``/``base_url``.
+
+    Returns:
+        UploadedSftRun with the train path and the optional eval path.
+
+    Raises:
+        SftDatasetInvalidError: If the pair carries any error-severity issue
+            or the training split is empty. Carries the full validation
+            report; nothing has been uploaded.
+    """
+    report = validate_sft_dataset(train, eval)
+    # Refuse before constructing a client or serializing anything. The empty
+    # train check is deliberately explicit rather than leaning on report.ok's
+    # "nothing validated is not a pass" rule, so this gate keeps its meaning
+    # if that rule ever moves.
+    if not train.rows:
+        raise SftDatasetInvalidError(
+            report,
+            f"refusing to upload SFT run {run_name!r}: the training dataset "
+            f"{train.path!r} has no rows.",
+        )
+    if not report.ok:
+        raise SftDatasetInvalidError(
+            report,
+            f"refusing to upload SFT run {run_name!r}: the dataset pair did not "
+            f"validate. {_error_summary(report)}",
+        )
+
+    if storage_client is None:
+        # api_key optional: StorageClient resolves the bearer per request via
+        # the credential seam (ACT_AS_TOKEN_PATH / CASTFORM_API_KEY) when unset.
+        storage_client = StorageClient(
+            api_key=api_key,
+            base_url=base_url or config.platform_url(),
+        )
+
+    train_jsonl = canonical_jsonl(train)
+    eval_jsonl = canonical_jsonl(eval) if eval is not None else None
+
+    if dataset_prefix is None:
+        digest = hashlib.sha256(train_jsonl + (eval_jsonl or b"")).hexdigest()[:8]
+        dataset_prefix = f"datasets/{run_name}/{digest}"
+    _validate_blob_path(dataset_prefix, source="dataset_prefix/run_name")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+
+        train_local = tmpdir / "train.jsonl"
+        train_local.write_bytes(train_jsonl)
+        train_path = storage_client.upload_local_file(
+            f"{dataset_prefix}/train.jsonl", train_local
+        )["blobPath"]
+
+        eval_path: str | None = None
+        if eval_jsonl is not None:
+            eval_local = tmpdir / "eval.jsonl"
+            eval_local.write_bytes(eval_jsonl)
+            eval_path = storage_client.upload_local_file(
+                f"{dataset_prefix}/eval.jsonl", eval_local
+            )["blobPath"]
+
+    return UploadedSftRun(train_dataset_path=train_path, eval_dataset_path=eval_path)
+
+
+def _error_summary(report: SftValidationReport) -> str:
+    """The report's blocking issues, rendered for a one-line refusal message."""
+    errors = [issue for issue in report.issues if issue.severity == "error"]
+    if not errors:
+        return "no error-severity issues were reported."
+    shown = "; ".join(
+        f"{issue.source_path}:{issue.physical_line}: {issue.message}"
+        for issue in errors[:_MAX_REPORTED_ISSUES]
+    )
+    remaining = len(errors) - _MAX_REPORTED_ISSUES
+    if remaining > 0:
+        shown = f"{shown}; (+{remaining} more)"
+    return f"{len(errors)} blocking issue(s) — {shown}"
 
 
 def _collect_dataset_files(

--- a/packages/castform/tests/unit/platform/test_client.py
+++ b/packages/castform/tests/unit/platform/test_client.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import httpx
 import pytest
+from castform.platform import client as client_module
 from castform.platform.client import (
     LaunchArgSpec,
     RolloutClient,
@@ -15,6 +16,7 @@ from castform.platform.client import (
 )
 from castform.platform.exceptions import (
     AuthenticationError,
+    JobLaunchError,
     RolloutNotFound,
     RolloutServerError,
 )
@@ -195,6 +197,166 @@ def test_launch_training_run_reads_run_id_not_experiment_id():
         )
         == "the-id"
     )
+
+
+# ---------------------------------------------------------------------------
+# Wire format: launch_sft_run nests training_mode + dataset paths in args
+# ---------------------------------------------------------------------------
+
+
+def _capture_sft_launch(
+    response: httpx.Response | None = None, **kwargs: Any
+) -> dict[str, Any]:
+    """Run launch_sft_run against a mock transport; return the captured request."""
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content.decode())
+        return response or httpx.Response(200, json={"runId": "sft-run-1"})
+
+    trainer = _make_trainer_with_transport(handler)
+    captured["run_id"] = trainer.launch_sft_run(**kwargs)
+    return captured
+
+
+def test_launch_sft_run_posts_exact_nested_args_body():
+    """The whole JSON body is asserted, not just the fields of interest.
+
+    Platform-service reads args.training_mode and IGNORES a top-level one
+    (silently falling through to an RL run), so an exact body is the only
+    assertion that catches the field drifting back out of `args`.
+    """
+    captured = _capture_sft_launch(
+        name="sft-run",
+        train_dataset_path="datasets/sft-run/abc123/train.jsonl",
+        eval_dataset_path="datasets/sft-run/abc123/eval.jsonl",
+    )
+
+    assert "/train/runs/launch" in captured["url"]
+    assert captured["run_id"] == "sft-run-1"
+    assert captured["body"] == {
+        "name": "sft-run",
+        "args": {
+            "training_mode": "sft",
+            "train_dataset_path": "datasets/sft-run/abc123/train.jsonl",
+            "eval_dataset_path": "datasets/sft-run/abc123/eval.jsonl",
+        },
+    }
+
+
+def test_launch_sft_run_omits_eval_dataset_path_when_none():
+    """No eval means the key is absent — not null, not an empty string."""
+    captured = _capture_sft_launch(
+        name="train-only",
+        train_dataset_path="datasets/train-only/abc123/train.jsonl",
+    )
+
+    assert captured["body"] == {
+        "name": "train-only",
+        "args": {
+            "training_mode": "sft",
+            "train_dataset_path": "datasets/train-only/abc123/train.jsonl",
+        },
+    }
+
+
+def test_launch_sft_run_merges_extra_launcher_args():
+    captured = _capture_sft_launch(
+        name="tuned",
+        train_dataset_path="t.jsonl",
+        launcher_args={"learning_rate": 1e-5, "max_seq_len": 4096},
+    )
+
+    assert captured["body"]["args"] == {
+        "training_mode": "sft",
+        "train_dataset_path": "t.jsonl",
+        "learning_rate": 1e-5,
+        "max_seq_len": 4096,
+    }
+
+
+def test_launch_sft_run_explicit_paths_win_over_launcher_args():
+    """launcher_args cannot override the training mode or the explicit paths."""
+    captured = _capture_sft_launch(
+        name="precedence",
+        train_dataset_path="explicit/train.jsonl",
+        eval_dataset_path="explicit/eval.jsonl",
+        launcher_args={
+            "training_mode": "rl",
+            "train_dataset_path": "sneaky/train.jsonl",
+            "eval_dataset_path": "sneaky/eval.jsonl",
+        },
+    )
+
+    assert captured["body"]["args"] == {
+        "training_mode": "sft",
+        "train_dataset_path": "explicit/train.jsonl",
+        "eval_dataset_path": "explicit/eval.jsonl",
+    }
+
+
+def test_launch_sft_run_launcher_args_cannot_smuggle_back_an_omitted_eval():
+    """eval_dataset_path=None decides the outcome last — the key stays absent."""
+    captured = _capture_sft_launch(
+        name="no-eval",
+        train_dataset_path="explicit/train.jsonl",
+        eval_dataset_path=None,
+        launcher_args={"eval_dataset_path": "sneaky/eval.jsonl"},
+    )
+
+    assert "eval_dataset_path" not in captured["body"]["args"]
+
+
+def test_launch_sft_run_surfaces_server_warnings():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"runId": "warned", "warnings": ["dataset is small"]}
+        )
+
+    trainer = _make_trainer_with_transport(handler)
+    with pytest.warns(UserWarning, match="dataset is small"):
+        run_id = trainer.launch_sft_run(name="warned", train_dataset_path="t.jsonl")
+
+    assert run_id == "warned"
+
+
+def test_launch_sft_run_raises_job_launch_error_on_403():
+    """A 403 passes through as JobLaunchError with its status intact.
+
+    Includes the platform's current rejection of `training_mode` while
+    SFT_LAUNCH_SUPPORTED is False: it is a plain launch failure, never
+    reclassified into a bespoke "unsupported" type on a message heuristic.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"error": "unrecognized launch argument"})
+
+    trainer = _make_trainer_with_transport(handler)
+    with pytest.raises(JobLaunchError) as exc_info:
+        trainer.launch_sft_run(name="rejected", train_dataset_path="t.jsonl")
+
+    assert exc_info.value.status_code == 403
+    assert not isinstance(exc_info.value, AuthenticationError)
+    assert "unrecognized launch argument" in exc_info.value.message
+
+
+def test_launch_sft_run_raises_authentication_error_on_401():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "missing api key"})
+
+    trainer = _make_trainer_with_transport(handler)
+    with pytest.raises(AuthenticationError) as exc_info:
+        trainer.launch_sft_run(name="unauthorized", train_dataset_path="t.jsonl")
+
+    assert exc_info.value.status_code == 401
+
+
+def test_sft_launch_stays_unsupported_until_the_platform_accepts_it():
+    """The trainer side has not landed; the flag gates the scaffold launch path."""
+    assert client_module.SFT_LAUNCH_SUPPORTED is False
 
 
 # ---------------------------------------------------------------------------

--- a/packages/castform/tests/unit/platform/test_sft_run.py
+++ b/packages/castform/tests/unit/platform/test_sft_run.py
@@ -1,0 +1,308 @@
+"""Unit tests for castform.platform.upload_sft_run — the upload half of the
+canonicalize -> validate -> upload boundary."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+from benchmax.sft import SftDataset, SftIssue, SftRow, load_sft_dataset
+from castform.platform import (
+    SftDatasetInvalidError,
+    UploadedSftRun,
+    upload_sft_run,
+)
+
+
+def _row(text: str = "hello") -> dict:
+    return {
+        "messages": [
+            {"role": "user", "content": text},
+            {"role": "assistant", "content": f"re: {text}"},
+        ]
+    }
+
+
+def _write_dataset(tmp_path: Path, name: str, rows: list[dict]) -> SftDataset:
+    path = tmp_path / name
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+    return load_sft_dataset(path)
+
+
+class FakeStorageClient:
+    """In-memory StorageClient stand-in. Records calls; returns synthetic blob paths."""
+
+    def __init__(self):
+        self.uploads: list[tuple[str, bytes]] = []
+
+    def upload_local_file(
+        self, path: str, file_path: Path, *, expires_in_minutes: int | None = None
+    ) -> dict:
+        # Verify the file actually exists at upload time (it lives in a tempdir
+        # that gets deleted on context exit — catches lifetime bugs).
+        assert Path(file_path).exists(), f"File missing at upload: {file_path}"
+        self.uploads.append((path, Path(file_path).read_bytes()))
+        return {
+            "blobPath": f"blob://{path}",
+            "uploadUrl": f"https://example.invalid/{path}",
+            "expiresAt": "2099-01-01T00:00:00Z",
+            "willOverwrite": False,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Happy path: layout, spread compatibility, optional eval
+# ---------------------------------------------------------------------------
+
+
+def test_upload_sft_run_returns_paths_matching_launch_kwargs(tmp_path):
+    """Field names must spread cleanly into TrainerClient.launch_sft_run."""
+    storage = FakeStorageClient()
+    result = upload_sft_run(
+        train=_write_dataset(tmp_path, "train.jsonl", [_row()]),
+        eval=_write_dataset(tmp_path, "eval.jsonl", [_row("eval")]),
+        run_name="test-run",
+        storage_client=storage,  # type: ignore[arg-type]
+    )
+
+    assert isinstance(result, UploadedSftRun)
+    assert set(dataclasses.asdict(result)) == {
+        "train_dataset_path",
+        "eval_dataset_path",
+    }
+
+
+def test_upload_sft_run_uses_hashed_dataset_layout(tmp_path):
+    storage = FakeStorageClient()
+    result = upload_sft_run(
+        train=_write_dataset(tmp_path, "train.jsonl", [_row()]),
+        eval=_write_dataset(tmp_path, "eval.jsonl", [_row("eval")]),
+        run_name="test-run",
+        storage_client=storage,  # type: ignore[arg-type]
+    )
+
+    keys = [key for key, _ in storage.uploads]
+    assert len(keys) == 2
+    prefix = keys[0].rsplit("/", 1)[0]
+    assert prefix.startswith("datasets/test-run/")
+    assert keys == [f"{prefix}/train.jsonl", f"{prefix}/eval.jsonl"]
+    assert result.train_dataset_path == f"blob://{prefix}/train.jsonl"
+    assert result.eval_dataset_path == f"blob://{prefix}/eval.jsonl"
+
+
+def test_upload_sft_run_uploads_nothing_for_eval_when_omitted(tmp_path):
+    storage = FakeStorageClient()
+    result = upload_sft_run(
+        train=_write_dataset(tmp_path, "train.jsonl", [_row()]),
+        run_name="train-only",
+        storage_client=storage,  # type: ignore[arg-type]
+    )
+
+    keys = [key for key, _ in storage.uploads]
+    assert len(keys) == 1
+    assert keys[0].endswith("/train.jsonl")
+    assert result.eval_dataset_path is None
+
+
+def test_upload_sft_run_hashes_train_only_and_train_plus_eval_differently(tmp_path):
+    """The prefix hash covers the bytes actually uploaded, so adding an eval
+    split cannot land on top of an earlier train-only run."""
+    train = _write_dataset(tmp_path, "train.jsonl", [_row()])
+    eval_dataset = _write_dataset(tmp_path, "eval.jsonl", [_row("eval")])
+
+    train_only = FakeStorageClient()
+    upload_sft_run(
+        train=train,
+        run_name="same-name",
+        storage_client=train_only,  # type: ignore[arg-type]
+    )
+    with_eval = FakeStorageClient()
+    upload_sft_run(
+        train=train,
+        eval=eval_dataset,
+        run_name="same-name",
+        storage_client=with_eval,  # type: ignore[arg-type]
+    )
+
+    assert train_only.uploads[0][0] != with_eval.uploads[0][0]
+
+
+def test_upload_sft_run_uploads_canonical_jsonl_bytes(tmp_path):
+    """Rows go through canonical_jsonl only — never re-serialized here."""
+    storage = FakeStorageClient()
+    upload_sft_run(
+        train=_write_dataset(tmp_path, "train.jsonl", [_row("a"), _row("b")]),
+        run_name="canonical",
+        storage_client=storage,  # type: ignore[arg-type]
+    )
+
+    _, content = storage.uploads[0]
+    lines = content.decode("utf-8").splitlines()
+    assert [json.loads(line) for line in lines] == [_row("a"), _row("b")]
+
+
+def test_upload_sft_run_respects_dataset_prefix_override(tmp_path):
+    storage = FakeStorageClient()
+    upload_sft_run(
+        train=_write_dataset(tmp_path, "train.jsonl", [_row()]),
+        run_name="ignored-for-paths",
+        dataset_prefix="datasets/custom/place",
+        storage_client=storage,  # type: ignore[arg-type]
+    )
+
+    assert [key for key, _ in storage.uploads] == ["datasets/custom/place/train.jsonl"]
+
+
+def test_upload_sft_run_rejects_unsafe_run_name(tmp_path):
+    storage = FakeStorageClient()
+    with pytest.raises(ValueError, match="Invalid storage path segment"):
+        upload_sft_run(
+            train=_write_dataset(tmp_path, "train.jsonl", [_row()]),
+            run_name="bad name?",
+            storage_client=storage,  # type: ignore[arg-type]
+        )
+
+    assert storage.uploads == []
+
+
+# ---------------------------------------------------------------------------
+# Enforcement: refusal happens before any storage mutation
+# ---------------------------------------------------------------------------
+
+
+def test_upload_sft_run_refuses_schema_invalid_rows_before_any_upload(tmp_path):
+    """A row that fails the schema stops the upload with nothing written."""
+    storage = FakeStorageClient()
+    # No assistant turn — validate_row reports an error-severity issue.
+    invalid = {"messages": [{"role": "user", "content": "unanswered"}]}
+
+    with pytest.raises(SftDatasetInvalidError) as exc_info:
+        upload_sft_run(
+            train=_write_dataset(tmp_path, "train.jsonl", [invalid]),
+            run_name="invalid-rows",
+            storage_client=storage,  # type: ignore[arg-type]
+        )
+
+    assert storage.uploads == []
+    assert not exc_info.value.report.ok
+    assert any(issue.severity == "error" for issue in exc_info.value.report.issues)
+
+
+def test_upload_sft_run_refuses_partially_loaded_dataset_before_any_upload(tmp_path):
+    """A file with one unparseable line never uploads its readable rows."""
+    storage = FakeStorageClient()
+    path = tmp_path / "train.jsonl"
+    path.write_text(json.dumps(_row()) + "\n{ not json\n", encoding="utf-8")
+
+    with pytest.raises(SftDatasetInvalidError) as exc_info:
+        upload_sft_run(
+            train=load_sft_dataset(path),
+            run_name="partial",
+            storage_client=storage,  # type: ignore[arg-type]
+        )
+
+    assert storage.uploads == []
+    assert any("invalid JSON" in issue.message for issue in exc_info.value.report.issues)
+
+
+def test_upload_sft_run_refuses_empty_training_data_before_any_upload(tmp_path):
+    storage = FakeStorageClient()
+
+    with pytest.raises(SftDatasetInvalidError, match="no rows") as exc_info:
+        upload_sft_run(
+            train=_write_dataset(tmp_path, "train.jsonl", []),
+            run_name="empty",
+            storage_client=storage,  # type: ignore[arg-type]
+        )
+
+    assert storage.uploads == []
+    assert exc_info.value.report.train_row_count == 0
+
+
+def test_upload_sft_run_refuses_a_hand_built_dataset_that_skipped_validation(tmp_path):
+    """The gate is defensive: an SftDataset assembled in code, never passed
+    through load_sft_dataset or validate_sft_dataset, is still refused."""
+    storage = FakeStorageClient()
+    hand_built = SftDataset(
+        path=str(tmp_path / "in-memory.jsonl"),
+        rows=[SftRow("in-memory.jsonl", 1, {"messages": [], "extra": 1})],
+        load_issues=[SftIssue("in-memory.jsonl", 2, "error", "truncated read")],
+    )
+
+    with pytest.raises(SftDatasetInvalidError):
+        upload_sft_run(
+            train=hand_built,
+            run_name="hand-built",
+            storage_client=storage,  # type: ignore[arg-type]
+        )
+
+    assert storage.uploads == []
+
+
+def test_upload_sft_run_refuses_before_constructing_a_storage_client(monkeypatch, tmp_path):
+    """With no storage_client passed, the refusal must still precede every
+    storage interaction — including building the client that would perform it."""
+    import castform.platform.training_run as training_run
+
+    def explode(*args, **kwargs):
+        raise AssertionError("StorageClient constructed before the validation gate")
+
+    monkeypatch.setattr(training_run, "StorageClient", explode)
+
+    with pytest.raises(SftDatasetInvalidError):
+        upload_sft_run(
+            train=_write_dataset(tmp_path, "train.jsonl", []),
+            run_name="no-client",
+        )
+
+
+def test_upload_sft_run_refusal_names_the_blocking_issues(tmp_path):
+    """The message is actionable on its own — a caller that only prints the
+    exception still learns which line to fix."""
+    storage = FakeStorageClient()
+    invalid = {"messages": [{"role": "user", "content": "unanswered"}]}
+
+    with pytest.raises(SftDatasetInvalidError) as exc_info:
+        upload_sft_run(
+            train=_write_dataset(tmp_path, "train.jsonl", [_row(), invalid]),
+            run_name="named-issues",
+            storage_client=storage,  # type: ignore[arg-type]
+        )
+
+    message = str(exc_info.value)
+    assert "named-issues" in message
+    assert "train.jsonl:2" in message
+    assert "no trained assistant turn" in message
+
+
+def test_upload_sft_run_refuses_an_invalid_eval_split_before_any_upload(tmp_path):
+    """A valid train split does not buy a pass for a broken eval split — and
+    the train file must not be uploaded on its own."""
+    storage = FakeStorageClient()
+    invalid = {"messages": [{"role": "user", "content": "unanswered"}]}
+
+    with pytest.raises(SftDatasetInvalidError):
+        upload_sft_run(
+            train=_write_dataset(tmp_path, "train.jsonl", [_row()]),
+            eval=_write_dataset(tmp_path, "eval.jsonl", [invalid]),
+            run_name="bad-eval",
+            storage_client=storage,  # type: ignore[arg-type]
+        )
+
+    assert storage.uploads == []
+
+
+def test_upload_sft_run_accepts_an_empty_eval_split(tmp_path):
+    """An empty eval dataset is a notice, not an error — it must not block."""
+    storage = FakeStorageClient()
+    result = upload_sft_run(
+        train=_write_dataset(tmp_path, "train.jsonl", [_row()]),
+        eval=_write_dataset(tmp_path, "eval.jsonl", []),
+        run_name="empty-eval",
+        storage_client=storage,  # type: ignore[arg-type]
+    )
+
+    assert len(storage.uploads) == 2
+    assert result.eval_dataset_path is not None

--- a/packages/castform/tests/unit/platform/test_sft_run.py
+++ b/packages/castform/tests/unit/platform/test_sft_run.py
@@ -8,7 +8,13 @@ import json
 from pathlib import Path
 
 import pytest
-from benchmax.sft import SftDataset, SftIssue, SftRow, load_sft_dataset
+from benchmax.sft import (
+    SftDataset,
+    SftIssue,
+    SftRow,
+    SftSerializationError,
+    load_sft_dataset,
+)
 from castform.platform import (
     SftDatasetInvalidError,
     UploadedSftRun,
@@ -106,27 +112,52 @@ def test_upload_sft_run_uploads_nothing_for_eval_when_omitted(tmp_path):
     assert result.eval_dataset_path is None
 
 
+def _upload_prefix(tmp_path, train_rows: list[dict], eval_rows: list[dict] | None) -> str:
+    """Run an upload under a fixed run_name and return the dataset prefix used."""
+    storage = FakeStorageClient()
+    upload_sft_run(
+        train=_write_dataset(tmp_path, "train.jsonl", train_rows),
+        eval=(
+            None
+            if eval_rows is None
+            else _write_dataset(tmp_path, "eval.jsonl", eval_rows)
+        ),
+        run_name="same-name",
+        storage_client=storage,  # type: ignore[arg-type]
+    )
+    return storage.uploads[0][0].rsplit("/", 1)[0]
+
+
 def test_upload_sft_run_hashes_train_only_and_train_plus_eval_differently(tmp_path):
     """The prefix hash covers the bytes actually uploaded, so adding an eval
     split cannot land on top of an earlier train-only run."""
-    train = _write_dataset(tmp_path, "train.jsonl", [_row()])
-    eval_dataset = _write_dataset(tmp_path, "eval.jsonl", [_row("eval")])
+    train_only = _upload_prefix(tmp_path, [_row("a")], None)
+    with_eval = _upload_prefix(tmp_path, [_row("a")], [_row("b")])
 
-    train_only = FakeStorageClient()
-    upload_sft_run(
-        train=train,
-        run_name="same-name",
-        storage_client=train_only,  # type: ignore[arg-type]
-    )
-    with_eval = FakeStorageClient()
-    upload_sft_run(
-        train=train,
-        eval=eval_dataset,
-        run_name="same-name",
-        storage_client=with_eval,  # type: ignore[arg-type]
-    )
+    assert train_only != with_eval
 
-    assert train_only.uploads[0][0] != with_eval.uploads[0][0]
+
+def test_upload_sft_run_hashes_distinguish_how_rows_are_split(tmp_path):
+    """Canonical JSONL is newline-terminated per row, so concatenating the two
+    splits loses the boundary between them: [a]+[b] and [a, b]+nothing would
+    hash the same bytes. The prefix must depend on the partition too, or a
+    re-split run silently reuses another run's directory."""
+    split_across = _upload_prefix(tmp_path, [_row("a")], [_row("b")])
+    all_in_train = _upload_prefix(tmp_path, [_row("a"), _row("b")], None)
+
+    assert split_across != all_in_train
+
+
+def test_upload_sft_run_hashes_distinguish_absent_eval_from_empty_eval(tmp_path):
+    """eval=None uploads only train.jsonl; an empty eval dataset also uploads an
+    empty eval.jsonl. Sharing a prefix would leave a stale eval.jsonl in place
+    for a later train-only run."""
+    absent_eval = _upload_prefix(tmp_path, [_row("a"), _row("b")], None)
+    empty_eval = _upload_prefix(tmp_path, [_row("a"), _row("b")], [])
+    split_across = _upload_prefix(tmp_path, [_row("a")], [_row("b")])
+
+    assert absent_eval != empty_eval
+    assert split_across != empty_eval
 
 
 def test_upload_sft_run_uploads_canonical_jsonl_bytes(tmp_path):
@@ -239,6 +270,87 @@ def test_upload_sft_run_refuses_a_hand_built_dataset_that_skipped_validation(tmp
         )
 
     assert storage.uploads == []
+
+
+def _notice_only_load_issue_dataset(tmp_path) -> SftDataset:
+    """A dataset whose rows all validate, carrying one notice-severity load issue.
+
+    load_sft_dataset only emits error-severity load issues today, so the
+    notice-severity case has to be built by hand — it is exactly the case
+    report.ok does not catch, since report.ok counts error severity only.
+    """
+    return SftDataset(
+        path=str(tmp_path / "partial.jsonl"),
+        rows=[SftRow("partial.jsonl", 1, _row())],
+        load_issues=[SftIssue("partial.jsonl", 7, "notice", "stopped reading early")],
+    )
+
+
+def test_upload_sft_run_refuses_a_notice_severity_load_issue(tmp_path):
+    """A load issue blocks whatever its severity: the rows present may not be
+    the whole dataset. report.ok would pass this pair, so the refusal has to
+    come from the load-issue gate — and as the domain exception, not the
+    SftSerializationError canonical_jsonl would have raised later."""
+    storage = FakeStorageClient()
+
+    with pytest.raises(SftDatasetInvalidError) as exc_info:
+        upload_sft_run(
+            train=_notice_only_load_issue_dataset(tmp_path),
+            run_name="notice-load-issue",
+            storage_client=storage,  # type: ignore[arg-type]
+        )
+
+    assert not isinstance(exc_info.value, SftSerializationError)
+    assert storage.uploads == []
+    # The gate must not be the report.ok gate in disguise.
+    assert exc_info.value.report is not None
+    assert exc_info.value.report.ok
+    message = str(exc_info.value)
+    assert "partial.jsonl:7" in message
+    assert "stopped reading early" in message
+
+
+def test_upload_sft_run_refuses_a_notice_severity_load_issue_before_the_client(
+    monkeypatch, tmp_path
+):
+    """The notice-severity load issue must be refused before the client exists,
+    not deep inside serialization with a StorageClient already built."""
+    import castform.platform.training_run as training_run
+
+    def explode(*args, **kwargs):
+        raise AssertionError("StorageClient constructed before the validation gate")
+
+    monkeypatch.setattr(training_run, "StorageClient", explode)
+
+    with pytest.raises(SftDatasetInvalidError):
+        upload_sft_run(
+            train=_notice_only_load_issue_dataset(tmp_path),
+            run_name="notice-no-client",
+        )
+
+
+def test_upload_sft_run_refuses_a_notice_severity_load_issue_on_the_eval_split(tmp_path):
+    """The eval split's load issues are gated on the same terms as train's."""
+    storage = FakeStorageClient()
+
+    with pytest.raises(SftDatasetInvalidError):
+        upload_sft_run(
+            train=_write_dataset(tmp_path, "train.jsonl", [_row()]),
+            eval=_notice_only_load_issue_dataset(tmp_path),
+            run_name="notice-eval",
+            storage_client=storage,  # type: ignore[arg-type]
+        )
+
+    assert storage.uploads == []
+
+
+def test_upload_sft_run_empty_eval_file_carries_no_load_issues(tmp_path):
+    """Guards the load-issue gate against over-refusing: an empty eval file is
+    reported as a notice on the validation report, never as a load issue, so it
+    must stay uploadable."""
+    empty_eval = _write_dataset(tmp_path, "eval.jsonl", [])
+
+    assert empty_eval.load_issues == []
 
 
 def test_upload_sft_run_refuses_before_constructing_a_storage_client(monkeypatch, tmp_path):

--- a/packages/castform/tests/unit/test_cli_setup.py
+++ b/packages/castform/tests/unit/test_cli_setup.py
@@ -266,6 +266,67 @@ def test_setup_template_rag_force_overwrites(tmp_path):
     assert "CustomSearchEnv" in main_py and main_py != "MINE"
 
 
+def test_setup_template_sft_writes_dataset_project(tmp_path, monkeypatch):
+    """--template sft ships the env-less SFT main.py verbatim plus tiny chat-format
+    seed datasets at the shared train.jsonl / eval.jsonl destinations. There is no
+    env class and no reward, so no seed env test is written."""
+    monkeypatch.setattr(setup, "version", lambda distribution: "0.1.2")
+    assert setup._cmd_setup(_ns(tmp_path, template="sft")) == 0
+
+    packaged = (
+        Path(setup.__file__).parent / "scaffold" / "sft_main.py"
+    ).read_text()
+    assert (tmp_path / "main.py").read_text() == packaged  # written verbatim
+    assert not (tmp_path / "tests" / "test_env.py").exists()
+
+    for name in ("train.jsonl", "eval.jsonl"):
+        rows = _read_jsonl(tmp_path / name)
+        assert rows, name
+        for row in rows:
+            assert set(row) == {"messages"}
+            assert {m["role"] for m in row["messages"]} == {"user", "assistant"}
+
+    project = tomllib.loads((tmp_path / "pyproject.toml").read_text())
+    assert project["project"]["dependencies"] == [
+        "benchmax==0.1.2",
+        "castform==0.1.2",  # env-less: no rag extra
+    ]
+
+
+def test_setup_template_sft_seeds_match_the_template_inline_seed(tmp_path):
+    """The written seeds and `python main.py data` must produce the same rows —
+    otherwise regenerating the dataset from the template silently changes it."""
+    assert setup._cmd_setup(_ns(tmp_path, template="sft")) == 0
+    module = load_module(tmp_path / "main.py")
+    assert _read_jsonl(tmp_path / "train.jsonl") == module._SEED_TRAIN
+    assert _read_jsonl(tmp_path / "eval.jsonl") == module._SEED_EVAL
+    # the multimodal demonstration stays opt-in data inside the template only
+    assert module._SEED_MULTIMODAL not in module._SEED_TRAIN
+    assert "image_url" not in (tmp_path / "train.jsonl").read_text()
+
+
+def test_setup_template_sft_validates_day_one(tmp_path):
+    """The scaffolded project passes its local validate stage with zero edits."""
+    assert setup._cmd_setup(_ns(tmp_path, template="sft")) == 0
+    done = subprocess.run(
+        [sys.executable, "main.py", "validate"],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+    )
+    assert done.returncode == 0, done.stderr
+    assert "validate: pass" in done.stdout
+
+
+def test_setup_template_sft_refuses_existing_main_py(tmp_path, capsys):
+    """The hollow-pass guard covers the sft template too: an existing main.py and
+    no --force must fail loudly and leave the file untouched."""
+    (tmp_path / "main.py").write_text("MINE")
+    assert setup._cmd_setup(_ns(tmp_path, template="sft")) == 1
+    assert (tmp_path / "main.py").read_text() == "MINE"  # untouched
+    assert "already exists" in capsys.readouterr().err
+
+
 def test_setup_force_replaces_main_py_but_keeps_datasets(tmp_path):
     """--force clears the main.py overwrite guard but must NOT clobber datasets —
     real project-generated output is never overwritten by the placeholder seed."""

--- a/packages/castform/tests/unit/test_cli_setup.py
+++ b/packages/castform/tests/unit/test_cli_setup.py
@@ -293,6 +293,32 @@ def test_setup_template_sft_writes_dataset_project(tmp_path, monkeypatch):
     ]
 
 
+def test_setup_template_sft_emits_env_less_onboarding(tmp_path, capsys):
+    """SFT setup copy matches its env-less, capability-first runtime."""
+    assert setup._cmd_setup(_ns(tmp_path, template="sft")) == 0
+    terminal = capsys.readouterr().out.lower()
+    getting_started = " ".join(
+        (tmp_path / "GETTING_STARTED.md").read_text().lower().split()
+    )
+
+    assert "prepare an sft dataset" in terminal
+    assert "capability check · currently stops before upload" in terminal
+    assert "project template" in terminal
+    assert "env template" not in terminal
+    assert "reasonable environment" not in terminal
+    assert "local group of 2" not in terminal
+
+    assert "env-less supervised fine-tuning dataset" in getting_started
+    assert "capability check; currently stops before upload" in getting_started
+    assert "first step is the platform capability check" in getting_started
+    assert "build a castform environment" not in getting_started
+    assert "general environment" not in getting_started
+    assert "sibling" not in getting_started
+    assert "validate, confirm cost, upload and launch" not in getting_started
+    for marker in ("rag:", "rl:", "sft:"):
+        assert marker not in getting_started
+
+
 def test_setup_template_sft_seeds_match_the_template_inline_seed(tmp_path):
     """The written seeds and `python main.py data` must produce the same rows —
     otherwise regenerating the dataset from the template silently changes it."""

--- a/packages/castform/tests/unit/test_doc_refs.py
+++ b/packages/castform/tests/unit/test_doc_refs.py
@@ -1,0 +1,365 @@
+"""Keep the shipped docs and agent skills honest about the real code surface.
+
+Every check here resolves what the prose claims against the live tree — imports
+the symbols it names, parses the snippets it shows, and reads the seed
+template's own argparse/config surface — so a rename or a moved boundary breaks
+the docs here rather than in a user's project. The last test is the inverse
+guard: names from the pre-two-package layout must not reappear in the docs.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import re
+from pathlib import Path
+
+import castform.cli.scaffold as scaffold_pkg
+import pytest
+from castform.cli import build_parser, setup
+
+from ._scaffold import discover_env_class, load_module
+
+_SCAFFOLD_DIR = Path(scaffold_pkg.__file__).parent
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+_SKILL_NAMES = (
+    "design-environment",
+    "generate-data",
+    "verify-environment",
+    "launch-run",
+    "view-progress",
+)
+
+# The doc surface this slice owns: the published package guides plus everything
+# `castform setup` copies into a scaffolded project.
+DOC_FILES = {
+    "readme": _REPO_ROOT / "README.md",
+    "benchmax-readme": _REPO_ROOT / "packages" / "benchmax" / "README.md",
+    "castform-readme": _REPO_ROOT / "packages" / "castform" / "README.md",
+    "scaffold-claude": _SCAFFOLD_DIR / "CLAUDE.md",
+    "scaffold-starter": _SCAFFOLD_DIR / "STARTER.md",
+    **{f"skill-{name}": _SCAFFOLD_DIR / "skills" / name / "SKILL.md" for name in _SKILL_NAMES},
+}
+
+# (doc key, text the doc must contain, ``module:attr.path`` it must resolve to).
+# The literal half keeps a doc from quietly dropping a reference; the dotted
+# half keeps the reference pointing at something that still exists.
+SYMBOL_REFS = [
+    ("benchmax-readme", "benchmax.sft", "benchmax:sft"),
+    ("benchmax-readme", "SftSerializationError", "benchmax.sft:SftSerializationError"),
+    ("benchmax-readme", "benchmax.envs.base.content", "benchmax.envs.base:content"),
+    ("benchmax-readme", "message_text", "benchmax.envs.base.content:message_text"),
+    ("benchmax-readme", "content_preview", "benchmax.envs.base.content:content_preview"),
+    ("benchmax-readme", "iter_image_refs", "benchmax.envs.base.content:iter_image_refs"),
+    (
+        "benchmax-readme",
+        "image_to_data_uri",
+        "benchmax.envs.base.content:image_to_data_uri",
+    ),
+    ("castform-readme", "upload_sft_run", "castform.platform:upload_sft_run"),
+    (
+        "castform-readme",
+        "launch_sft_run",
+        "castform.platform.client:TrainerClient.launch_sft_run",
+    ),
+    (
+        "castform-readme",
+        "castform.platform.client.SFT_LAUNCH_SUPPORTED",
+        "castform.platform.client:SFT_LAUNCH_SUPPORTED",
+    ),
+    (
+        "scaffold-claude",
+        "castform.platform.client.SFT_LAUNCH_SUPPORTED",
+        "castform.platform.client:SFT_LAUNCH_SUPPORTED",
+    ),
+    ("scaffold-claude", "upload_sft_run", "castform.platform:upload_sft_run"),
+    (
+        "scaffold-claude",
+        "TrainerClient.launch_sft_run",
+        "castform.platform.client:TrainerClient.launch_sft_run",
+    ),
+    ("scaffold-claude", "dump_bundle", "benchmax.bundle:dump_bundle"),
+    ("skill-design-environment", "benchmax.sft", "benchmax:sft"),
+    (
+        "skill-design-environment",
+        "benchmax.envs.base.content",
+        "benchmax.envs.base:content",
+    ),
+    (
+        "skill-design-environment",
+        "message_text",
+        "benchmax.envs.base.content:message_text",
+    ),
+    (
+        "skill-design-environment",
+        "content_preview",
+        "benchmax.envs.base.content:content_preview",
+    ),
+    (
+        "skill-design-environment",
+        "iter_image_refs",
+        "benchmax.envs.base.content:iter_image_refs",
+    ),
+    (
+        "skill-design-environment",
+        "image_to_data_uri",
+        "benchmax.envs.base.content:image_to_data_uri",
+    ),
+    ("skill-generate-data", "load_sft_dataset", "benchmax.sft:load_sft_dataset"),
+    ("skill-generate-data", "validate_sft_dataset", "benchmax.sft:validate_sft_dataset"),
+    ("skill-generate-data", "canonical_jsonl", "benchmax.sft:canonical_jsonl"),
+    (
+        "skill-generate-data",
+        "castform.traces.TracesPipeline",
+        "castform.traces:TracesPipeline",
+    ),
+    (
+        "skill-verify-environment",
+        "benchmax.sft.load_sft_dataset",
+        "benchmax.sft:load_sft_dataset",
+    ),
+    (
+        "skill-verify-environment",
+        "validate_sft_dataset",
+        "benchmax.sft:validate_sft_dataset",
+    ),
+    ("skill-launch-run", "upload_sft_run", "castform.platform:upload_sft_run"),
+    (
+        "skill-launch-run",
+        "TrainerClient.launch_sft_run",
+        "castform.platform.client:TrainerClient.launch_sft_run",
+    ),
+    (
+        "skill-launch-run",
+        "castform.platform.client.SFT_LAUNCH_SUPPORTED",
+        "castform.platform.client:SFT_LAUNCH_SUPPORTED",
+    ),
+]
+
+# Names from the pre-two-package layout (and from the CLI verbs the restructure
+# deleted). Each maps to what replaced it, so a failure says where to go.
+STALE_REFERENCES = {
+    r"castform validate": "the scaffold's `python main.py validate` stage",
+    r"castform launch": "the scaffold's `python main.py launch` stage",
+    r"castform data ": "the `castform.traces` / `castform.rag` libraries",
+    r"cli/launch\.py": "the per-template scaffold `main.py`",
+    r"--set model=": "a `LAUNCH_CONFIG` key",
+    r"(?<!-)--model\b": "a `LAUNCH_CONFIG` key",
+    r"--allow-experimental-weights": "`LAUNCH_CONFIG['allow_experimental_weights']`",
+    r"PLATFORM_API_KEY": "CASTFORM_API_KEY",
+    r"benchmax\.platform": "castform.platform",
+    r"benchmax\.cli": "castform.cli",
+    r"train_dataset\.jsonl": "train.jsonl",
+    r"eval_dataset\.jsonl": "eval.jsonl",
+}
+
+_FENCE_RE = re.compile(r"^```(\w+)\n(.*?)^```", re.DOTALL | re.MULTILINE)
+
+
+def _read(key: str) -> str:
+    path = DOC_FILES[key]
+    assert path.is_file(), f"documented file is missing: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _fences(text: str, lang: str) -> list[str]:
+    return [body for fence_lang, body in _FENCE_RE.findall(text) if fence_lang == lang]
+
+
+def _section(text: str, heading: str) -> str:
+    """The body of a ``## heading`` section, up to the next same-level heading."""
+    start = text.index(f"## {heading}")
+    rest = text[start:]
+    following = re.search(r"^## ", rest[3:], re.MULTILINE)
+    return rest if following is None else rest[: following.start() + 3]
+
+
+def _resolve(dotted: str):
+    """Resolve a ``module:attr.path`` reference, or fail with what broke."""
+    module_name, _, attr_path = dotted.partition(":")
+    try:
+        obj = importlib.import_module(module_name)
+    except ImportError as error:  # pragma: no cover - only on a real regression
+        raise AssertionError(f"documented module {module_name!r} is gone: {error}")
+    for attr in filter(None, attr_path.split(".")):
+        assert hasattr(obj, attr), f"documented name {dotted!r} lost its {attr!r}"
+        obj = getattr(obj, attr)
+    return obj
+
+
+@pytest.fixture(scope="module")
+def sft_seed():
+    return load_module(_SCAFFOLD_DIR / "sft_main.py")
+
+
+@pytest.mark.parametrize(
+    ("doc", "mention", "dotted"),
+    SYMBOL_REFS,
+    ids=[f"{doc}:{dotted}" for doc, _mention, dotted in SYMBOL_REFS],
+)
+def test_documented_symbols_are_named_and_resolvable(doc, mention, dotted):
+    assert mention in _read(doc), f"{DOC_FILES[doc]} no longer mentions {mention!r}"
+    _resolve(dotted)
+
+
+@pytest.mark.parametrize("doc", sorted(DOC_FILES))
+def test_documented_python_snippets_parse_and_their_imports_resolve(doc):
+    snippets = _fences(_read(doc), "python")
+    for snippet in snippets:
+        tree = ast.parse(snippet)  # a doc snippet that cannot parse is a doc bug
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom) or node.module is None:
+                continue
+            for alias in node.names:
+                _resolve(f"{node.module}:{alias.name}")
+
+
+def test_documented_sft_row_format_loads_and_validates(tmp_path):
+    """The `messages` row the generate-data skill shows must survive the real
+    loader and validator — not merely look like the schema."""
+    from benchmax.sft import canonical_jsonl, load_sft_dataset, validate_sft_dataset
+
+    section = _section(_read("skill-generate-data"), "SFT — the `messages` row format")
+    rows = _fences(section, "jsonl")
+    assert rows, "the SFT section no longer shows a `messages` row"
+
+    path = tmp_path / "train.jsonl"
+    path.write_text("".join(rows), encoding="utf-8")
+    dataset = load_sft_dataset(path)
+    report = validate_sft_dataset(dataset)
+    assert report.ok, [issue.message for issue in report.issues]
+    assert canonical_jsonl(dataset)
+
+
+def test_documented_sft_snippets_run(tmp_path, monkeypatch, sft_seed):
+    """Run the generate-data SFT snippets rather than only resolving their
+    imports, so a stale call — a renamed function, a dropped argument — fails
+    here. Only this section's snippets are self-contained enough to execute;
+    the launch-side ones would need a live platform."""
+    import base64
+
+    monkeypatch.chdir(tmp_path)
+    section = _section(_read("skill-generate-data"), "SFT — the `messages` row format")
+    Path("train.jsonl").write_text("".join(_fences(section, "jsonl")), encoding="utf-8")
+    _, _, encoded = sft_seed._TINY_PNG_DATA_URI.partition("base64,")
+    Path("figure.png").write_bytes(base64.b64decode(encoded))
+
+    namespace: dict = {}
+    for snippet in _fences(section, "python"):
+        exec(compile(snippet, "<generate-data SKILL.md>", "exec"), namespace)
+    assert namespace["report"].ok
+    assert namespace["image_url"].startswith("data:image/png;base64,")
+
+
+def test_documented_multimodal_row_shape_survives_canonicalization(tmp_path):
+    """design-environment claims a content-part list is preserved byte-for-byte
+    through canonicalization. Check that against the seed's own multimodal row."""
+    import json
+
+    from benchmax.sft import canonical_jsonl, load_sft_dataset
+
+    seed = load_module(_SCAFFOLD_DIR / "sft_main.py")
+    path = tmp_path / "train.jsonl"
+    path.write_text(json.dumps(seed._SEED_MULTIMODAL) + "\n", encoding="utf-8")
+
+    round_tripped = json.loads(canonical_jsonl(load_sft_dataset(path)).splitlines()[0])
+    assert round_tripped["messages"] == seed._SEED_MULTIMODAL["messages"]
+
+
+def test_documented_seed_stages_and_flags_exist(sft_seed, capsys):
+    """Every stage and flag the docs spell out is on the seed's real parser."""
+    with pytest.raises(SystemExit) as exit_info:
+        sft_seed.main(["--help"])
+    assert exit_info.value.code == 0
+    help_text = capsys.readouterr().out
+
+    documented = _read("scaffold-claude") + _read("skill-verify-environment")
+    documented += _read("skill-launch-run") + _read("scaffold-starter")
+    for token in ("data", "validate", "launch", "--force", "-y", "--yes"):
+        assert token in help_text, f"the sft seed no longer accepts {token!r}"
+        assert token in documented, f"the docs no longer mention {token!r}"
+
+
+def test_documented_dataset_filenames_match_the_seed(sft_seed):
+    assert (sft_seed.TRAIN_FILE, sft_seed.EVAL_FILE) == ("train.jsonl", "eval.jsonl")
+    for name in (sft_seed.TRAIN_FILE, sft_seed.EVAL_FILE):
+        assert name in _read("skill-verify-environment")
+
+
+def test_documented_validate_stage_exits_zero_on_the_seed_dataset(sft_seed, tmp_path, monkeypatch):
+    """verify-environment promises `validate` exits 0 on a valid dataset."""
+    monkeypatch.chdir(tmp_path)
+    sft_seed.generate_data()
+    assert sft_seed.main(["validate"]) == 0
+
+
+def test_documented_config_keys_match_the_seed(sft_seed):
+    """launch-run and verify-environment name specific config keys and split
+    them into wire args vs locally-resolved ones. Both halves are checkable."""
+    from benchmax.sft import sft_validate_kwargs
+
+    assert sft_seed.LAUNCH_CONFIG["training_mode"] == "sft"
+    assert sft_seed._LAUNCH_CONFIG_RESERVED == frozenset(
+        {"type", "name", "allow_experimental_weights"}
+    )
+    launch_doc = _read("skill-launch-run")
+    for key in sorted(sft_seed._LAUNCH_CONFIG_RESERVED) + ["training_mode", "model"]:
+        assert key in launch_doc, f"launch-run no longer documents {key!r}"
+
+    knobs = {"max_seq_len": 4096, "max_row_bytes": 1 << 20}
+    assert sft_validate_kwargs(knobs) == knobs
+    verify_doc = _read("skill-verify-environment")
+    assert all(knob in verify_doc for knob in knobs)
+
+
+def test_documented_rl_versus_sft_marker_is_real(sft_seed):
+    """CLAUDE.md routes on `LAUNCH_CONFIG["training_mode"]` plus the presence of
+    a `BaseEnv` subclass. Both templates must actually differ that way."""
+    from benchmax.envs import Environment
+
+    assert 'LAUNCH_CONFIG["training_mode"] == "sft"' in _read("scaffold-claude")
+    assert not [
+        value
+        for value in vars(sft_seed).values()
+        if isinstance(value, type) and issubclass(value, Environment)
+    ]
+    for template in ("generic_main.py", "rag_main.py"):
+        rl_seed = load_module(_SCAFFOLD_DIR / template)
+        assert "training_mode" not in rl_seed.LAUNCH_CONFIG
+        assert discover_env_class(rl_seed) is not None
+
+
+def test_documented_setup_template_choices_are_registered():
+    parser = build_parser()
+    (subparsers,) = [
+        action
+        for action in parser._actions
+        if hasattr(action, "choices") and isinstance(action.choices, dict)
+    ]
+    template = subparsers.choices["setup"]._option_string_actions["--template"]
+    assert "sft" in template.choices
+    assert "castform setup --template sft" in _read("scaffold-claude")
+
+
+def test_documented_skill_files_exist():
+    """The scaffold docs point the agent at per-stage skills by path; every
+    referenced skill must be packaged and registered with setup."""
+    referenced = set()
+    for key in ("scaffold-claude", "scaffold-starter"):
+        referenced |= set(re.findall(r"\.claude/skills/([\w-]+)/SKILL\.md", _read(key)))
+    assert referenced, "the scaffold docs no longer point at any skill"
+    for name in referenced:
+        assert name in setup._SKILLS
+        assert (_SCAFFOLD_DIR / "skills" / name / "SKILL.md").is_file()
+
+
+@pytest.mark.parametrize("doc", sorted(DOC_FILES))
+def test_docs_carry_no_stale_references(doc):
+    text = _read(doc)
+    hits = [
+        f"{pattern!r} (use {replacement})"
+        for pattern, replacement in STALE_REFERENCES.items()
+        if re.search(pattern, text)
+    ]
+    assert not hits, f"{DOC_FILES[doc]} carries stale references: {hits}"

--- a/packages/castform/tests/unit/test_scaffold_sft_runner.py
+++ b/packages/castform/tests/unit/test_scaffold_sft_runner.py
@@ -1,0 +1,334 @@
+"""The sft seed's `main.py` runnable stage-runner: local validate, the two
+launch gates, and the validate → upload → submit ordering that reaches the
+wire.
+
+Tested against `sft_main.py` directly rather than through `castform setup`, so
+a template regression is caught here and not only in the setup gate. The wire
+half runs a REAL `TrainerClient` over a mock transport, so the asserted body is
+the one that would be posted.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import castform.cli.scaffold as scaffold_pkg
+import httpx
+import pytest
+from castform.platform import client as client_module
+from castform.platform.client import TrainerClient
+from castform.platform.training_run import upload_sft_run
+
+from ._scaffold import load_module
+
+_SFT_SEED = Path(scaffold_pkg.__file__).parent / "sft_main.py"
+
+
+@pytest.fixture
+def mod(tmp_path, monkeypatch):
+    """Load the sft seed as a module (its `__main__` block does not fire) with
+    the cwd pointed at an empty project dir."""
+    monkeypatch.chdir(tmp_path)
+    module = load_module(_SFT_SEED)
+    monkeypatch.setattr(module, "ensure_session", lambda *a, **k: None)
+    return module
+
+
+def _row(text: str = "hello") -> dict:
+    return {
+        "messages": [
+            {"role": "user", "content": text},
+            {"role": "assistant", "content": f"re: {text}"},
+        ]
+    }
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+
+
+class FakeStorageClient:
+    """In-memory StorageClient stand-in. Records calls; returns synthetic blob paths."""
+
+    def __init__(self):
+        self.uploads: list[tuple[str, bytes]] = []
+
+    def upload_local_file(
+        self, path: str, file_path: Path, *, expires_in_minutes: int | None = None
+    ) -> dict:
+        self.uploads.append((path, Path(file_path).read_bytes()))
+        return {"blobPath": f"blob://{path}"}
+
+
+# ── import safety + config shape ───────────────────────────────────────────────
+
+
+def test_import_defines_stages_without_running(mod, tmp_path):
+    """Loading the seed defines the runner but executes NO stage (the `__main__`
+    block is import-safe)."""
+    assert all(hasattr(mod, n) for n in ("main", "generate_data", "validate", "launch"))
+    assert not (tmp_path / "train.jsonl").exists()
+
+
+def test_dataset_filenames_match_setups_destinations(mod):
+    """`castform setup` writes the seed data to these exact names."""
+    assert (mod.TRAIN_FILE, mod.EVAL_FILE) == ("train.jsonl", "eval.jsonl")
+
+
+def test_training_mode_is_a_launch_config_key(mod):
+    """The mode is a config key, not a flag — the run reproduces from this file."""
+    assert mod.LAUNCH_CONFIG["training_mode"] == "sft"
+
+
+def test_reserved_key_filter_keeps_the_wire_keys(mod):
+    """The local-only keys are stripped; `training_mode` and the optional
+    per-run `model` must survive — the server reads both."""
+    mod.LAUNCH_CONFIG["model"] = "Qwen/Qwen3.5-4B"
+    mod.LAUNCH_CONFIG["type"] = "simple"
+    mod.LAUNCH_CONFIG["name"] = "custom-run"
+    mod.LAUNCH_CONFIG["allow_experimental_weights"] = True
+
+    args = mod._launcher_args()
+
+    assert args["training_mode"] == "sft"
+    assert args["model"] == "Qwen/Qwen3.5-4B"
+    assert args["num_epochs"] == mod.LAUNCH_CONFIG["num_epochs"]
+    assert not {"type", "name", "allow_experimental_weights"} & set(args)
+
+
+def test_launcher_args_refuses_a_foreign_training_mode(mod):
+    """`launch_sft_run` would overwrite it; refuse instead of silently ignoring."""
+    mod.LAUNCH_CONFIG["training_mode"] = "rl"
+    with pytest.raises(mod.SftConfigError, match="training_mode"):
+        mod._launcher_args()
+
+
+# ── validate stage: local-only, and its exit code ──────────────────────────────
+
+
+def test_validate_passes_on_the_seed_rows(mod, tmp_path, capsys):
+    """The shipped seed must validate on day one: `main.py` → data → validate."""
+    assert mod.main([]) == 0
+    assert "validate: pass" in capsys.readouterr().out
+    assert (tmp_path / "train.jsonl").exists()
+
+
+def test_validate_exits_1_on_invalid_rows(mod, tmp_path, capsys):
+    """A schema-invalid row is a hard stop — an agent or CI cannot read a broken
+    dataset as success."""
+    _write_jsonl(tmp_path / "train.jsonl", [{"messages": [{"role": "user"}]}])
+
+    assert mod.main(["validate"]) == 1
+    assert "validate: fail" in capsys.readouterr().out
+
+
+def test_validate_exits_1_on_malformed_json(mod, tmp_path):
+    (tmp_path / "train.jsonl").write_text("{not json\n", encoding="utf-8")
+    assert mod.main(["validate"]) == 1
+
+
+def test_validate_makes_no_platform_call(mod, tmp_path, monkeypatch):
+    """SFT validate is a local dataset check — no rollout, no credential, no HTTP."""
+    _write_jsonl(tmp_path / "train.jsonl", [_row()])
+    monkeypatch.setattr(
+        mod,
+        "ensure_session",
+        lambda *a, **k: pytest.fail("validate requested a login"),
+    )
+    monkeypatch.setattr(
+        mod, "TrainerClient", lambda *a, **k: pytest.fail("validate opened a client")
+    )
+
+    assert mod.main(["validate"]) == 0
+
+
+def test_generate_data_refuses_eval_without_train(mod, tmp_path):
+    """eval-without-train is a corrupted project, not a first run."""
+    _write_jsonl(tmp_path / "eval.jsonl", [_row()])
+    with pytest.raises(mod.SftScaffoldError):
+        mod.generate_data()
+    assert mod.main(["data"]) == 1  # surfaced as a clean exit code, not a traceback
+
+
+# ── launch gates ───────────────────────────────────────────────────────────────
+
+
+def _forbid_platform_calls(mod, monkeypatch) -> None:
+    """Turn any upload or launch into a test failure."""
+    monkeypatch.setattr(
+        mod,
+        "upload_sft_run",
+        lambda **kw: pytest.fail("uploaded behind a closed gate"),
+    )
+    monkeypatch.setattr(
+        mod,
+        "TrainerClient",
+        lambda *a, **k: pytest.fail("opened a trainer client behind a closed gate"),
+    )
+    monkeypatch.setattr(
+        "builtins.input", lambda *a: pytest.fail("prompted behind a closed gate")
+    )
+
+
+def test_sft_launch_capability_is_still_off():
+    """Pins the inert state the whole re-port merges in: the platform does not
+    accept env-less sft runs yet."""
+    assert client_module.SFT_LAUNCH_SUPPORTED is False
+
+
+def test_real_capability_false_blocks_before_any_upload_or_post(
+    mod, tmp_path, monkeypatch, capsys
+):
+    """With the REAL flag (False): exit 1, zero upload, zero POST."""
+    _write_jsonl(tmp_path / "train.jsonl", [_row()])
+    _write_jsonl(tmp_path / "eval.jsonl", [_row("eval")])
+    _forbid_platform_calls(mod, monkeypatch)
+
+    assert mod.launch(assume_yes=True) is None
+    assert mod.main(["launch"]) == 1
+    assert "SFT_LAUNCH_SUPPORTED is False" in capsys.readouterr().err
+
+
+def test_launch_blocked_by_failing_validate(mod, tmp_path, monkeypatch, capsys):
+    _write_jsonl(tmp_path / "train.jsonl", [{"messages": []}])
+    _forbid_platform_calls(mod, monkeypatch)
+    monkeypatch.setattr(client_module, "SFT_LAUNCH_SUPPORTED", True)
+
+    assert mod.launch(assume_yes=True) is None
+    assert "validate gate failed" in capsys.readouterr().err
+
+
+def test_launch_blocked_by_the_weight_gate(mod, tmp_path, monkeypatch, capsys):
+    """A weight-bearing dataset validates fine but is a separate capability."""
+    weighted = {
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello", "weight": 1},
+        ]
+    }
+    _write_jsonl(tmp_path / "train.jsonl", [weighted])
+    _forbid_platform_calls(mod, monkeypatch)
+    monkeypatch.setattr(client_module, "SFT_LAUNCH_SUPPORTED", True)
+
+    assert mod.launch(assume_yes=True) is None
+    assert "allow_experimental_weights" in capsys.readouterr().err
+
+
+def test_weight_gate_rejects_a_non_bool_override(mod, tmp_path, monkeypatch):
+    """`"false"` is truthy in Python — a typo must fail loudly, not open the gate."""
+    _write_jsonl(
+        tmp_path / "train.jsonl",
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "hello", "weight": 1},
+                ]
+            }
+        ],
+    )
+    _forbid_platform_calls(mod, monkeypatch)
+    monkeypatch.setattr(client_module, "SFT_LAUNCH_SUPPORTED", True)
+    mod.LAUNCH_CONFIG["allow_experimental_weights"] = "false"
+
+    assert mod.main(["launch"]) == 1
+
+
+# ── capability-true path: validate → upload → submit, and the wire body ────────
+
+
+def _stub_launchable(mod, monkeypatch) -> tuple[list[str], dict]:
+    """Open the capability gate and record the call order plus the posted body.
+
+    Real `upload_sft_run` (over a fake storage client) and a real
+    `TrainerClient` (over a mock transport) — only the I/O edges are faked.
+    """
+    monkeypatch.setattr(client_module, "SFT_LAUNCH_SUPPORTED", True)
+    order: list[str] = []
+    captured: dict = {}
+    storage = FakeStorageClient()
+
+    real_validate = mod.validate_sft_dataset
+
+    def recording_validate(*args, **kwargs):
+        order.append("validate")
+        return real_validate(*args, **kwargs)
+
+    def recording_upload(**kwargs):
+        order.append("upload")
+        return upload_sft_run(**kwargs, storage_client=storage)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        order.append("submit")
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content.decode())
+        return httpx.Response(200, json={"runId": "sft-run-1"})
+
+    def make_client() -> TrainerClient:
+        client = TrainerClient(api_key="test-key", base_url="https://example.invalid")
+        client._http_client = httpx.Client(
+            base_url="https://example.invalid",
+            transport=httpx.MockTransport(handler),
+        )
+        return client
+
+    monkeypatch.setattr(mod, "validate_sft_dataset", recording_validate)
+    monkeypatch.setattr(mod, "upload_sft_run", recording_upload)
+    monkeypatch.setattr(mod, "TrainerClient", make_client)
+    captured["storage"] = storage
+    return order, captured
+
+
+def test_capability_true_runs_validate_then_upload_then_submit(
+    mod, tmp_path, monkeypatch
+):
+    _write_jsonl(tmp_path / "train.jsonl", [_row()])
+    _write_jsonl(tmp_path / "eval.jsonl", [_row("eval")])
+    order, captured = _stub_launchable(mod, monkeypatch)
+
+    assert mod.launch(assume_yes=True) == "sft-run-1"
+    assert order == ["validate", "upload", "submit"]
+    # both splits reached storage before the run was submitted
+    assert [key.rsplit("/", 1)[-1] for key, _ in captured["storage"].uploads] == [
+        "train.jsonl",
+        "eval.jsonl",
+    ]
+
+
+def test_capability_true_posts_nested_training_mode(mod, tmp_path, monkeypatch):
+    """The mode must sit inside `args` — a top-level one is silently ignored by
+    the platform and would fall through to an RL run."""
+    _write_jsonl(tmp_path / "train.jsonl", [_row()])
+    _write_jsonl(tmp_path / "eval.jsonl", [_row("eval")])
+    mod.LAUNCH_CONFIG["model"] = "Qwen/Qwen3.5-4B"
+    _, captured = _stub_launchable(mod, monkeypatch)
+
+    assert mod.launch(assume_yes=True) == "sft-run-1"
+    body = captured["body"]
+    assert "/train/runs/launch" in captured["url"]
+    assert "training_mode" not in body
+    assert body["args"]["training_mode"] == "sft"
+    assert body["args"]["model"] == "Qwen/Qwen3.5-4B"
+    assert body["args"]["train_dataset_path"].endswith("/train.jsonl")
+    assert body["args"]["eval_dataset_path"].endswith("/eval.jsonl")
+    assert body["name"] == mod._run_name()
+
+
+def test_train_only_project_omits_eval_from_the_wire(mod, tmp_path, monkeypatch):
+    _write_jsonl(tmp_path / "train.jsonl", [_row()])
+    _, captured = _stub_launchable(mod, monkeypatch)
+
+    assert mod.launch(assume_yes=True) == "sft-run-1"
+    assert "eval_dataset_path" not in captured["body"]["args"]
+    assert len(captured["storage"].uploads) == 1
+
+
+def test_launch_declined_at_confirm_uploads_nothing(mod, tmp_path, monkeypatch):
+    _write_jsonl(tmp_path / "train.jsonl", [_row()])
+    order, captured = _stub_launchable(mod, monkeypatch)
+    monkeypatch.setattr("builtins.input", lambda *a: "n")
+
+    assert mod.launch() is None
+    assert order == ["validate"]
+    assert not captured["storage"].uploads

--- a/packages/castform/tests/unit/test_scaffold_sft_runner.py
+++ b/packages/castform/tests/unit/test_scaffold_sft_runner.py
@@ -28,11 +28,14 @@ _SFT_SEED = Path(scaffold_pkg.__file__).parent / "sft_main.py"
 @pytest.fixture
 def mod(tmp_path, monkeypatch):
     """Load the sft seed as a module (its `__main__` block does not fire) with
-    the cwd pointed at an empty project dir."""
+    the cwd pointed at an empty project dir.
+
+    `ensure_session` is deliberately NOT neutralized here: a blanket no-op would
+    hide a login fired behind a closed gate. Tests that legitimately reach the
+    wire neutralize it themselves (`_stub_launchable`).
+    """
     monkeypatch.chdir(tmp_path)
-    module = load_module(_SFT_SEED)
-    monkeypatch.setattr(module, "ensure_session", lambda *a, **k: None)
-    return module
+    return load_module(_SFT_SEED)
 
 
 def _row(text: str = "hello") -> dict:
@@ -155,7 +158,12 @@ def test_generate_data_refuses_eval_without_train(mod, tmp_path):
 
 
 def _forbid_platform_calls(mod, monkeypatch) -> None:
-    """Turn any upload or launch into a test failure."""
+    """Turn any login, prompt, upload or launch into a test failure."""
+    monkeypatch.setattr(
+        mod,
+        "ensure_session",
+        lambda *a, **k: pytest.fail("requested a login behind a closed gate"),
+    )
     monkeypatch.setattr(
         mod,
         "upload_sft_run",
@@ -180,13 +188,20 @@ def test_sft_launch_capability_is_still_off():
 def test_real_capability_false_blocks_before_any_upload_or_post(
     mod, tmp_path, monkeypatch, capsys
 ):
-    """With the REAL flag (False): exit 1, zero upload, zero POST."""
+    """With the REAL flag (False): exit 1 and ZERO side effects — no login, no
+    prompt, no upload, no POST — from either entrypoint.
+
+    The login matters as much as the upload: `ensure_session` can open an
+    interactive device flow, so firing it before the capability check would make
+    an unlaunchable run demand credentials.
+    """
     _write_jsonl(tmp_path / "train.jsonl", [_row()])
     _write_jsonl(tmp_path / "eval.jsonl", [_row("eval")])
     _forbid_platform_calls(mod, monkeypatch)
 
     assert mod.launch(assume_yes=True) is None
     assert mod.main(["launch"]) == 1
+    assert mod.main(["launch", "-y"]) == 1
     assert "SFT_LAUNCH_SUPPORTED is False" in capsys.readouterr().err
 
 
@@ -246,8 +261,11 @@ def _stub_launchable(mod, monkeypatch) -> tuple[list[str], dict]:
     """
     monkeypatch.setattr(client_module, "SFT_LAUNCH_SUPPORTED", True)
     order: list[str] = []
-    captured: dict = {}
+    captured: dict = {"logins": 0}
     storage = FakeStorageClient()
+
+    def fake_ensure_session(*args, **kwargs):
+        captured["logins"] += 1
 
     real_validate = mod.validate_sft_dataset
 
@@ -273,6 +291,7 @@ def _stub_launchable(mod, monkeypatch) -> tuple[list[str], dict]:
         )
         return client
 
+    monkeypatch.setattr(mod, "ensure_session", fake_ensure_session)
     monkeypatch.setattr(mod, "validate_sft_dataset", recording_validate)
     monkeypatch.setattr(mod, "upload_sft_run", recording_upload)
     monkeypatch.setattr(mod, "TrainerClient", make_client)
@@ -289,6 +308,7 @@ def test_capability_true_runs_validate_then_upload_then_submit(
 
     assert mod.launch(assume_yes=True) == "sft-run-1"
     assert order == ["validate", "upload", "submit"]
+    assert captured["logins"] == 1  # the open path still authenticates
     # both splits reached storage before the run was submitted
     assert [key.rsplit("/", 1)[-1] for key, _ in captured["storage"].uploads] == [
         "train.jsonl",
@@ -332,3 +352,4 @@ def test_launch_declined_at_confirm_uploads_nothing(mod, tmp_path, monkeypatch):
     assert mod.launch() is None
     assert order == ["validate"]
     assert not captured["storage"].uploads
+    assert captured["logins"] == 0  # declining never costs a login


### PR DESCRIPTION
castform package slice from the sft multimodal report.\n\nstacks on the benchmax pr so the branch order stays linear.