### PR TITLE
Validate environment model contracts

### DIFF
--- a/examples/aime/README.md
+++ b/examples/aime/README.md
@@ -52,9 +52,9 @@ class AimeMiniSweHarborEnv(HarborEnv):
 
 harbor resolves the dataset, runs each rollout as a sandboxed trial, and settles the reward with the dataset's verifier.
 
-## harness
+## why the custom harness
 
-the agent harness lives in [`harness/`](harness/): the upstream mini-swe-agent installed offline — wheels are prefetched on the trial host and uploaded into the sandbox, so the sandbox itself needs no apt or PyPI access. it is the default, not a requirement. pass any `BundledHarborAgent` as `harness=` to run a different agent loop against the same dataset and verifier:
+this is operational hardening, not an AIME requirement. Harbor's stock mini-swe installer ran apt and PyPI setup in every fresh sandbox, taking 40–90 seconds and sometimes exceeding its setup timeout. the harness in [`harness/`](harness/) instead prefetches wheels on the trial host and installs them offline. use `TrialAgentConfig(name="mini-swe-agent")` when stock installation is reliable; pass a `BundledHarborAgent` only when a custom harness is actually needed:
 
 ```python
 env = AimeMiniSweHarborEnv(

--- a/examples/aime/main.py
+++ b/examples/aime/main.py
@@ -18,7 +18,6 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from benchmax.bundle import dump_bundle
 from benchmax.envs.environment import Environment
 from benchmax.envs.harbor import (
     BundledAgentSource,
@@ -36,6 +35,8 @@ from harbor import (
     TrialVerifierConfig,
 )
 from harness.aime_agent import MINI_SWE_AGENT_VERSION
+
+from benchmax.bundle import dump_bundle
 
 _HARNESS_SOURCE = BundledAgentSource.from_directory(
     Path(__file__).parent / "harness",
@@ -155,6 +156,14 @@ def launch(uploaded_assets: Any, *, assume_yes: bool) -> str | None:
 
 
 def _print_validation(report: Any) -> None:
+    for location in ("static", "local", "remote"):
+        warnings = getattr(report, f"{location}_warnings", {}) or {}
+        for item, messages in warnings.items():
+            values = messages if isinstance(messages, list) else [messages]
+            for message in values:
+                print(f"⚠️ {location} {item}: {message}")
+    for item, error in (getattr(report, "static_errors", {}) or {}).items():
+        print(f"❌ static {item}: {error}")
     for location in ("local", "remote"):
         outcomes = getattr(report, location)
         if outcomes is None:

--- a/examples/aime/main.py
+++ b/examples/aime/main.py
@@ -125,7 +125,7 @@ def validate(env: AimeMiniSweHarborEnv, uploaded_assets: Any) -> Any:
             validate_environment(
                 env,
                 model=VALIDATE_MODEL,
-                split="eval",
+                split="train",
                 base_dir=Path(tmp),
                 remote_assets=uploaded_assets,
             )

--- a/examples/aime/tests/test_workflow.py
+++ b/examples/aime/tests/test_workflow.py
@@ -68,3 +68,24 @@ def test_main_requires_credential_arguments(capsys: pytest.CaptureFixture[str]) 
     stderr = capsys.readouterr().err
     for name in ("--modal-token-id", "--modal-token-secret"):
         assert name in stderr
+
+
+def test_print_validation_surfaces_contract_diagnostics(capsys) -> None:
+    example._print_validation(
+        SimpleNamespace(
+            static_warnings={"agent.kwargs.max_tokens": "output cap may be clamped"},
+            static_errors={"agent.kwargs.temperature": "trainer-owned"},
+            local_warnings={"local-1": ["history not exercised"]},
+            remote_warnings={},
+            local={},
+            remote=None,
+            local_errors={},
+            remote_errors={},
+            ok=False,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert "⚠️ static agent.kwargs.max_tokens: output cap may be clamped" in output
+    assert "⚠️ local local-1: history not exercised" in output
+    assert "❌ static agent.kwargs.temperature: trainer-owned" in output

--- a/examples/chroma_rag/main.py
+++ b/examples/chroma_rag/main.py
@@ -53,7 +53,7 @@ def validate(env: ChromaRagEnv, uploaded_assets):
         validate_environment(
             env,
             model="gpt-5.4-mini",
-            split="eval",
+            split="train",
             base_dir=DATA_DIR,
             remote_assets=uploaded_assets,
             max_context_tokens=4_096,

--- a/examples/dominant-color/main.py
+++ b/examples/dominant-color/main.py
@@ -401,7 +401,7 @@ def validate(env: DominantColorEnv, uploaded_assets: Any) -> Any:
         validate_environment(
             env,
             model=VALIDATE_MODEL,
-            split="eval",
+            split="train",
             base_dir=DATA_DIR,
             remote_assets=uploaded_assets,
             max_context_tokens=2048,

--- a/examples/geo3k/main.py
+++ b/examples/geo3k/main.py
@@ -400,7 +400,7 @@ def validate(env: Geo3KEnv, uploaded_assets: Any) -> Any:
         validate_environment(
             env,
             model=VALIDATE_MODEL,
-            split="eval",
+            split="train",
             base_dir=DATA_DIR,
             remote_assets=uploaded_assets,
             max_context_tokens=2048,

--- a/examples/harvey/main.py
+++ b/examples/harvey/main.py
@@ -23,7 +23,6 @@ from pathlib import Path
 from typing import Any, Literal
 
 import httpx
-from benchmax.bundle import dump_bundle
 from benchmax.envs.environment import Environment
 from benchmax.envs.harbor import (
     BundledAgentSource,
@@ -40,6 +39,8 @@ from harbor import (
     TrialEnvironmentConfig,
     TrialVerifierConfig,
 )
+
+from benchmax.bundle import dump_bundle
 
 _HARNESS_SOURCE = BundledAgentSource.from_directory(
     Path(__file__).parent / "harness",
@@ -297,9 +298,9 @@ def validate(env: HarveyLabHarborEnv, uploaded_assets: Any) -> Any:
                 base_dir=Path(tmp),
                 remote_assets=uploaded_assets,
                 # Small enough that the budget stop ends trials in minutes
-                # instead of the full 30-turn loop; 4096 was measured too
-                # small for even the first model call.
-                max_context_tokens=6144,
+                # instead of the full 30-turn loop; 6144 was measured too
+                # small for the harness prompt plus its first useful turn.
+                max_context_tokens=8192,
                 # Modal sandbox build plus a several-turn trial still exceeds
                 # the 120s local default.
                 local_timeout_seconds=1800,

--- a/examples/harvey/main.py
+++ b/examples/harvey/main.py
@@ -332,6 +332,14 @@ def launch(uploaded_assets: Any, *, assume_yes: bool) -> str | None:
 
 
 def _print_validation(report: Any) -> None:
+    for location in ("static", "local", "remote"):
+        warnings = getattr(report, f"{location}_warnings", {}) or {}
+        for item, messages in warnings.items():
+            values = messages if isinstance(messages, list) else [messages]
+            for message in values:
+                print(f"⚠️ {location} {item}: {message}")
+    for item, error in (getattr(report, "static_errors", {}) or {}).items():
+        print(f"❌ static {item}: {error}")
     for location in ("local", "remote"):
         outcomes = getattr(report, location)
         if outcomes is None:

--- a/examples/harvey/main.py
+++ b/examples/harvey/main.py
@@ -294,7 +294,7 @@ def validate(env: HarveyLabHarborEnv, uploaded_assets: Any) -> Any:
             validate_environment(
                 env,
                 model=VALIDATE_MODEL,
-                split="eval",
+                split="train",
                 base_dir=Path(tmp),
                 remote_assets=uploaded_assets,
                 # Small enough that the budget stop ends trials in minutes

--- a/examples/harvey/tests/test_workflow.py
+++ b/examples/harvey/tests/test_workflow.py
@@ -92,6 +92,27 @@ def test_main_requires_credential_arguments(capsys: pytest.CaptureFixture[str]) 
         assert name in stderr
 
 
+def test_print_validation_surfaces_contract_diagnostics(capsys) -> None:
+    example._print_validation(
+        SimpleNamespace(
+            static_warnings={"agent.kwargs.max_tokens": "output cap may be clamped"},
+            static_errors={"agent.kwargs.temperature": "trainer-owned"},
+            local_warnings={"local-1": ["history not exercised"]},
+            remote_warnings={},
+            local={},
+            remote=None,
+            local_errors={},
+            remote_errors={},
+            ok=False,
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert "⚠️ static agent.kwargs.max_tokens: output cap may be clamped" in output
+    assert "⚠️ local local-1: history not exercised" in output
+    assert "❌ static agent.kwargs.temperature: trainer-owned" in output
+
+
 def test_judge_preflight_rejects_a_bad_key(monkeypatch) -> None:
     response = SimpleNamespace(
         status_code=401,

--- a/examples/math/main.py
+++ b/examples/math/main.py
@@ -228,7 +228,7 @@ def validate(env: MathEnv, uploaded_assets):
         validate_environment(
             env,
             model=VALIDATION_MODEL,
-            split="eval",
+            split="train",
             base_dir=DATA_DIR,
             remote_assets=uploaded_assets,
             max_context_tokens=2048,

--- a/examples/neon_rag/main.py
+++ b/examples/neon_rag/main.py
@@ -42,7 +42,7 @@ def validate(env: NeonRagEnv, uploaded_assets):
         validate_environment(
             env,
             model=VALIDATION_MODEL,
-            split="eval",
+            split="train",
             base_dir=DATA_DIR,
             remote_assets=uploaded_assets,
             max_context_tokens=10_000,

--- a/examples/pinecone_rag/main.py
+++ b/examples/pinecone_rag/main.py
@@ -52,7 +52,7 @@ def validate(env: PineconeRagEnv, uploaded_assets):
         validate_environment(
             env,
             model="gpt-5.4-mini",
-            split="eval",
+            split="train",
             base_dir=DATA_DIR,
             remote_assets=uploaded_assets,
             max_context_tokens=4_096,

--- a/examples/qwen3-ocr-reverse/main.py
+++ b/examples/qwen3-ocr-reverse/main.py
@@ -265,7 +265,7 @@ def validate(env: Qwen3OCREnv, uploaded_assets: Any) -> Any:
         validate_environment(
             env,
             model=VALIDATE_MODEL,
-            split="eval",
+            split="train",
             base_dir=DATA_DIR,
             remote_assets=uploaded_assets,
             max_context_tokens=2048,

--- a/examples/telestich/main.py
+++ b/examples/telestich/main.py
@@ -1452,7 +1452,7 @@ def validate(env: TelestichEnv, uploaded_assets: Any) -> Any:
         validate_environment(
             env,
             model=VALIDATE_MODEL,
-            split="eval",
+            split="train",
             base_dir=DATA_DIR,
             remote_assets=uploaded_assets,
             max_context_tokens=2048,

--- a/examples/turbopuffer_rag/main.py
+++ b/examples/turbopuffer_rag/main.py
@@ -51,7 +51,7 @@ def validate(env: TurbopufferRagEnv, uploaded_assets):
         validate_environment(
             env,
             model="gpt-5.4-mini",
-            split="eval",
+            split="train",
             base_dir=DATA_DIR,
             remote_assets=uploaded_assets,
             max_context_tokens=4_096,

--- a/packages/benchmax/src/benchmax/envs/__init__.py
+++ b/packages/benchmax/src/benchmax/envs/__init__.py
@@ -19,6 +19,7 @@ from benchmax.envs.shared_types import (
     RolloutFailure,
     RolloutOutcome,
     RolloutRequest,
+    ValidationDiagnostic,
 )
 
 __all__ = [
@@ -39,6 +40,7 @@ __all__ = [
     "RolloutFailure",
     "RolloutOutcome",
     "RolloutRequest",
+    "ValidationDiagnostic",
     "Tool",
     "StaticBearerAuth",
     "bind_model_auth",

--- a/packages/benchmax/src/benchmax/envs/environment.py
+++ b/packages/benchmax/src/benchmax/envs/environment.py
@@ -15,6 +15,7 @@ from benchmax.envs.shared_types import (
     RolloutFailure,
     RolloutOutcome,
     RolloutRequest,
+    ValidationDiagnostic,
 )
 
 __all__ = ["Environment"]
@@ -41,6 +42,11 @@ class Environment[Payload, Attempt: RolloutAttempt](ABC):
         """Use a public model URL when rollouts run in a remote sandbox."""
 
         return False
+
+    def validation_diagnostics(self) -> Sequence[ValidationDiagnostic]:
+        """Return static warnings and errors for environment configuration."""
+
+        return ()
 
     @abstractmethod
     async def create_dataset(

--- a/packages/benchmax/src/benchmax/envs/harbor/env.py
+++ b/packages/benchmax/src/benchmax/envs/harbor/env.py
@@ -26,6 +26,7 @@ from benchmax.envs.shared_types import (
     RolloutAttempt,
     RolloutOutcome,
     RolloutRequest,
+    ValidationDiagnostic,
 )
 
 if TYPE_CHECKING:
@@ -59,6 +60,72 @@ _TERMINATION_REASON_BY_EXCEPTION = {
 _HARNESS_REPORTED_TERMINATION_REASONS = frozenset(
     {"context_exceeded", "output_exceeded", "max_turns_exceeded", "tool_budget_exceeded"}
 )
+_TRAINER_OWNED_MODEL_FIELDS = frozenset(
+    {
+        "temperature",
+        "top_p",
+        "top_k",
+        "presence_penalty",
+        "frequency_penalty",
+        "seed",
+        "stop",
+    }
+)
+_OUTPUT_CAP_FIELDS = frozenset({"max_tokens", "max_completion_tokens"})
+_UNSUPPORTED_MODEL_FIELDS = frozenset(
+    {
+        "best_of",
+        "do_sample",
+        "function_call",
+        "functions",
+        "grammar",
+        "max_new_tokens",
+        "min_p",
+        "min_tokens",
+        "num_beams",
+        "prediction",
+        "reasoning_effort",
+        "repetition_penalty",
+        "typical_p",
+        "verbosity",
+        "web_search_options",
+    }
+)
+
+
+def _walk_model_controls(
+    value: Mapping[str, object],
+    prefix: str = "agent.kwargs",
+) -> Sequence[tuple[str, str, object]]:
+    controls: list[tuple[str, str, object]] = []
+    for field, child in value.items():
+        path = f"{prefix}.{field}"
+        controls.append((path, field, child))
+        if isinstance(child, Mapping):
+            controls.extend(_walk_model_controls(child, path))
+    return controls
+
+
+def _unsupported_model_control(field: str, value: object) -> bool:
+    if field == "return_routed_experts":
+        return True
+    if field in _UNSUPPORTED_MODEL_FIELDS:
+        return value is not None
+    if field == "n":
+        return value not in (None, 1)
+    if field == "tool_choice":
+        return value not in (None, "auto")
+    if field == "logprobs":
+        return value not in (None, False)
+    if field == "top_logprobs":
+        return value is not None
+    if field == "parallel_tool_calls":
+        return value not in (None, True)
+    if field == "response_format":
+        return value not in (None, {}, {"type": "text"})
+    if field == "logit_bias":
+        return value not in (None, {})
+    return False
 
 
 class HarborEnv(Environment["TaskConfig", RolloutAttempt]):
@@ -73,6 +140,48 @@ class HarborEnv(Environment["TaskConfig", RolloutAttempt]):
         """Use a public model URL when Harbor runs in a remote sandbox."""
 
         return self._requires_public_model_endpoint
+
+    def validation_diagnostics(self) -> Sequence[ValidationDiagnostic]:
+        """Flag Harbor harness controls that conflict with tracked training."""
+
+        agent = self._trial.agent
+        config = agent.config if isinstance(agent, BundledHarborAgent) else agent
+        kwargs = getattr(config, "kwargs", None)
+        if not isinstance(kwargs, Mapping):
+            return ()
+        diagnostics: list[ValidationDiagnostic] = []
+        for path, field, value in _walk_model_controls(kwargs):
+            if field in _OUTPUT_CAP_FIELDS:
+                diagnostics.append(
+                    ValidationDiagnostic(
+                        severity="warning",
+                        code="harness_output_cap",
+                        location=path,
+                        message=(
+                            f"{path} is a harness-requested output cap; Castform may clamp it "
+                            "to the remaining trainer context budget"
+                        ),
+                    )
+                )
+            elif field in _TRAINER_OWNED_MODEL_FIELDS:
+                diagnostics.append(
+                    ValidationDiagnostic(
+                        severity="error",
+                        code="trainer_owned_model_control",
+                        location=path,
+                        message=(f"{path} is trainer-owned and cannot be set by a Harbor harness"),
+                    )
+                )
+            elif _unsupported_model_control(field, value):
+                diagnostics.append(
+                    ValidationDiagnostic(
+                        severity="error",
+                        code="unsupported_model_control",
+                        location=path,
+                        message=f"{path}={value!r} is unsupported by tracked training sessions",
+                    )
+                )
+        return tuple(diagnostics)
 
     def __init__(
         self,

--- a/packages/benchmax/src/benchmax/envs/shared_types.py
+++ b/packages/benchmax/src/benchmax/envs/shared_types.py
@@ -13,10 +13,21 @@ __all__ = [
     "RolloutFailure",
     "RolloutOutcome",
     "RolloutRequest",
+    "ValidationDiagnostic",
 ]
 
 DatasetSplit = Literal["train", "eval"]
 type RewardMap = Mapping[str, float]
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationDiagnostic:
+    """A configuration issue discoverable before executing a rollout."""
+
+    severity: Literal["warning", "error"]
+    code: str
+    message: str
+    location: str | None = None
 
 
 class RolloutFailure(RuntimeError):  # noqa: N818 — public exported name

--- a/packages/castform/README.md
+++ b/packages/castform/README.md
@@ -60,12 +60,14 @@ The CLI does not duplicate that orchestration. Use it for `login`, `setup`,
 
 ## Optional libraries
 
-Add only the features the project uses:
+Add only the optional features the project uses:
 
 ```bash
 uv add 'castform[rag]'
-uv add 'castform[traces]'
 ```
+
+Trace adapters and `castform.traces.TracesPipeline` ship with the base
+`castform` package; no trace-specific extra is required.
 
 Vector-store integrations ship as their own extras: `castform[chroma]`,
 `castform[pinecone]`, `castform[turbopuffer]`.

--- a/packages/castform/pyproject.toml
+++ b/packages/castform/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = "==3.12.*"
 dependencies = [
     "benchmax==0.2.2",
     "httpx[http2]>=0.27.0",
+    "tqdm>=4.66.0",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -34,9 +35,7 @@ rag = [
     "ruamel-yaml>=0.19.1",
     "scikit-learn>=1.8.0",
     "sentence-transformers>=5.2.3",
-    "tqdm>=4.66.0",
 ]
-traces = ["tqdm>=4.66.0"]
 chroma = ["chromadb>=1.5.9,<2", "snowballstemmer>=2.2.0"]
 pinecone = ["pinecone>=9.1.0,<10"]
 turbopuffer = ["turbopuffer>=2.6.0,<3"]

--- a/packages/castform/src/castform/cli/scaffold/CLAUDE.md
+++ b/packages/castform/src/castform/cli/scaffold/CLAUDE.md
@@ -53,6 +53,14 @@ completed zero reward is valid, while an empty result with a failure termination
 reason is not. Hosted validation uses the exact uploaded assets that launch would
 consume.
 
+Model sampling is trainer-owned. Harness code may request only an output ceiling
+with `max_tokens` or `max_completion_tokens`; validation prints a warning because
+the effective cap may be lower. Do not set `temperature`, `top_p`, `top_k`,
+penalties, `seed`, or `stop` in harness model kwargs. Static validation rejects
+those controls and unsupported response options. Tracked local and hosted
+validation also rejects sampling conflicts, changed tools, overlapping calls,
+and rewritten multi-turn history. Never launch with a contract error.
+
 ## Bundle and launch boundary
 
 The launch stage must remain visibly ordered:

--- a/packages/castform/src/castform/cli/scaffold/HARBOR_STARTER.md
+++ b/packages/castform/src/castform/cli/scaffold/HARBOR_STARTER.md
@@ -1,0 +1,50 @@
+# Get started with Harbor
+
+This project is shaped for a Harbor package: Harbor resolves the task dataset,
+creates the sandbox, runs the harness, and executes the verifier. Castform uploads
+the environment bundle and supplies the model session used by the harness.
+
+```bash
+uv sync
+uv run python main.py data --dataset <org/package>
+uv run python main.py validate --dataset <org/package> \
+  --modal-token-id <id> --modal-token-secret <secret>
+uv run python main.py launch --dataset <org/package> \
+  --modal-token-id <id> --modal-token-secret <secret>
+```
+
+If the packaged verifier needs credentials, inspect its configuration and pass
+each requirement explicitly, for example
+`--verifier-env OPENAI_API_KEY=<key>`. Do not read ambient environment variables
+inside the environment constructor.
+
+## Work with your agent
+
+Ask your agent to inspect the task package, then start from the closest maintained
+example under <https://github.com/castform-ai/benchmax/tree/main/examples>.
+
+Use Harbor when the source is a Harbor package or its records describe executable
+tasks with sandbox/build configuration, a named harness, and an in-sandbox
+verifier. Use `BaseEnv` when the records are ordinary prompts/examples and your
+Python environment owns the model loop and reward directly.
+
+Keep the stock `TrialAgentConfig(name="mini-swe-agent")` when it fits. AIME shows
+an offline-installed Mini-SWE variant for unreliable per-sandbox installation;
+Harvey shows a task-specific native harness. Add custom harness code only for a
+similarly concrete reason.
+
+The script follows the maintained example shape:
+
+- `_constructor_args(args)` builds explicit, serializable configuration once;
+- the same dictionary constructs the local env and the uploaded bundle;
+- Harbor data remains runtime-managed, so `upload_assets` gets no JSONL dataset;
+- validation prints static, local, and remote warnings/errors before launch.
+
+Harnesses may request `max_tokens` or `max_completion_tokens`, but validation warns
+because Castform can clamp the effective cap. Do not set trainer-owned sampling
+controls such as `temperature`, `top_p`, penalties, `seed`, or `stop`. A green
+validation also requires real model calls, compatible tracked history, verifier
+execution, and scorable rewards—not merely a completed process.
+
+Run `uv run pytest tests` for the structural seed tests, then add task-specific
+tests for required verifier environment, sandbox configuration, and reward output.

--- a/packages/castform/src/castform/cli/scaffold/STARTER.md
+++ b/packages/castform/src/castform/cli/scaffold/STARTER.md
@@ -29,8 +29,10 @@ Point your coding agent at the real task and ask it to load the matching skill i
 
 ```
 Build a Castform environment for <task>. Start with a small representative train
-and eval set, define an explicit reward shape, validate two sibling rollouts, and
-show me the result before proposing a launch.
+and eval set. Use the closest maintained example under
+https://github.com/castform-ai/benchmax/tree/main/examples as the starting point,
+define an explicit reward shape, validate two sibling rollouts, and show me the
+result before proposing a launch.
 ```
 
 **RAG environment:**

--- a/packages/castform/src/castform/cli/scaffold/STARTER.md
+++ b/packages/castform/src/castform/cli/scaffold/STARTER.md
@@ -60,6 +60,13 @@ can be a valid completed result. An operational failure instead has a
 non-`finished` `termination_reason`, empty rewards, an `error` message on the
 outcome, and a corresponding log entry.
 
+Validation checks model-request ownership before running and checks tracked
+sampling and history behavior at runtime. Harnesses may request `max_tokens` or
+`max_completion_tokens`, but the scorecard emits a warning when Castform can
+clamp the effective ceiling. Do not set trainer-owned controls such as
+`temperature`, `top_p`, `top_k`, penalties, `seed`, or `stop`; fix any static or
+runtime contract error before launch.
+
 After a green baseline, decide deliberately:
 
 - iterate on the environment, data or reward and validate again; or

--- a/packages/castform/src/castform/cli/scaffold/STARTER.md
+++ b/packages/castform/src/castform/cli/scaffold/STARTER.md
@@ -29,7 +29,7 @@ Point your coding agent at the real task and ask it to load the matching skill i
 
 ```
 Build a Castform environment for <task>. Start with a small representative train
-and eval set. Use the closest maintained example under
+set and add an eval set when available. Use the closest maintained example under
 https://github.com/castform-ai/benchmax/tree/main/examples as the starting point,
 define an explicit reward shape, validate two sibling rollouts, and show me the
 result before proposing a launch.
@@ -61,6 +61,9 @@ reward components, and produced believable task-specific scores. A zero score
 can be a valid completed result. An operational failure instead has a
 non-`finished` `termination_reason`, empty rewards, an `error` message on the
 outcome, and a corresponding log entry.
+
+Validation smoke-tests the required train split. Eval data is optional and remains
+the right source for measuring generalization when the task provides it.
 
 Validation checks model-request ownership before running and checks tracked
 sampling and history behavior at runtime. Harnesses may request `max_tokens` or

--- a/packages/castform/src/castform/cli/scaffold/generic_env_tests.py
+++ b/packages/castform/src/castform/cli/scaffold/generic_env_tests.py
@@ -1,11 +1,13 @@
-"""Unit tests for the reward. Grow these alongside main.py: cover empty,
-wrong, partial and correct answers so reward changes stay honest.
+"""Unit tests for the dataset and reward. Grow these alongside main.py: cover
+malformed rows plus empty, wrong, partial and correct answers.
 
 Plain `asyncio.run` keeps the suite dependency-free; run with `uv run pytest tests`.
 """
 
 import asyncio
+import json
 
+import pytest
 from benchmax.envs.base import BaseRollout
 from main import CustomEnv
 
@@ -26,32 +28,65 @@ def _reward(answer: str, ground_truth: str) -> dict[str, float]:
     return asyncio.run(CustomEnv().compute_reward(_rollout(answer, ground_truth)))
 
 
-def test_empty_answer_scores_zero_everywhere() -> None:
-    assert _reward("", "Paris") == {
-        "overlap": 0.0,
-        "contains_gold": 0.0,
-        "answered": 0.0,
-    }
+def test_empty_answer_is_incorrect() -> None:
+    assert _reward("", "Paris") == {"correctness": 0.0}
 
 
-def test_exact_answer_scores_full_overlap_and_contains_gold() -> None:
-    reward = _reward("Paris", "Paris")
-
-    assert reward["overlap"] == 1.0
-    assert reward["contains_gold"] == 0.5
-    assert reward["answered"] == 0.1
+def test_exact_answer_is_correct() -> None:
+    assert _reward("Paris", "Paris") == {"correctness": 1.0}
 
 
-def test_wrong_answer_keeps_only_the_answered_shaping() -> None:
-    reward = _reward("Berlin", "Paris")
-
-    assert reward["contains_gold"] == 0.0
-    assert reward["overlap"] < 0.5
-    assert reward["answered"] == 0.1
+def test_case_and_outer_whitespace_are_normalized() -> None:
+    assert _reward("  PARIS\n", "Paris") == {"correctness": 1.0}
 
 
-def test_verbose_answer_containing_gold_gets_partial_overlap() -> None:
-    reward = _reward("The capital of France is Paris.", "Paris")
+def test_wrong_answer_is_incorrect() -> None:
+    assert _reward("Berlin", "Paris") == {"correctness": 0.0}
 
-    assert reward["contains_gold"] == 0.5
-    assert 0.0 < reward["overlap"] < 1.0
+
+def test_verbose_answer_containing_gold_is_not_an_exact_answer() -> None:
+    assert _reward("The capital of France is Paris.", "Paris") == {"correctness": 0.0}
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        {},
+        {"prompt": "", "ground_truth": "Paris"},
+        {"prompt": "Capital of France?"},
+        {"prompt": "Capital of France?", "ground_truth": ""},
+    ],
+)
+def test_malformed_rows_fail_loudly(row) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        CustomEnv()._example_from_row(row)
+
+
+def test_semantic_payload_has_stable_identity() -> None:
+    env = CustomEnv()
+    row = {"prompt": "Capital of France?", "ground_truth": "Paris"}
+
+    assert env._example_from_row(row).id == env._example_from_row(dict(row)).id
+    assert (
+        env._example_from_row(row).id != env._example_from_row({**row, "ground_truth": "Lyon"}).id
+    )
+
+
+def test_split_order_and_identity_are_preserved(tmp_path) -> None:
+    train_rows = [
+        {"prompt": "first", "ground_truth": "one"},
+        {"prompt": "second", "ground_truth": "two"},
+    ]
+    eval_rows = [{"prompt": "third", "ground_truth": "three"}]
+    for split, rows in (("train", train_rows), ("eval", eval_rows)):
+        (tmp_path / f"{split}.jsonl").write_text(
+            "".join(f"{json.dumps(row)}\n" for row in rows),
+            encoding="utf-8",
+        )
+
+    env = CustomEnv()
+    train = asyncio.run(env.create_dataset("train", tmp_path))
+    eval_ = asyncio.run(env.create_dataset("eval", tmp_path))
+
+    assert [example.payload["ground_truth"] for example in train] == ["one", "two"]
+    assert {example.id for example in train}.isdisjoint(example.id for example in eval_)

--- a/packages/castform/src/castform/cli/scaffold/generic_main.py
+++ b/packages/castform/src/castform/cli/scaffold/generic_main.py
@@ -34,7 +34,6 @@ from benchmax.envs import (
     canonical_example_id,
 )
 from benchmax.rewards import extract_completion_text
-
 from castform import validate_environment
 from castform.platform.client import TrainerClient
 from castform.platform.environment_assets import upload_assets
@@ -191,6 +190,14 @@ def generate_data(force: bool = False) -> bool:
 
 
 def _print_validation(report: Any) -> None:
+    for location in ("static", "local", "remote"):
+        warnings = getattr(report, f"{location}_warnings", {}) or {}
+        for item, messages in warnings.items():
+            values = messages if isinstance(messages, list) else [messages]
+            for message in values:
+                print(f"⚠️ {location} {item}: {message}")
+    for item, error in (getattr(report, "static_errors", {}) or {}).items():
+        print(f"❌ static {item}: {error}")
     for location in ("local", "remote"):
         outcomes = getattr(report, location)
         if outcomes is None:

--- a/packages/castform/src/castform/cli/scaffold/generic_main.py
+++ b/packages/castform/src/castform/cli/scaffold/generic_main.py
@@ -134,7 +134,6 @@ LAUNCH_CONFIG = {
 
 TRAIN_FILE = "train.jsonl"
 EVAL_FILE = "eval.jsonl"
-ENV_ARGS: dict[str, Any] = {}  # CustomEnv constructor kwargs (none by default)
 
 # Dependencies installed in the remote rollout runtime. Keep this declaration at
 # the script boundary: add only packages imported by your env/reward/tool code.
@@ -169,6 +168,16 @@ def _load_jsonl(path: str) -> list[dict[str, Any]]:
 
 def _run_name() -> str:
     return str(LAUNCH_CONFIG.get("name") or CustomEnv.__name__.lower())
+
+
+def _constructor_args(args: argparse.Namespace) -> dict[str, Any]:
+    """Build explicit, serializable kwargs shared by local and remote envs.
+
+    Add task configuration and credentials as CLI arguments, then translate them
+    here instead of reading ambient environment variables inside ``CustomEnv``.
+    """
+    del args
+    return {}
 
 
 def generate_data(force: bool = False) -> bool:
@@ -294,11 +303,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.action == "data":
         return 0
 
+    constructor_args = _constructor_args(args)
     ensure_session()  # data preparation stays usable without platform login
     print(f"[stage 2/{total_stages}] bundling environment")
     bundled_environment = dump_bundle(
         CustomEnv,
-        constructor_args=ENV_ARGS,
+        constructor_args=constructor_args,
         pip_dependencies=RUNTIME_DEPENDENCIES,
     )
     print(f"[stage 3/{total_stages}] uploading environment and dataset")
@@ -312,7 +322,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"  env_metadata_path: {uploaded_assets.env_metadata_path}")
     print(f"  dataset_path: {uploaded_assets.dataset_path}")
     print(f"[stage 4/{total_stages}] validating environment")
-    report = validate(CustomEnv(**ENV_ARGS), uploaded_assets)
+    report = validate(CustomEnv(**constructor_args), uploaded_assets)
     if not report.ok:
         return 1
     if args.action == "launch":

--- a/packages/castform/src/castform/cli/scaffold/generic_main.py
+++ b/packages/castform/src/castform/cli/scaffold/generic_main.py
@@ -17,10 +17,11 @@ from __future__ import annotations
 import argparse
 import asyncio
 import dataclasses
-import difflib
 import json
 from pathlib import Path
 from typing import Any
+
+from benchmax.envs.base import resolve_dataset_path
 
 from benchmax.bundle import dump_bundle
 from benchmax.envs import (
@@ -43,12 +44,12 @@ from castform.platform.login import ensure_session
 class CustomEnv(BaseEnv):
     """A single-turn env: the model answers a prompt, scored against ground_truth.
 
-    No tools and no LLM judge — the reward itself is deterministic string overlap
+    No tools and no LLM judge — the reward is normalized exact-match correctness
     and needs no separate judge call. Swap in your own reward / tools / judge.
     """
 
     # Advertised to the model each rollout (optional; default ""). Keep it short.
-    system_prompt = "Answer the question concisely and directly."
+    system_prompt = "Return only the answer, without explanation."
     max_turns = 1
 
     async def create_dataset(
@@ -59,7 +60,7 @@ class CustomEnv(BaseEnv):
         max_examples: int | None = None,
     ) -> JsonlDataset[JsonRow]:
         return JsonlDataset(
-            base_dir / f"{split}.jsonl",
+            resolve_dataset_path(base_dir, f"{split}.jsonl"),
             row_to_example=self._example_from_row,
             max_examples=max_examples,
         )
@@ -68,12 +69,25 @@ class CustomEnv(BaseEnv):
         prompt = row.get("prompt")
         if not isinstance(prompt, str):
             raise TypeError("dataset rows require a string 'prompt'")
+        if not prompt.strip():
+            raise ValueError("dataset rows require a non-empty 'prompt'")
+        ground_truth = row.get("ground_truth")
+        if not isinstance(ground_truth, str):
+            raise TypeError("dataset rows require a string 'ground_truth'")
+        if not ground_truth.strip():
+            raise ValueError("dataset rows require a non-empty 'ground_truth'")
+        extra = {
+            key: value
+            for key, value in row.items()
+            if key not in ("prompt", "ground_truth", "prompt_messages")
+        }
         payload: JsonRow = {
+            **extra,
             "prompt_messages": [
                 {"role": "system", "content": self.system_prompt},
                 {"role": "user", "content": prompt},
             ],
-            **{key: value for key, value in row.items() if key != "prompt"},
+            "ground_truth": ground_truth,
         }
         return Example(id=canonical_example_id(payload), payload=payload)
 
@@ -81,25 +95,14 @@ class CustomEnv(BaseEnv):
         self,
         rollout: BaseRollout,
     ) -> dict[str, float]:
-        """Score the answer against `ground_truth`. Return positive scores only; all
-        components are SUMMED into one scalar — this is your whole training signal,
-        so edit it. (Deterministic overlap here; swap in an LLM judge for open-ended
-        answers — see the design-environment skill.)
-        """
-        t = rollout.example_args
+        """Score a normalized exact answer against the required ground truth."""
         answer = extract_completion_text(rollout.messages).strip()
-        gold = str(t.get("ground_truth") or t.get("answer") or "").strip()
-        if not answer:
-            return {"overlap": 0.0, "contains_gold": 0.0, "answered": 0.0}
-        overlap = (
-            difflib.SequenceMatcher(None, answer.lower(), gold.lower()).ratio() if gold else 0.0
-        )
-        contains = 1.0 if gold and gold.lower() in answer.lower() else 0.0
-        return {
-            "overlap": overlap,  # fuzzy match with the gold answer, in [0, 1]
-            "contains_gold": 0.5 * contains,  # the gold string appears verbatim
-            "answered": 0.1,  # small shaping: produced a non-empty answer
-        }
+        gold = rollout.example_args.get("ground_truth")
+        if not isinstance(gold, str) or not gold.strip():
+            raise ValueError("rollout requires a non-empty string 'ground_truth'")
+        normalized_answer = " ".join(answer.casefold().split())
+        normalized_gold = " ".join(gold.casefold().split())
+        return {"correctness": float(normalized_answer == normalized_gold)}
 
 
 # ── Run config — validate/launch read these so the run reproduces from this
@@ -111,6 +114,7 @@ VALIDATE_CONFIG = {
 }
 
 LAUNCH_CONFIG = {
+    "model": "Qwen/Qwen3.5-4B",
     # Total prompt + response tokens across the WHOLE rollout. Single-turn answers
     # are short; raise it if your task needs longer prompts or tool transcripts.
     "max_context_tokens": 4096,
@@ -188,13 +192,20 @@ def generate_data(force: bool = False) -> bool:
     the gen code here so the dataset stays reproducible from this file. Re-run with
     --force to regenerate; skip-if-exists otherwise.
     """
-    have = Path(TRAIN_FILE).exists() and Path(EVAL_FILE).exists()
-    if have and not force:
+    datasets = (
+        (Path(TRAIN_FILE), _SEED_TRAIN),
+        (Path(EVAL_FILE), _SEED_EVAL),
+    )
+    pending = (
+        list(datasets) if force else [(path, rows) for path, rows in datasets if not path.exists()]
+    )
+    if not pending:
         print(f"data: {TRAIN_FILE} / {EVAL_FILE} present — skipping (--force to redo)")
         return True
-    _write_jsonl(TRAIN_FILE, _SEED_TRAIN)
-    _write_jsonl(EVAL_FILE, _SEED_EVAL)
-    print(f"data: wrote {len(_SEED_TRAIN)} train / {len(_SEED_EVAL)} eval rows")
+    for path, rows in pending:
+        _write_jsonl(str(path), rows)
+    written = ", ".join(f"{path} ({len(rows)} rows)" for path, rows in pending)
+    print(f"data: wrote {written}")
     return True
 
 

--- a/packages/castform/src/castform/cli/scaffold/harbor_env_tests.py
+++ b/packages/castform/src/castform/cli/scaffold/harbor_env_tests.py
@@ -1,0 +1,64 @@
+"""Structural tests for the Harbor seed. Add task-specific verifier tests here."""
+
+import argparse
+
+import pytest
+from benchmax.envs.harbor import HarborEnv, ModalCredentials
+from main import (
+    CustomHarborEnv,
+    _constructor_args,
+    _parse_verifier_env,
+)
+
+
+def _args(**overrides):
+    values = {
+        "dataset": "org/task-package",
+        "dataset_ref": "latest",
+        "modal_token_id": "modal-id",
+        "modal_token_secret": "modal-secret",
+        "verifier_env": ["OPENAI_API_KEY=judge-key"],
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_constructor_args_are_explicit_and_build_the_stock_harness() -> None:
+    constructor_args = _constructor_args(_args())
+    env = CustomHarborEnv(**constructor_args)
+
+    assert isinstance(env, HarborEnv)
+    assert constructor_args["dataset_name"] == "org/task-package"
+    assert constructor_args["dataset_ref"] == "latest"
+    assert isinstance(constructor_args["sandbox_credentials"], ModalCredentials)
+    assert constructor_args["verifier_env"] == {"OPENAI_API_KEY": "judge-key"}
+    assert env._trial.agent.name == "mini-swe-agent"
+    assert env._trial.agent.model_name is None
+    assert env._trial.agent.kwargs == {}
+
+
+def test_stock_harness_has_no_static_model_contract_errors() -> None:
+    env = CustomHarborEnv(**_constructor_args(_args()))
+
+    assert env.validation_diagnostics() == ()
+
+
+def test_verifier_env_accepts_repeated_name_value_arguments() -> None:
+    assert _parse_verifier_env(["OPENAI_API_KEY=key", "OPENAI_BASE_URL=https://host/v1"]) == {
+        "OPENAI_API_KEY": "key",
+        "OPENAI_BASE_URL": "https://host/v1",
+    }
+
+
+@pytest.mark.parametrize(
+    "assignments",
+    [
+        ["OPENAI_API_KEY"],
+        ["OPENAI_API_KEY="],
+        ["BAD-NAME=value"],
+        ["OPENAI_API_KEY=one", "OPENAI_API_KEY=two"],
+    ],
+)
+def test_verifier_env_rejects_ambiguous_values(assignments: list[str]) -> None:
+    with pytest.raises(ValueError):
+        _parse_verifier_env(assignments)

--- a/packages/castform/src/castform/cli/scaffold/harbor_main.py
+++ b/packages/castform/src/castform/cli/scaffold/harbor_main.py
@@ -1,0 +1,283 @@
+"""Harbor environment seed written by ``castform setup --template harbor``.
+
+Use this shape when Harbor owns the task package, sandbox, harness, and verifier.
+The package dataset resolves at runtime, so Castform uploads only this environment
+bundle. Modal and verifier credentials enter through explicit CLI arguments and
+are serialized into the same constructor kwargs used locally and remotely.
+
+The stock Mini-SWE agent is intentional. Replace it with a bundled/custom harness
+only when the task requires a different loop or hermetic installation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import re
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from benchmax.envs.harbor import (
+    HarborEnv,
+    HarborTrialTemplate,
+    ModalCredentials,
+)
+from harbor import (
+    DatasetConfig,
+    EnvironmentType,
+    TrialAgentConfig,
+    TrialEnvironmentConfig,
+    TrialVerifierConfig,
+)
+
+from benchmax.bundle import dump_bundle
+from benchmax.envs import Environment
+from castform import validate_environment
+from castform.platform.client import TrainerClient
+from castform.platform.environment_assets import upload_assets
+from castform.platform.login import ensure_session
+
+_ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class CustomHarborEnv(HarborEnv):
+    """A Harbor package on Modal using Harbor's stock Mini-SWE harness."""
+
+    def __init__(
+        self,
+        *,
+        dataset_name: str,
+        dataset_ref: str,
+        sandbox_credentials: ModalCredentials,
+        verifier_env: Mapping[str, str] | None = None,
+    ) -> None:
+        if not dataset_name.strip():
+            raise ValueError("dataset_name must be non-empty")
+        if not dataset_ref.strip():
+            raise ValueError("dataset_ref must be non-empty")
+        super().__init__(
+            dataset=DatasetConfig(name=dataset_name, ref=dataset_ref),
+            eval_ratio=0.1,
+            trial=HarborTrialTemplate(
+                # Leave model_name and sampling kwargs unset. HarborEnv injects
+                # Castform's tracked model session for each rollout.
+                agent=TrialAgentConfig(name="mini-swe-agent"),
+                environment=TrialEnvironmentConfig(type=EnvironmentType.MODAL),
+                verifier=TrialVerifierConfig(env=dict(verifier_env or {})),
+            ),
+            sandbox_credentials=sandbox_credentials,
+            # Do not impose a small environment-side rollout bottleneck. Provider
+            # and trainer capacity still bound actual concurrency.
+            max_concurrent_trials=1000,
+        )
+
+
+VALIDATE_CONFIG = {
+    "model": "gpt-5.4-mini",
+    "max_context_tokens": 16_384,
+    "local_timeout_seconds": 1_800,
+}
+
+LAUNCH_CONFIG = {
+    "model": "Qwen/Qwen3.5-4B",
+    "max_context_tokens": 16_384,
+    "num_epochs": 2,
+}
+
+RUNTIME_DEPENDENCIES = ["harbor[modal]>=0.18.0,<0.19"]
+
+
+def _parse_verifier_env(assignments: Sequence[str]) -> dict[str, str]:
+    environment: dict[str, str] = {}
+    for assignment in assignments:
+        name, separator, value = assignment.partition("=")
+        if not separator or not _ENV_NAME.fullmatch(name) or not value:
+            raise ValueError("--verifier-env values must use a non-empty NAME=VALUE form")
+        if name in environment:
+            raise ValueError(f"duplicate verifier environment variable: {name}")
+        environment[name] = value
+    return environment
+
+
+def _constructor_args(args: argparse.Namespace) -> dict[str, Any]:
+    """Translate CLI inputs into the exact kwargs bundled for remote workers."""
+    return {
+        "dataset_name": args.dataset,
+        "dataset_ref": args.dataset_ref,
+        "sandbox_credentials": ModalCredentials(
+            token_id=args.modal_token_id,
+            token_secret=args.modal_token_secret,
+        ),
+        "verifier_env": _parse_verifier_env(args.verifier_env),
+    }
+
+
+def _run_name(args: argparse.Namespace) -> str:
+    if args.run_name:
+        return args.run_name
+    dataset = re.sub(r"[^A-Za-z0-9._-]+", "-", args.dataset).strip("-")
+    return f"harbor-{dataset}"
+
+
+def generate_data(*, dataset_name: str, dataset_ref: str) -> None:
+    print(
+        f"data: {dataset_name}@{dataset_ref} resolves through Harbor at runtime; "
+        "no JSONL upload is needed"
+    )
+
+
+def _print_validation(report: Any) -> None:
+    for location in ("static", "local", "remote"):
+        warnings = getattr(report, f"{location}_warnings", {}) or {}
+        for item, messages in warnings.items():
+            values = messages if isinstance(messages, list) else [messages]
+            for message in values:
+                print(f"⚠️ {location} {item}: {message}")
+    for item, error in (getattr(report, "static_errors", {}) or {}).items():
+        print(f"❌ static {item}: {error}")
+    for location in ("local", "remote"):
+        outcomes = getattr(report, location)
+        if outcomes is None:
+            continue
+        errors = getattr(report, f"{location}_errors")
+        for rollout_id, outcome in outcomes.items():
+            if rollout_id in errors:
+                print(f"❌ {location} {rollout_id}: {errors[rollout_id]}")
+                continue
+            mark = (
+                "✅"
+                if outcome.termination_reason in Environment.scorable_termination_reasons
+                else "❌"
+            )
+            suffix = f" error={outcome.error}" if outcome.error else ""
+            print(
+                f"{mark} {location} {rollout_id}: "
+                f"{outcome.termination_reason} {dict(outcome.rewards)}{suffix}"
+            )
+        for rollout_id, error in errors.items():
+            if rollout_id not in outcomes:
+                print(f"❌ {location} {rollout_id}: {error}")
+    print("✅ validation passed" if report.ok else "❌ validation failed")
+
+
+def validate(env: CustomHarborEnv, uploaded_assets: Any) -> Any:
+    with tempfile.TemporaryDirectory() as tmp:
+        report = asyncio.run(
+            validate_environment(
+                env,
+                model=str(VALIDATE_CONFIG["model"]),
+                split="train",
+                base_dir=Path(tmp),
+                remote_assets=uploaded_assets,
+                max_context_tokens=int(VALIDATE_CONFIG["max_context_tokens"]),
+                local_timeout_seconds=float(VALIDATE_CONFIG["local_timeout_seconds"]),
+            )
+        )
+    _print_validation(report)
+    return report
+
+
+def launch(
+    uploaded_assets: Any,
+    *,
+    run_name: str,
+    assume_yes: bool = False,
+) -> str | None:
+    if not assume_yes:
+        reply = input(f"Launch '{run_name}' on GPUs — this spends credits. Continue? [y/N] ")
+        if reply.strip().lower() not in ("y", "yes"):
+            print("launch: aborted.")
+            return None
+    with TrainerClient() as client:
+        run_id = client.launch_training_run(
+            name=run_name,
+            launcher_args=LAUNCH_CONFIG,
+            **dataclasses.asdict(uploaded_assets),
+        )
+    print(f"launch: started run {run_id}")
+    return run_id
+
+
+def _require_execution_args(
+    parser: argparse.ArgumentParser,
+    args: argparse.Namespace,
+) -> None:
+    missing = [
+        flag
+        for flag, value in (
+            ("--modal-token-id", args.modal_token_id),
+            ("--modal-token-secret", args.modal_token_secret),
+        )
+        if not value
+    ]
+    if missing:
+        parser.error(f"{', '.join(missing)} required for validate and launch")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run Castform for a Harbor package on Modal.")
+    parser.add_argument(
+        "action",
+        nargs="?",
+        default="validate",
+        choices=["data", "validate", "launch"],
+    )
+    parser.add_argument(
+        "--dataset",
+        required=True,
+        help="Harbor package dataset, for example aime/aime.",
+    )
+    parser.add_argument("--dataset-ref", default="latest")
+    parser.add_argument("--run-name")
+    parser.add_argument("--modal-token-id")
+    parser.add_argument("--modal-token-secret")
+    parser.add_argument(
+        "--verifier-env",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help="Verifier credential/config; repeat for each required variable.",
+    )
+    parser.add_argument("-y", "--yes", action="store_true")
+    args = parser.parse_args(argv)
+    total_stages = {"data": 1, "validate": 4, "launch": 5}[args.action]
+
+    print(f"[stage 1/{total_stages}] resolving data")
+    generate_data(dataset_name=args.dataset, dataset_ref=args.dataset_ref)
+    if args.action == "data":
+        return 0
+
+    _require_execution_args(parser, args)
+    constructor_args = _constructor_args(args)
+    run_name = _run_name(args)
+    ensure_session()
+
+    print(f"[stage 2/{total_stages}] bundling Harbor environment")
+    bundle = dump_bundle(
+        CustomHarborEnv,
+        constructor_args=constructor_args,
+        pip_dependencies=RUNTIME_DEPENDENCIES,
+    )
+    print(f"[stage 3/{total_stages}] uploading environment")
+    uploaded_assets = upload_assets(bundle=bundle, run_name=run_name)
+    print(f"  env_cls_path: {uploaded_assets.env_cls_path}")
+    print(f"  env_metadata_path: {uploaded_assets.env_metadata_path}")
+    print(f"  dataset_path: {uploaded_assets.dataset_path}")
+
+    print(f"[stage 4/{total_stages}] validating Harbor trials")
+    report = validate(CustomHarborEnv(**constructor_args), uploaded_assets)
+    if not report.ok:
+        return 1
+    if args.action == "launch":
+        print(f"[stage 5/{total_stages}] launching training")
+        return (
+            0 if launch(uploaded_assets, run_name=run_name, assume_yes=args.yes) is not None else 1
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/castform/src/castform/cli/scaffold/skills/design-environment/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/design-environment/SKILL.md
@@ -19,6 +19,7 @@ Extend `Environment` directly only for another genuinely different rollout loop.
 from pathlib import Path
 
 from benchmax.envs import BaseEnv, BaseRollout, DatasetSplit, JsonlDataset
+from benchmax.envs.base import resolve_dataset_path
 from benchmax.rewards import extract_completion_text
 
 
@@ -28,7 +29,8 @@ class MyEnv(BaseEnv):
     async def create_dataset(
         self, split: DatasetSplit, base_dir: Path
     ) -> JsonlDataset:
-        return JsonlDataset(base_dir / f"{split}.jsonl", row_to_example=...)
+        path = resolve_dataset_path(base_dir, f"{split}.jsonl")
+        return JsonlDataset(path, row_to_example=...)
 
     async def compute_reward(self, rollout: BaseRollout) -> dict[str, float]:
         answer = extract_completion_text(rollout.messages)

--- a/packages/castform/src/castform/cli/scaffold/skills/design-environment/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/design-environment/SKILL.md
@@ -5,9 +5,13 @@ description: Design a benchmax environment, its ordered dataset, tools, and expl
 
 # Design an environment
 
+Before coding, inspect the maintained [examples](https://github.com/castform-ai/benchmax/tree/main/examples), choose the closest task shape, and follow its `README.md` and `main.py`.
+
 Use `BaseEnv` for the standard OpenAI-compatible chat and tool loop. Use
-`HarborEnv` when Harbor owns the complete agent/sandbox/verifier harness. Extend
-`Environment` directly only for another genuinely different rollout loop.
+`HarborEnv` for a Harbor dataset/package or tasks that ship their own instruction,
+sandbox, and verifier. Start with `aime` for packaged tasks or `harvey` for a
+custom harness. Do not infer Harbor from a judge, tool, or Dockerfile alone.
+Extend `Environment` directly only for another genuinely different rollout loop.
 
 ## Required BaseEnv shape
 
@@ -67,6 +71,16 @@ async def run_tool(self, rollout_id: str, tool_name: str, **tool_args):
 ```
 
 Keep clients pickle-safe. Use `InjectedAuth` for calls through the Castform LLM endpoint so Castform supplies the current session credential. Use explicit `StaticBearerAuth` for a user-managed external endpoint; never read Castform credentials from benchmax environment code.
+
+## Model-request ownership
+
+Treat model sampling as trainer-owned. A harness may request an output ceiling
+with `max_tokens` or `max_completion_tokens`; static validation emits a warning
+because Castform may clamp that ceiling to the remaining context budget. Do not
+set `temperature`, `top_p`, `top_k`, penalties, `seed`, or `stop` in agent or
+nested model kwargs. Static validation rejects them instead of allowing a later
+training failure. It also rejects unsupported controls such as `n > 1`, forced
+`tool_choice`, logprobs, and non-text response formats.
 
 ## Review before handoff
 

--- a/packages/castform/src/castform/cli/scaffold/skills/generate-data/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/generate-data/SKILL.md
@@ -74,9 +74,10 @@ chosen Harbor workflow genuinely needs a folder or artifact uploaded.
 
 ## Traces
 
-Install `castform[traces]`, normalize provider traces with the adapter for that
-provider, and pass them through `castform.traces.TracesPipeline`. Keep the resulting
-train/eval split and detected prompt/tool assumptions visible in the project.
+Normalize provider traces with the adapter for that provider and pass them through
+`castform.traces.TracesPipeline`, which ships with the base `castform` package.
+Keep the resulting train/eval split and detected prompt/tool assumptions visible
+in the project.
 Inspect for secrets, relayed tool output, duplicates and trivial examples before
 using traces as training data.
 

--- a/packages/castform/src/castform/cli/scaffold/skills/launch-run/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/launch-run/SKILL.md
@@ -52,7 +52,7 @@ runtime:
 ```python
 bundle = dump_bundle(
     CustomEnv,
-    constructor_args=ENV_ARGS,
+    constructor_args=constructor_args,
     pip_dependencies=RUNTIME_DEPENDENCIES,
 )
 ```

--- a/packages/castform/src/castform/cli/scaffold/skills/launch-run/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/launch-run/SKILL.md
@@ -14,8 +14,16 @@ uv run python main.py launch
 ```
 
 Do not pass `--yes` unless the user has already explicitly authorized the cost.
+Never launch after `validate_environment` reports a static or runtime sampling
+or history-contract error. Review output-cap warnings (`max_tokens` or
+`max_completion_tokens`) and confirm any effective clamp is intentional.
 
 ## Required ordering
+
+Accept user configuration as explicit `main.py` arguments, normalize it once in
+`_constructor_args(args)`, and reuse that dictionary for local construction and
+`dump_bundle`. Avoid ambient `os.environ` reads in environments, tools, rewards,
+and harness configuration.
 
 Read the script and confirm that the launch action does all of the following
 in order:

--- a/packages/castform/src/castform/cli/scaffold/skills/verify-environment/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/verify-environment/SKILL.md
@@ -21,6 +21,16 @@ that were just uploaded — the same ones a launch would train on. Keep the loca
 budget shared through `VALIDATE_CONFIG["max_context_tokens"]`; the local
 wall-clock backstop is `VALIDATE_CONFIG["local_timeout_seconds"]`.
 
+`validate_environment` first performs static model-parameter checks, then uses
+tracked model sessions locally and remotely to enforce the same sampling and
+multi-turn history contract as training. Review static and runtime warnings as
+well as outcomes. A `max_tokens` or `max_completion_tokens` warning is allowed
+when the effective cap is acceptable. Sampling conflicts, unsupported controls,
+changed tools, overlapping generations, and rewritten assistant history are
+errors. Do not launch while any contract error remains. If validation made only
+one model call, treat the “multi-turn history was not exercised” warning as a
+coverage gap for harnesses expected to loop.
+
 ## Read both outcomes
 
 For each sibling, inspect:

--- a/packages/castform/src/castform/cli/setup.py
+++ b/packages/castform/src/castform/cli/setup.py
@@ -83,6 +83,9 @@ requires-python = "==3.12.*"
 dependencies = [
 {dependency_lines}
 ]
+
+[dependency-groups]
+dev = ["pytest>=8.4"]
 """
 
 
@@ -132,7 +135,7 @@ def _apply_template_conditionals(text: str, template: str) -> str:
 _PRIMARY_PROMPT = (
     "i want to start a training run to improve a model on <your task>. create a "
     "reasonable environment with relevant tools, generate a small synthetic "
-    "dataset, run a baseline eval, review the results, and propose next steps to "
+    "dataset, run baseline validation, review the results, and propose next steps to "
     "either iterate or launch."
 )
 _HARBOR_PROMPT = (

--- a/packages/castform/src/castform/cli/setup.py
+++ b/packages/castform/src/castform/cli/setup.py
@@ -4,11 +4,11 @@ Logs you in (no-op if already authed), then writes the agent scaffold from the
 packaged templates (``castform.cli.scaffold``): CLAUDE.md / AGENTS.md, the
 per-stage skills into each agent's skills dir (claude → ``.claude/skills/``,
 codex → ``.agents/skills/``, with the body's path references retargeted), a
-starter prompt, and a standalone ``pyproject.toml`` + runnable seed ``main.py`` +
-tiny seed datasets (a minimal single-turn env) so ``python main.py validate``
-runs on day one. The ``rag`` template adds RAG dependencies and links to the
-maintained Benchmax examples. ``--no-template`` skips the seed (docs + skills only; the agent writes
-``main.py`` from the design-environment skill). Does NOT open the agent.
+starter prompt, and a standalone ``pyproject.toml`` + runnable seed ``main.py``.
+The default and ``rag`` templates include tiny single-turn datasets; the
+``harbor`` template resolves its dataset through Harbor at runtime. ``--no-template``
+skips the seed (docs + skills only; the agent writes ``main.py`` from the
+design-environment skill). Does NOT open the agent.
 """
 
 from __future__ import annotations
@@ -45,8 +45,8 @@ _SKILLS = (
 # under `.agents/skills/` and point AGENTS.md at them explicitly.
 _SKILLS_DIR = {"claude": ".claude/skills", "codex": ".agents/skills"}
 
-# Per-template seed files in the scaffold dir: a runnable `main.py` + tiny seed
-# datasets, copied into the project so `python main.py validate` runs day one.
+# Per-template seed files in the scaffold dir. Runtime-resolved environments such
+# as Harbor intentionally omit local dataset files.
 _TEMPLATE_SEEDS = {
     "generic": {
         "main": "generic_main.py",
@@ -60,6 +60,11 @@ _TEMPLATE_SEEDS = {
         "eval": "generic_eval_dataset.jsonl",
         "tests": "generic_env_tests.py",
     },
+    "harbor": {
+        "main": "harbor_main.py",
+        "tests": "harbor_env_tests.py",
+        "starter": "HARBOR_STARTER.md",
+    },
 }
 
 
@@ -67,15 +72,18 @@ def _project_toml(template: str) -> str:
     benchmax_requirement = _installed_requirement("benchmax")
     castform_name = "castform[rag]" if template == "rag" else "castform"
     castform_requirement = _installed_requirement(castform_name, distribution="castform")
-    return f'''[project]
+    dependencies = [benchmax_requirement, castform_requirement]
+    if template == "harbor":
+        dependencies.append("harbor[modal]>=0.18.0,<0.19")
+    dependency_lines = "\n".join(f'    "{requirement}",' for requirement in dependencies)
+    return f"""[project]
 name = "castform-environment"
 version = "0.1.0"
 requires-python = "==3.12.*"
 dependencies = [
-    "{benchmax_requirement}",
-    "{castform_requirement}",
+{dependency_lines}
 ]
-'''
+"""
 
 
 def _installed_requirement(name: str, *, distribution: str | None = None) -> str:
@@ -127,6 +135,12 @@ _PRIMARY_PROMPT = (
     "dataset, run a baseline eval, review the results, and propose next steps to "
     "either iterate or launch."
 )
+_HARBOR_PROMPT = (
+    "i want to train on the Harbor package <org/package> using Modal. inspect its "
+    "task, harness, sandbox, and verifier requirements, adapt the Harbor scaffold "
+    "from the closest Benchmax example, validate it, and show me the result before "
+    "proposing a launch."
+)
 
 # (command, what it does) — the few verbs worth surfacing right after setup.
 _QUICK_COMMANDS = (
@@ -147,7 +161,7 @@ def _wrap(text: str, width: int) -> list[str]:
     return textwrap.wrap(text, width) or [""]
 
 
-def _print_get_started() -> None:
+def _print_get_started(template: str) -> None:
     """Render the get-started block: an ``ask your agent`` divider over the one
     prompt to paste (plain indented lines — no box, so it copy-pastes clean),
     then a ``helpful commands`` divider over an unboxed command list. Command and
@@ -158,7 +172,8 @@ def _print_get_started() -> None:
 
     print()
     print("  " + rule_label("ask your agent", ORANGE, width))
-    for ln in _wrap(_PRIMARY_PROMPT, width - 2):
+    prompt = _HARBOR_PROMPT if template == "harbor" else _PRIMARY_PROMPT
+    for ln in _wrap(prompt, width - 2):
         print("    " + paint(ln, italic=True))
 
     print()
@@ -238,7 +253,8 @@ def _cmd_setup(args: argparse.Namespace) -> int:
     agents = _choose_agents(args.agent)
     root = _scaffold()
     instructions = (root / "CLAUDE.md").read_text(encoding="utf-8")
-    starter = (root / "STARTER.md").read_text(encoding="utf-8")
+    starter_name = _TEMPLATE_SEEDS[args.template].get("starter", "STARTER.md")
+    starter = (root / starter_name).read_text(encoding="utf-8")
 
     print()
     print(paint(f"Scaffolding {target} for your coding agent…", bold=True))
@@ -270,13 +286,11 @@ def _cmd_setup(args: argparse.Namespace) -> int:
             dest = target.joinpath(*skills_dir, name, "SKILL.md")
             skill_writes.append(w(dest, prep(skill, agent)))
 
-    # 3) env template — every template ships a standalone pyproject, runnable
-    #    main.py, and tiny seed datasets so `python main.py validate` runs on day
-    #    one; the agent then
-    #    tailors them. --no-template skips the seed (docs + skills only). main.py
-    #    honors --force (the guard above cleared it); the datasets ALWAYS
-    #    skip-if-exists — --force is only for the main.py guard, and real prepared
-    #    data must never be clobbered by the placeholder.
+    # 3) env template — every template ships a standalone pyproject and runnable
+    #    main.py. BaseEnv templates also include tiny seed datasets; Harbor resolves
+    #    package data at runtime. --no-template skips the seed (docs + skills only).
+    #    main.py honors --force (the guard above cleared it); dataset placeholders
+    #    ALWAYS skip-if-exists so real prepared data is never clobbered.
     env_writes: list[bool] = []
     if not args.no_template:
         seed = _TEMPLATE_SEEDS[args.template]
@@ -289,14 +303,15 @@ def _cmd_setup(args: argparse.Namespace) -> int:
             )
         )
         env_writes.append(w(target / "main.py", (root / seed["main"]).read_text("utf-8")))
-        env_writes.append(
-            _write(
-                target / "train.jsonl",
-                (root / seed["train"]).read_text("utf-8"),
-                force=False,
-                log=log,
+        if "train" in seed:
+            env_writes.append(
+                _write(
+                    target / "train.jsonl",
+                    (root / seed["train"]).read_text("utf-8"),
+                    force=False,
+                    log=log,
+                )
             )
-        )
         # tests/ mirrors the examples' layout: conftest pins the import path,
         # and templates with a deterministic reward seed a reward test to grow.
         env_writes.append(
@@ -316,14 +331,15 @@ def _cmd_setup(args: argparse.Namespace) -> int:
                     log=log,
                 )
             )
-        env_writes.append(
-            _write(
-                target / "eval.jsonl",
-                (root / seed["eval"]).read_text("utf-8"),
-                force=False,
-                log=log,
+        if "eval" in seed:
+            env_writes.append(
+                _write(
+                    target / "eval.jsonl",
+                    (root / seed["eval"]).read_text("utf-8"),
+                    force=False,
+                    log=log,
+                )
             )
-        )
 
     if args.verbose:
         print("\n".join(log))
@@ -337,12 +353,12 @@ def _cmd_setup(args: argparse.Namespace) -> int:
                 f"{len(_SKILLS)} stages × {n_ag} agent{'s' * (n_ag != 1)}",
             ),
         ]
-        if env_writes:  # every template ships a seed main.py + datasets
+        if env_writes:
             groups.append(
                 (
                     "env template",
                     env_writes,
-                    f"pyproject + main.py + datasets + tests ({args.template})",
+                    f"pyproject + main.py + data/tests ({args.template})",
                 )
             )
         label_w = max(len(label) for label, _, _ in groups)
@@ -352,7 +368,7 @@ def _cmd_setup(args: argparse.Namespace) -> int:
     print()
     print(paint(f"{target} has been set up for castform and your coding agent.", bold=True))
 
-    _print_get_started()
+    _print_get_started(args.template)
     return 0
 
 
@@ -368,16 +384,16 @@ def register(sub: argparse._SubParsersAction) -> None:
     p.add_argument("--force", action="store_true", help="Overwrite existing scaffold files")
     p.add_argument(
         "--template",
-        choices=["generic", "rag"],
+        choices=["generic", "rag", "harbor"],
         default="generic",
         help="Project guidance: 'generic' = a minimal single-turn env, 'rag' = "
-        "the same runnable seed plus RAG dependencies and links to maintained "
-        "Benchmax examples (default: generic)",
+        "the same runnable seed plus RAG dependencies, 'harbor' = a runtime "
+        "Harbor package with Modal sandboxes (default: generic)",
     )
     p.add_argument(
         "--no-template",
         action="store_true",
-        help="Skip the seed main.py + datasets (scaffold docs + skills only)",
+        help="Skip the seed main.py and any datasets (scaffold docs + skills only)",
     )
     p.add_argument("--skip-login", action="store_true", help="Don't sign in (scaffold only)")
     p.add_argument(

--- a/packages/castform/src/castform/validation.py
+++ b/packages/castform/src/castform/validation.py
@@ -11,8 +11,8 @@ from pathlib import Path
 from typing import Any
 
 from benchmax.auth import ModelAuth, StaticBearerAuth, bind_model_auth
-from benchmax.envs import DatasetSplit, Environment, RolloutOutcome, RolloutRequest
 
+from benchmax.envs import DatasetSplit, Environment, RolloutOutcome, RolloutRequest
 from castform import config
 from castform.model_auth import CastformModelAuth
 from castform.platform.client import RolloutClient
@@ -35,11 +35,16 @@ class ValidationReport:
     remote: dict[str, RolloutOutcome] | None = None
     local_errors: dict[str, str] = field(default_factory=dict)
     remote_errors: dict[str, str] = field(default_factory=dict)
+    static_warnings: dict[str, str] = field(default_factory=dict)
+    static_errors: dict[str, str] = field(default_factory=dict)
+    local_warnings: dict[str, list[str]] = field(default_factory=dict)
+    remote_warnings: dict[str, list[str]] = field(default_factory=dict)
 
     @property
     def ok(self) -> bool:
         return (
-            not self.local_errors
+            not self.static_errors
+            and not self.local_errors
             and _outcomes_executed(self.local)
             and (
                 self.remote is None or (not self.remote_errors and _outcomes_executed(self.remote))
@@ -76,6 +81,24 @@ async def validate_environment(
         max_context_tokens=max_context_tokens,
         local_timeout_seconds=local_timeout_seconds,
     )
+    diagnostics_method = getattr(env, "validation_diagnostics", None)
+    diagnostics = tuple(diagnostics_method()) if callable(diagnostics_method) else ()
+    static_warnings = {
+        diagnostic.location or f"warning-{index}": diagnostic.message
+        for index, diagnostic in enumerate(diagnostics)
+        if diagnostic.severity == "warning"
+    }
+    static_errors = {
+        diagnostic.location or f"error-{index}": diagnostic.message
+        for index, diagnostic in enumerate(diagnostics)
+        if diagnostic.severity == "error"
+    }
+    if static_errors:
+        return ValidationReport(
+            local={},
+            static_warnings=static_warnings,
+            static_errors=static_errors,
+        )
     resolved_base_url = config.llm_url()
     resolved_model_auth = model_auth or CastformModelAuth()
     if auth_bindings is None:
@@ -92,7 +115,7 @@ async def validate_environment(
     # model-call 5xx) should not force a full re-run of the whole pipeline.
     # A genuine environment defect still fails on the second attempt.
     for attempt in range(2):
-        local, local_errors, rollout_ids = await _run_local_validation(
+        local, local_errors, local_warnings, rollout_ids = await _run_local_validation(
             env=env,
             model=model,
             split=split,
@@ -115,6 +138,7 @@ async def validate_environment(
 
     remote: dict[str, RolloutOutcome] | None = None
     remote_errors: dict[str, str] = {}
+    remote_warnings: dict[str, list[str]] = {}
     if remote_assets is not None:
         client = RolloutClient(server_url=platform_url)
         for attempt in range(2):
@@ -133,12 +157,19 @@ async def validate_environment(
                 raise ValueError(f"hosted validation returned {len(events)} rollouts; expected 2")
             remote = {}
             remote_errors = {}
+            remote_warnings = {}
             for index, event in enumerate(events):
                 rollout_id = str(event.get("rollout_id") or f"remote-{index}")
                 if event.get("success") is not True:
                     remote_errors[rollout_id] = str(
                         event.get("error") or "rollout produced no usable model trace"
                     )
+                contract_errors = _contract_diagnostics(event, "contract_errors")
+                if contract_errors:
+                    _append_error(remote_errors, rollout_id, "; ".join(contract_errors))
+                contract_warnings = _contract_diagnostics(event, "contract_warnings")
+                if contract_warnings:
+                    remote_warnings[rollout_id] = contract_warnings
                 remote[rollout_id] = RolloutOutcome(
                     rewards=dict(event.get("rewards") or {}),
                     termination_reason=str(event.get("termination_reason") or "unknown"),
@@ -155,6 +186,10 @@ async def validate_environment(
         remote=remote,
         local_errors=local_errors,
         remote_errors=remote_errors,
+        static_warnings=static_warnings,
+        static_errors=static_errors,
+        local_warnings=local_warnings,
+        remote_warnings=remote_warnings,
     )
 
 
@@ -169,7 +204,12 @@ async def _run_local_validation(
     proxy_base_url: str,
     max_context_tokens: int,
     timeout_seconds: float | None,
-) -> tuple[dict[str, RolloutOutcome], dict[str, str], tuple[str, str]]:
+) -> tuple[
+    dict[str, RolloutOutcome],
+    dict[str, str],
+    dict[str, list[str]],
+    tuple[str, str],
+]:
     """Run one local group through ephemeral tracked llm-proxy sessions."""
 
     rollout_ids = tuple(f"validate-{uuid.uuid4()}" for _ in range(2))
@@ -230,6 +270,7 @@ async def _run_local_validation(
                     for rollout_id, outcome in local.items()
                     if outcome.error is not None
                 }
+                local_warnings: dict[str, list[str]] = {}
                 for session in sessions:
                     try:
                         capture = await session_client.collect(session)
@@ -243,7 +284,21 @@ async def _run_local_validation(
                             local_errors.setdefault(
                                 session.session_id, "rollout produced no usable model trace"
                             )
-                return local, local_errors, rollout_ids
+                        contract_errors = _contract_diagnostics(capture, "contract_errors")
+                        if contract_errors:
+                            _append_error(
+                                local_errors,
+                                session.session_id,
+                                "; ".join(contract_errors),
+                            )
+                        contract_warnings = _contract_diagnostics(capture, "contract_warnings")
+                        if contract_warnings:
+                            local_warnings[session.session_id] = contract_warnings
+                        if capture.get("num_calls") == 1:
+                            local_warnings.setdefault(session.session_id, []).append(
+                                "multi-turn history contract was not exercised"
+                            )
+                return local, local_errors, local_warnings, rollout_ids
     except TimeoutError as error:
         if not timeout.expired():
             raise
@@ -297,3 +352,25 @@ def _outcomes_executed(outcomes: dict[str, RolloutOutcome]) -> bool:
 
 def _termination_is_non_error(reason: str) -> bool:
     return reason.strip().lower() in _VALIDATION_NON_ERROR_TERMINATIONS
+
+
+def _contract_diagnostics(payload: Mapping[str, Any], field: str) -> list[str]:
+    raw = payload.get(field)
+    if not isinstance(raw, list):
+        return []
+    formatted: list[str] = []
+    for item in raw:
+        if not isinstance(item, Mapping):
+            formatted.append(str(item))
+            continue
+        code = str(item.get("code") or "session_contract")
+        location = item.get("field")
+        message = item.get("message")
+        detail = str(message) if message else repr(dict(item))
+        formatted.append(f"{code}{f' at {location}' if location else ''}: {detail}")
+    return formatted
+
+
+def _append_error(errors: dict[str, str], rollout_id: str, detail: str) -> None:
+    previous = errors.get(rollout_id)
+    errors[rollout_id] = f"{previous}; {detail}" if previous else detail

--- a/packages/castform/tests/unit/test_cli_setup.py
+++ b/packages/castform/tests/unit/test_cli_setup.py
@@ -160,6 +160,7 @@ def test_setup_generic_ships_seed_env_and_data(tmp_path, monkeypatch):
         "benchmax==0.1.2",
         "castform==0.1.2",
     ]
+    assert project["dependency-groups"]["dev"] == ["pytest>=8.4"]
 
 
 def test_setup_no_template_ships_docs_and_skills_only(tmp_path):
@@ -222,6 +223,7 @@ def test_setup_template_harbor_uses_runtime_data_and_explicit_args(tmp_path, mon
         "castform==0.1.2",
         "harbor[modal]>=0.18.0,<0.19",
     ]
+    assert project["dependency-groups"]["dev"] == ["pytest>=8.4"]
     main = (tmp_path / "main.py").read_text()
     assert "def _constructor_args(args: argparse.Namespace)" in main
     assert 'TrialAgentConfig(name="mini-swe-agent")' in main

--- a/packages/castform/tests/unit/test_cli_setup.py
+++ b/packages/castform/tests/unit/test_cli_setup.py
@@ -19,7 +19,7 @@ _SKILLS = (
     "view-progress",
 )
 
-# Every template now ships these — a runnable seed + tiny day-one datasets.
+# BaseEnv templates ship these — a runnable seed + tiny day-one datasets.
 _SEED_FILES = (
     "pyproject.toml",
     "main.py",
@@ -179,9 +179,7 @@ def test_setup_refuses_existing_main_py(tmp_path, capsys):
     assert "already exists" in capsys.readouterr().err
 
 
-def test_setup_template_rag_uses_generic_seed_and_provider_guidance(
-    tmp_path, monkeypatch
-):
+def test_setup_template_rag_uses_generic_seed_and_provider_guidance(tmp_path, monkeypatch):
     """The RAG template links to maintained examples instead of copying an adapter."""
     monkeypatch.setattr(setup, "version", lambda distribution: "0.1.2")
     assert setup._cmd_setup(_ns(tmp_path, template="rag")) == 0
@@ -201,14 +199,42 @@ def test_setup_template_rag_uses_generic_seed_and_provider_guidance(
     guidance = "\n".join(
         [
             (tmp_path / "GETTING_STARTED.md").read_text(),
-            (
-                tmp_path / ".agents" / "skills" / "generate-data" / "SKILL.md"
-            ).read_text(),
+            (tmp_path / ".agents" / "skills" / "generate-data" / "SKILL.md").read_text(),
         ]
     )
     for example in ("neon_rag", "turbopuffer_rag", "chroma_rag", "pinecone_rag"):
         assert f"benchmax/tree/main/examples/{example}" in guidance
     assert "HostedCorpusSearch" not in (tmp_path / "main.py").read_text()
+
+
+def test_setup_template_harbor_uses_runtime_data_and_explicit_args(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(setup, "version", lambda distribution: "0.1.2")
+    assert setup._cmd_setup(_ns(tmp_path, template="harbor")) == 0
+
+    module = load_module(tmp_path / "main.py")
+    assert discover_env_class(module).__name__ == "CustomHarborEnv"
+    assert not (tmp_path / "train.jsonl").exists()
+    assert not (tmp_path / "eval.jsonl").exists()
+
+    project = tomllib.loads((tmp_path / "pyproject.toml").read_text())
+    assert project["project"]["dependencies"] == [
+        "benchmax==0.1.2",
+        "castform==0.1.2",
+        "harbor[modal]>=0.18.0,<0.19",
+    ]
+    main = (tmp_path / "main.py").read_text()
+    assert "def _constructor_args(args: argparse.Namespace)" in main
+    assert 'TrialAgentConfig(name="mini-swe-agent")' in main
+    assert "upload_assets(bundle=bundle, run_name=run_name)" in main
+    assert "os.environ" not in main
+
+    getting_started = (tmp_path / "GETTING_STARTED.md").read_text()
+    assert "Harbor package" in getting_started
+    assert "AIME" in getting_started and "Harvey" in getting_started
+    assert "--verifier-env OPENAI_API_KEY=<key>" in getting_started
+    output = capsys.readouterr().out
+    assert "Harbor package <org/package>" in output
+    assert "synthetic dataset" not in output
 
 
 def test_setup_template_rag_refuses_existing_main_py(tmp_path, capsys):
@@ -252,6 +278,7 @@ def test_getting_started_teaches_script_workflow(tmp_path):
     assert "castform launch" not in gs
     assert "castform data" not in gs
     assert "Useful CLI commands" in gs
+    assert "closest maintained example" in gs.lower()
 
 
 def test_setup_env_conditional_surfacing(tmp_path):
@@ -280,10 +307,14 @@ def test_setup_env_conditional_surfacing(tmp_path):
         "reference_chunks",
         "source-ID canonicalization",
         "castform.rag",
-        "benchmax/tree/main/examples",
     ):
         assert sentinel in rag, f"rag scaffold missing {sentinel!r}"
         assert sentinel not in generic, f"generic scaffold leaked {sentinel!r}"
+
+    # Both flows send the agent to the closest maintained example; only the RAG
+    # flow adds provider-specific implementation guidance.
+    for blob in (generic, rag):
+        assert "benchmax/tree/main/examples" in blob
 
     # reversed convention + main.py naming in both scaffolds' guide/skills
     for blob in (generic, rag):

--- a/packages/castform/tests/unit/test_example_validation_contract.py
+++ b/packages/castform/tests/unit/test_example_validation_contract.py
@@ -1,0 +1,33 @@
+"""Repository-wide validation conventions for maintained examples."""
+
+import ast
+from pathlib import Path
+
+
+def test_examples_smoke_validate_the_required_train_split() -> None:
+    repository_root = Path(__file__).parents[4]
+    offenders = []
+    for main_py in sorted((repository_root / "examples").glob("*/main.py")):
+        tree = ast.parse(main_py.read_text(encoding="utf-8"))
+        validation_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and (
+                (isinstance(node.func, ast.Name) and node.func.id == "validate_environment")
+                or (
+                    isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "validate_environment"
+                )
+            )
+        ]
+        splits = [
+            keyword.value.value
+            for call in validation_calls
+            for keyword in call.keywords
+            if keyword.arg == "split" and isinstance(keyword.value, ast.Constant)
+        ]
+        if validation_calls and splits != ["train"]:
+            offenders.append(main_py.parent.name)
+
+    assert offenders == []

--- a/packages/castform/tests/unit/test_harbor_scaffold_runner.py
+++ b/packages/castform/tests/unit/test_harbor_scaffold_runner.py
@@ -1,0 +1,141 @@
+"""The Harbor scaffold's explicit constructor and runtime-data workflow."""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import castform.cli.scaffold as scaffold_pkg
+import pytest
+
+from ._scaffold import load_module
+
+_SEED = Path(scaffold_pkg.__file__).parent / "harbor_main.py"
+
+
+@pytest.fixture
+def mod(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    return load_module(_SEED)
+
+
+def _argv(action: str = "validate") -> list[str]:
+    return [
+        action,
+        "--dataset",
+        "org/tasks",
+        "--modal-token-id",
+        "modal-id",
+        "--modal-token-secret",
+        "modal-secret",
+        "--verifier-env",
+        "OPENAI_API_KEY=judge-key",
+    ]
+
+
+def _report(ok: bool = True):
+    return types.SimpleNamespace(
+        ok=ok,
+        static_warnings={},
+        static_errors={},
+        local=None,
+        remote=None,
+        local_errors={},
+        remote_errors={},
+    )
+
+
+def test_constructor_uses_stock_harness_without_model_overrides(mod):
+    args = types.SimpleNamespace(
+        dataset="org/tasks",
+        dataset_ref="latest",
+        modal_token_id="modal-id",
+        modal_token_secret="modal-secret",
+        verifier_env=["OPENAI_API_KEY=judge-key"],
+    )
+
+    constructor_args = mod._constructor_args(args)
+    env = mod.CustomHarborEnv(**constructor_args)
+
+    assert env._trial.agent.name == "mini-swe-agent"
+    assert env._trial.agent.model_name is None
+    assert env._trial.agent.kwargs == {}
+    assert env._trial.verifier.env == {"OPENAI_API_KEY": "judge-key"}
+    assert env.validation_diagnostics() == ()
+
+
+def test_harbor_seed_bundles_with_its_explicit_constructor_args(mod):
+    args = types.SimpleNamespace(
+        dataset="org/tasks",
+        dataset_ref="latest",
+        modal_token_id="modal-id",
+        modal_token_secret="modal-secret",
+        verifier_env=[],
+    )
+
+    bundle = mod.dump_bundle(
+        mod.CustomHarborEnv,
+        constructor_args=mod._constructor_args(args),
+        pip_dependencies=mod.RUNTIME_DEPENDENCIES,
+    )
+
+    assert bundle.pickled
+    assert bundle.metadata.pip_dependencies == ("harbor[modal]<0.19,>=0.18.0",)
+
+
+def test_data_action_needs_dataset_but_not_credentials(mod, capsys):
+    assert mod.main(["data", "--dataset", "org/tasks"]) == 0
+
+    output = capsys.readouterr().out
+    assert "org/tasks@latest resolves through Harbor at runtime" in output
+    assert "no JSONL upload is needed" in output
+
+
+def test_validate_reuses_constructor_values_and_uploads_no_jsonl(mod, monkeypatch):
+    captured: dict[str, object] = {}
+    uploaded = types.SimpleNamespace(
+        env_cls_path="env.pkl",
+        env_metadata_path="metadata.json",
+        dataset_path=None,
+    )
+
+    monkeypatch.setattr(mod, "ensure_session", lambda: None)
+
+    def fake_bundle(env_class, **kwargs):
+        captured["env_class"] = env_class
+        captured["constructor_args"] = kwargs["constructor_args"]
+        return object()
+
+    def fake_upload(**kwargs):
+        captured["upload"] = kwargs
+        return uploaded
+
+    def fake_validate(env, assets):
+        captured["local_env"] = env
+        captured["validated_assets"] = assets
+        return _report()
+
+    monkeypatch.setattr(mod, "dump_bundle", fake_bundle)
+    monkeypatch.setattr(mod, "upload_assets", fake_upload)
+    monkeypatch.setattr(mod, "validate", fake_validate)
+
+    assert mod.main(_argv()) == 0
+
+    constructor_args = captured["constructor_args"]
+    local_env = captured["local_env"]
+    assert constructor_args["dataset_name"] == local_env._dataset.name
+    assert constructor_args["dataset_ref"] == local_env._dataset.ref
+    assert constructor_args["verifier_env"] == local_env._trial.verifier.env
+    assert set(captured["upload"]) == {"bundle", "run_name"}
+    assert captured["validated_assets"] is uploaded
+
+
+def test_validate_requires_explicit_modal_credentials_before_network(mod, monkeypatch):
+    monkeypatch.setattr(
+        mod,
+        "ensure_session",
+        lambda: (_ for _ in ()).throw(AssertionError("network stage reached")),
+    )
+
+    with pytest.raises(SystemExit):
+        mod.main(["validate", "--dataset", "org/tasks"])

--- a/packages/castform/tests/unit/test_scaffold_runner.py
+++ b/packages/castform/tests/unit/test_scaffold_runner.py
@@ -212,6 +212,71 @@ def test_scorecard_marks_error_settlements_and_shows_messages(mod, capsys):
     assert "❌ validation failed" in output
 
 
+def test_scorecard_surfaces_static_and_runtime_contract_warnings(mod, capsys):
+    outcome = types.SimpleNamespace(
+        rewards={"correct": 1.0},
+        termination_reason="finished",
+        error=None,
+    )
+    report = types.SimpleNamespace(
+        ok=True,
+        local={"validate-0": outcome},
+        remote=None,
+        static_warnings={"agent.kwargs.max_tokens": "output cap is trainer-clamped"},
+        local_warnings={
+            "validate-0": ["max_tokens requested 4096 but the effective output cap was 1024"]
+        },
+        remote_warnings={},
+        local_errors={},
+        remote_errors={},
+    )
+
+    mod._print_validation(report)
+
+    output = capsys.readouterr().out
+    assert "agent.kwargs.max_tokens" in output
+    assert "effective output cap was 1024" in output
+    assert "✅ validation passed" in output
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "CLAUDE.md",
+        "STARTER.md",
+        "skills/design-environment/SKILL.md",
+    ],
+)
+def test_scaffold_design_guidance_documents_model_parameter_ownership(
+    relative_path: str,
+) -> None:
+    guidance = (_SCAFFOLD_DIR / relative_path).read_text().lower()
+
+    assert "max_tokens" in guidance
+    assert "max_completion_tokens" in guidance
+    assert "temperature" in guidance
+    assert "top_p" in guidance
+    assert "warning" in guidance
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "skills/verify-environment/SKILL.md",
+        "skills/launch-run/SKILL.md",
+    ],
+)
+def test_scaffold_validation_guidance_requires_training_contract_checks(
+    relative_path: str,
+) -> None:
+    guidance = (_SCAFFOLD_DIR / relative_path).read_text().lower()
+
+    assert "sampling" in guidance
+    assert "history" in guidance
+    assert "validate_environment" in guidance
+    assert "do not launch" in guidance or "never launch" in guidance
+
+
 # ── launch stage: [y/N] confirm and the asdict spread ───────────────────────────
 
 _Uploaded = dataclasses.make_dataclass(
@@ -255,9 +320,9 @@ def test_launch_confirmed_spreads_uploaded_paths(mod, monkeypatch):
     # LAUNCH_CONFIG feeds launcher_args, minus reserved keys
     assert "type" not in (launched["launcher_args"] or {})
     assert "name" not in (launched["launcher_args"] or {})
-    assert launched["launcher_args"]["max_context_tokens"] == mod.LAUNCH_CONFIG[
-        "max_context_tokens"
-    ]
+    assert (
+        launched["launcher_args"]["max_context_tokens"] == mod.LAUNCH_CONFIG["max_context_tokens"]
+    )
 
 
 def test_launch_assume_yes_skips_prompt(mod, monkeypatch):

--- a/packages/castform/tests/unit/test_scaffold_runner.py
+++ b/packages/castform/tests/unit/test_scaffold_runner.py
@@ -49,6 +49,10 @@ def test_import_defines_stages_without_running(mod, tmp_path, monkeypatch):
     assert not (tmp_path / "train.jsonl").exists()
 
 
+def test_constructor_args_follow_the_example_shape(mod):
+    assert mod._constructor_args(types.SimpleNamespace()) == {}
+
+
 # ── argparse dispatch: the staged upload-once flow ──────────────────────────────
 
 
@@ -156,7 +160,9 @@ def test_validate_passes_uploaded_assets_and_config(mod, tmp_path, monkeypatch):
         return _fake_report(ok=True)
 
     monkeypatch.setattr(mod, "validate_environment", fake_validate_environment)
-    report = mod.validate(env_class(**mod.ENV_ARGS), remote_assets)
+    report = mod.validate(
+        env_class(**mod._constructor_args(types.SimpleNamespace())), remote_assets
+    )
 
     assert report.ok
     assert isinstance(captured["env"], env_class)
@@ -176,7 +182,7 @@ def test_validate_surfaces_public_dataset_materialization_failure(mod, monkeypat
     env_class = discover_env_class(mod)
 
     with pytest.raises(RuntimeError, match="dataset materialization failed"):
-        mod.validate(env_class(**mod.ENV_ARGS), None)
+        mod.validate(env_class(**mod._constructor_args(types.SimpleNamespace())), None)
 
 
 def test_scorecard_marks_error_settlements_and_shows_messages(mod, capsys):

--- a/packages/castform/tests/unit/test_scaffold_runner.py
+++ b/packages/castform/tests/unit/test_scaffold_runner.py
@@ -4,6 +4,7 @@ monkeypatched (no network)."""
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import types
 from pathlib import Path
@@ -51,6 +52,64 @@ def test_import_defines_stages_without_running(mod, tmp_path, monkeypatch):
 
 def test_constructor_args_follow_the_example_shape(mod):
     assert mod._constructor_args(types.SimpleNamespace()) == {}
+
+
+def test_launch_config_names_the_training_model(mod):
+    assert mod.LAUNCH_CONFIG["model"] == "Qwen/Qwen3.5-4B"
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        {},
+        {"prompt": "", "ground_truth": "Paris"},
+        {"prompt": 123, "ground_truth": "Paris"},
+        {"prompt": "Capital of France?"},
+        {"prompt": "Capital of France?", "ground_truth": ""},
+        {"prompt": "Capital of France?", "ground_truth": 123},
+    ],
+)
+def test_row_converter_rejects_malformed_seed_rows(mod, row):
+    with pytest.raises((TypeError, ValueError)):
+        mod.CustomEnv()._example_from_row(row)
+
+
+def test_row_converter_owns_reserved_prompt_messages(mod):
+    example = mod.CustomEnv()._example_from_row(
+        {
+            "prompt": "Capital of France?",
+            "ground_truth": "Paris",
+            "prompt_messages": [{"role": "user", "content": "override"}],
+        }
+    )
+
+    assert example.payload["prompt_messages"][-1]["content"] == "Capital of France?"
+
+
+def test_dataset_path_uses_the_safe_resolver(mod, tmp_path, monkeypatch):
+    data_path = tmp_path / "train.jsonl"
+    data_path.write_text('{"prompt":"question","ground_truth":"answer"}\n')
+    calls: list[tuple[Path, str]] = []
+
+    def fake_resolve(base_dir, relative_path):
+        calls.append((base_dir, relative_path))
+        return data_path
+
+    monkeypatch.setattr(mod, "resolve_dataset_path", fake_resolve)
+    dataset = asyncio.run(mod.CustomEnv().create_dataset("train", tmp_path))
+
+    assert len(dataset) == 1
+    assert calls == [(tmp_path, "train.jsonl")]
+
+
+def test_generate_data_preserves_an_existing_split_without_force(mod, tmp_path):
+    train_path = tmp_path / mod.TRAIN_FILE
+    train_path.write_text("curated train data\n")
+
+    assert mod.generate_data(force=False)
+
+    assert train_path.read_text() == "curated train data\n"
+    assert (tmp_path / mod.EVAL_FILE).exists()
 
 
 # ── argparse dispatch: the staged upload-once flow ──────────────────────────────
@@ -281,6 +340,13 @@ def test_scaffold_validation_guidance_requires_training_contract_checks(
     assert "history" in guidance
     assert "validate_environment" in guidance
     assert "do not launch" in guidance or "never launch" in guidance
+
+
+def test_launch_skill_uses_explicit_constructor_args_not_legacy_global() -> None:
+    guidance = (_SCAFFOLD_DIR / "skills/launch-run/SKILL.md").read_text()
+
+    assert "constructor_args=constructor_args" in guidance
+    assert "constructor_args=ENV_ARGS" not in guidance
 
 
 # ── launch stage: [y/N] confirm and the asdict spread ───────────────────────────

--- a/packages/castform/tests/unit/test_validation.py
+++ b/packages/castform/tests/unit/test_validation.py
@@ -6,16 +6,26 @@ from typing import Any
 
 import pytest
 from benchmax.auth import InjectedAuth, ModelRequestContext, StaticBearerAuth
-from benchmax.envs import Dataset, Example, RolloutOutcome
+from benchmax.envs.harbor import (
+    BundledAgentSource,
+    BundledHarborAgent,
+    HarborEnv,
+    HarborTrialTemplate,
+)
 from castform.model_auth import CastformModelAuth
 from castform.platform.environment_assets import UploadedEnvironmentAssets
 from castform.platform.model_session import ModelSession
 from castform.validation import validate_environment
+from harbor import DatasetConfig, EnvironmentType
+from harbor.models.trial.config import AgentConfig, EnvironmentConfig, VerifierConfig
+
+from benchmax.envs import Dataset, Example, RolloutOutcome
 
 
 class FakeModelSessionClient:
     instances: list[FakeModelSessionClient] = []
     capture_num_calls = 1
+    capture_payload: dict[str, Any] | None = None
 
     def __init__(self, *, base_url, model_auth):
         self.base_url = base_url
@@ -37,6 +47,8 @@ class FakeModelSessionClient:
 
     async def collect(self, session):
         self.collected.append(session.session_id)
+        if self.capture_payload is not None:
+            return dict(self.capture_payload)
         return {"num_calls": self.capture_num_calls, "truncated": False}
 
     async def discard(self, session):
@@ -50,6 +62,7 @@ class FakeModelSessionClient:
 def fake_model_sessions(monkeypatch):
     FakeModelSessionClient.instances.clear()
     FakeModelSessionClient.capture_num_calls = 1
+    FakeModelSessionClient.capture_payload = None
     monkeypatch.setattr(
         "castform.validation.ModelSessionClient",
         FakeModelSessionClient,
@@ -75,6 +88,47 @@ class RecordingEnvironment:
             Example(id="example-2", payload={}),
         ]
         return Dataset(examples[:max_examples])
+
+    async def run_group(self, requests):
+        group = list(requests)
+        self.groups.append(group)
+        return {
+            request.rollout_id: RolloutOutcome(
+                rewards={"score": 1.0},
+                termination_reason="finished",
+            )
+            for request in group
+        }
+
+
+class RecordingHarborEnvironment(HarborEnv):
+    def __init__(
+        self,
+        *,
+        tmp_path: Path,
+        agent_kwargs: dict[str, Any] | None = None,
+        agent: Any | None = None,
+    ) -> None:
+        super().__init__(
+            dataset=DatasetConfig(path=tmp_path),
+            trial=HarborTrialTemplate(
+                agent=agent or AgentConfig(name="mini-swe-agent", kwargs=agent_kwargs or {}),
+                environment=EnvironmentConfig(type=EnvironmentType.DOCKER),
+                verifier=VerifierConfig(),
+                trials_dir=tmp_path / "trials",
+            ),
+            requires_public_model_endpoint=False,
+        )
+        self.groups: list[list[Any]] = []
+
+    async def create_dataset(
+        self,
+        split,
+        base_dir,
+        *,
+        max_examples: int | None = None,
+    ):
+        return Dataset([Example(id="harbor-example", payload={})])
 
     async def run_group(self, requests):
         group = list(requests)
@@ -122,6 +176,215 @@ async def test_validation_uses_first_dataset_item_for_two_local_siblings(
     assert len(sessions.collected) == 2
     assert sessions.discarded == []
     assert sessions.closed
+
+
+@pytest.mark.parametrize("token_field", ["max_tokens", "max_completion_tokens"])
+async def test_harbor_static_validation_warns_for_harness_output_caps(
+    tmp_path: Path,
+    token_field: str,
+) -> None:
+    env = RecordingHarborEnvironment(
+        tmp_path=tmp_path,
+        agent_kwargs={token_field: 1024},
+    )
+
+    report = await validate_environment(
+        env,
+        model="test-model",
+        split="train",
+        base_dir=tmp_path,
+        model_auth=StaticBearerAuth("test-token"),
+    )
+
+    assert report.ok
+    warnings = getattr(report, "static_warnings", {})
+    assert warnings
+    assert token_field in str(warnings)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("temperature", 0.7),
+        ("top_p", 0.9),
+        ("presence_penalty", 0.2),
+        ("frequency_penalty", 0.2),
+        ("seed", 42),
+        ("stop", ["DONE"]),
+    ],
+)
+async def test_harbor_static_validation_rejects_trainer_owned_agent_sampling(
+    tmp_path: Path,
+    field: str,
+    value: Any,
+) -> None:
+    env = RecordingHarborEnvironment(
+        tmp_path=tmp_path,
+        agent_kwargs={field: value},
+    )
+
+    report = await validate_environment(
+        env,
+        model="test-model",
+        split="train",
+        base_dir=tmp_path,
+        model_auth=StaticBearerAuth("test-token"),
+    )
+
+    assert not report.ok
+    errors = getattr(report, "static_errors", {})
+    assert errors
+    assert field in str(errors)
+    assert env.groups == []
+
+
+async def test_harbor_static_validation_finds_nested_model_sampling(
+    tmp_path: Path,
+) -> None:
+    env = RecordingHarborEnvironment(
+        tmp_path=tmp_path,
+        agent_kwargs={"model_kwargs": {"temperature": 0.7}},
+    )
+
+    report = await validate_environment(
+        env,
+        model="test-model",
+        split="train",
+        base_dir=tmp_path,
+        model_auth=StaticBearerAuth("test-token"),
+    )
+
+    assert not report.ok
+    assert "model_kwargs.temperature" in str(getattr(report, "static_errors", {}))
+    assert env.groups == []
+
+
+async def test_harbor_static_validation_inspects_bundled_agent_kwargs(
+    tmp_path: Path,
+) -> None:
+    bundled = BundledHarborAgent(
+        config=AgentConfig(
+            import_path="agent:Agent",
+            kwargs={"temperature": 0.7},
+        ),
+        source=BundledAgentSource.from_files({"agent.py": b"class Agent:\n    pass\n"}),
+    )
+    env = RecordingHarborEnvironment(tmp_path=tmp_path, agent=bundled)
+
+    report = await validate_environment(
+        env,
+        model="test-model",
+        split="train",
+        base_dir=tmp_path,
+        model_auth=StaticBearerAuth("test-token"),
+    )
+
+    assert not report.ok
+    assert "temperature" in str(getattr(report, "static_errors", {}))
+    assert env.groups == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("n", 2),
+        ("tool_choice", "none"),
+        ("logprobs", True),
+        ("response_format", {"type": "json_object"}),
+        ("return_routed_experts", True),
+        ("max_new_tokens", 1024),
+        ("reasoning_effort", "high"),
+    ],
+)
+async def test_harbor_static_validation_rejects_unsupported_model_controls(
+    tmp_path: Path,
+    field: str,
+    value: Any,
+) -> None:
+    env = RecordingHarborEnvironment(
+        tmp_path=tmp_path,
+        agent_kwargs={field: value},
+    )
+
+    report = await validate_environment(
+        env,
+        model="test-model",
+        split="train",
+        base_dir=tmp_path,
+        model_auth=StaticBearerAuth("test-token"),
+    )
+
+    assert not report.ok
+    assert field in str(getattr(report, "static_errors", {}))
+    assert env.groups == []
+
+
+async def test_local_validation_fails_on_proxy_session_contract_errors(
+    fake_model_sessions,
+) -> None:
+    fake_model_sessions.capture_payload = {
+        "num_calls": 2,
+        "truncated": False,
+        "contract_errors": [
+            {
+                "turn": 1,
+                "field": "messages[1].content",
+                "code": "history_diverged",
+                "message": "committed assistant response changed",
+            }
+        ],
+    }
+
+    report = await validate_environment(
+        RecordingEnvironment(),
+        model="test-model",
+        model_auth=StaticBearerAuth("rollout-token"),
+    )
+
+    assert not report.ok
+    assert all("history_diverged" in error for error in report.local_errors.values())
+
+
+async def test_local_validation_surfaces_proxy_contract_warnings_without_failing(
+    fake_model_sessions,
+) -> None:
+    fake_model_sessions.capture_payload = {
+        "num_calls": 2,
+        "truncated": False,
+        "contract_warnings": [
+            {
+                "turn": 0,
+                "field": "max_tokens",
+                "code": "output_cap_clamped",
+                "requested": 4096,
+                "effective": 1024,
+            }
+        ],
+    }
+
+    report = await validate_environment(
+        RecordingEnvironment(),
+        model="test-model",
+        model_auth=StaticBearerAuth("rollout-token"),
+    )
+
+    assert report.ok
+    warnings = getattr(report, "local_warnings", {})
+    assert warnings
+    assert "output_cap_clamped" in str(warnings)
+
+
+async def test_single_call_validation_warns_that_history_was_not_exercised() -> None:
+    report = await validate_environment(
+        RecordingEnvironment(),
+        model="test-model",
+        model_auth=StaticBearerAuth("rollout-token"),
+    )
+
+    assert report.ok
+    warnings = getattr(report, "local_warnings", {})
+    assert warnings
+    assert "multi-turn" in str(warnings).lower()
 
 
 async def test_validation_rejects_an_empty_dataset() -> None:
@@ -210,6 +473,54 @@ async def test_remote_validation_rejects_a_finished_event_without_a_trace(
     assert report.remote_errors == {"remote-0": "missing_model_trace"}
     assert report.remote is not None
     assert report.remote["remote-1"].termination_reason == "context_exceeded"
+
+
+async def test_remote_validation_rejects_proxy_session_contract_errors(
+    monkeypatch,
+) -> None:
+    class ContractErrorRolloutClient:
+        def __init__(self, **kwargs):
+            pass
+
+        def run_group(self, **kwargs):
+            return [
+                {
+                    "rollout_id": f"remote-{index}",
+                    "success": True,
+                    "rewards": {"score": 1.0},
+                    "termination_reason": "finished",
+                    "contract_errors": [
+                        {
+                            "turn": 1,
+                            "field": "temperature",
+                            "code": "sampling_policy_conflict",
+                            "requested": 0.7,
+                            "configured": 0.2,
+                        }
+                    ],
+                }
+                for index in range(2)
+            ]
+
+    monkeypatch.setattr(
+        "castform.validation.RolloutClient",
+        ContractErrorRolloutClient,
+    )
+
+    report = await validate_environment(
+        RecordingEnvironment(),
+        model="test-model",
+        model_auth=StaticBearerAuth("rollout-token"),
+        remote_assets=UploadedEnvironmentAssets(
+            env_cls_path="envs/run/env-cls.pkl",
+            env_metadata_path="envs/run/env-metadata.json",
+            dataset_path=None,
+        ),
+    )
+
+    assert not report.ok
+    assert report.remote_errors
+    assert "sampling_policy_conflict" in str(report.remote_errors)
 
 
 async def test_auth_binding_covers_dataset_creation_and_all_managed_purposes() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ members = [
     "benchmax-example-dominant-color",
     "benchmax-example-geo3k",
     "benchmax-example-harvey",
+    "benchmax-example-ineqmath-45",
     "benchmax-example-math",
     "benchmax-example-neon-rag",
     "benchmax-example-pinecone-rag",
@@ -355,6 +356,35 @@ dev = [
 ]
 
 [[package]]
+name = "benchmax-example-ineqmath-45"
+version = "0.1.0"
+source = { editable = "examples/ineqmath-45" }
+dependencies = [
+    { name = "castform" },
+    { name = "harbor" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "castform", editable = "packages/castform" },
+    { name = "harbor", specifier = ">=0.18.0,<0.19" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
+    { name = "ruff", specifier = ">=0.14.2" },
+]
+
+[[package]]
 name = "benchmax-example-math"
 version = "0.1.0"
 source = { editable = "examples/math" }
@@ -543,6 +573,7 @@ source = { editable = "packages/castform" }
 dependencies = [
     { name = "benchmax" },
     { name = "httpx", extra = ["http2"] },
+    { name = "tqdm" },
 ]
 
 [package.optional-dependencies]
@@ -562,10 +593,6 @@ rag = [
     { name = "ruamel-yaml" },
     { name = "scikit-learn" },
     { name = "sentence-transformers" },
-    { name = "tqdm" },
-]
-traces = [
-    { name = "tqdm" },
 ]
 turbopuffer = [
     { name = "turbopuffer" },
@@ -594,11 +621,10 @@ requires-dist = [
     { name = "scikit-learn", marker = "extra == 'rag'", specifier = ">=1.8.0" },
     { name = "sentence-transformers", marker = "extra == 'rag'", specifier = ">=5.2.3" },
     { name = "snowballstemmer", marker = "extra == 'chroma'", specifier = ">=2.2.0" },
-    { name = "tqdm", marker = "extra == 'rag'", specifier = ">=4.66.0" },
-    { name = "tqdm", marker = "extra == 'traces'", specifier = ">=4.66.0" },
+    { name = "tqdm", specifier = ">=4.66.0" },
     { name = "turbopuffer", marker = "extra == 'turbopuffer'", specifier = ">=2.6.0,<3" },
 ]
-provides-extras = ["rag", "traces", "chroma", "pinecone", "turbopuffer"]
+provides-extras = ["rag", "chroma", "pinecone", "turbopuffer"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- add static Harbor harness diagnostics for trainer-owned and unsupported model controls while warning on output caps
- surface tracked-session sampling/history contract errors and warnings during local and hosted `validate_environment`
- update generated validation output and compact scaffold guidance for model ownership, explicit constructor arguments, closest examples, and Harbor-shaped tasks
- remove the unused `castform[traces]` extra and keep trace support in the base package
- raise Harvey's validation context budget to cover its first useful turn

## Why

Harbor harness configuration and rewritten multi-turn histories could pass environment validation but fail only after a GPU training run started. Validation now fails earlier on incompatible controls and consumes the same tracked-session diagnostics used by training.

## Impact

Environment authors get actionable static and runtime validation errors before launch. Output ceilings remain supported with a warning because the trainer may clamp them to the remaining context budget.

## Checks

- `uv run pytest packages/benchmax/tests/unit/harbor/test_harbor_env.py packages/castform/tests/unit/test_validation.py packages/castform/tests/unit/test_scaffold_runner.py` — 109 passed
- Ruff check and format check on all changed Python files
- manual review of the scaffold skill guidance
