### PR TITLE
SFT v1.1: optimizer/LoRA/batch knobs and eval assets in the SDK

### DIFF
--- a/packages/castform/src/castform/cli/scaffold/skills/train-sft/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/train-sft/SKILL.md
@@ -76,6 +76,8 @@ turns contribute to the loss.
 | `adam_beta2` | 0.9–0.999 | unset |
 | `grad_clip` | (0, 10] | unset |
 | `lora_rank` | 32 or 64 | unset — keeps the platform's fixed policy |
+| `global_batch_size` | 4–64, multiple of 4 | unset — 4 |
+| `eval_interval` (steps) | 1–10000; only with an eval set | unset — derived from `save_interval` |
 
 Every arg below `seed` is optional and unset by default: leave one out and the
 platform's own value applies, so an untouched config behaves exactly as before
@@ -87,6 +89,31 @@ a knob. Rank 128 is not accepted — it trains, but serving cannot load it.
 Model (`Qwen/Qwen3.5-4B`) and GPU topology are platform-owned — do not invent
 knobs for them. A row that renders past `max_context_tokens` tokens fails the
 run's preflight; trim long rows up front.
+
+## Held-out eval (optional)
+
+Pass a second dataset to score during training:
+
+```python
+assets = upload_sft_assets(dataset=train, eval_dataset=held_out, run_name="...")
+```
+
+The eval set is scored on the live weights between training steps and plotted
+as `eval/loss` beside `train/loss`. Rules worth knowing before you offer it:
+
+- **At most 2048 rows**, under the same per-row limits as training rows. The
+  bound is a compute bound, not a taste one — eval runs on the training GPUs
+  and pauses training while it does.
+- **It is never billed.** Eval forward passes cost the user nothing, which is
+  also why the size and cadence are capped rather than left open.
+- **Cadence defaults to `save_interval`**, so by default every eval lands on a
+  checkpoint. Set `eval_interval` only to make it sparser; a much denser
+  cadence is rejected at launch.
+- An eval set is part of the data identity: changing it produces a different
+  upload prefix, and a resumed run must keep the one it started with.
+
+Skip it for small or exploratory runs — a held-out split costs training rows,
+and `train/loss` alone answers "is this learning at all".
 
 ## Cost and consent
 
@@ -102,9 +129,10 @@ this account — surface that to the user rather than retrying.
 ## Monitor
 
 Same as any run (`view-progress` skill): `castform runs status <id>`, and
-`castform runs scalars <id>` — watch `train/loss` fall; there are no rollouts,
-evals, or reward curves for SFT runs. The run page shows loss, dataset prefix,
-and config only.
+`castform runs scalars <id>` — watch `train/loss` fall, and `eval/loss` too
+when the run has an eval set. There are no rollouts or reward curves for SFT
+runs. The run page shows loss, dataset prefix, and config; runs with an eval
+set also get an eval tab, chart-only.
 
 ## Reference
 

--- a/packages/castform/src/castform/cli/scaffold/skills/train-sft/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/train-sft/SKILL.md
@@ -70,10 +70,23 @@ turns contribute to the loss.
 | `max_context_tokens` | 256–8192 (hard cap) | 8192 |
 | `save_interval` (steps) | 1–10000 | 20 |
 | `seed` | 0–2147483647 | 42 |
+| `lr_decay_style` | `"constant"` or `"cosine"` | unset — keeps the platform default |
+| `min_lr` | ≥ 0 and below `learning_rate` | unset |
+| `warmup_ratio` | 0–0.5 of total steps | unset |
+| `adam_beta2` | 0.9–0.999 | unset |
+| `grad_clip` | (0, 10] | unset |
+| `lora_rank` | 32 or 64 | unset — keeps the platform's fixed policy |
 
-Model (`Qwen/Qwen3.5-4B`), LoRA policy, and GPU topology are platform-owned —
-do not invent knobs for them. A row that renders past `max_context_tokens`
-tokens fails the run's preflight; trim long rows up front.
+Every arg below `seed` is optional and unset by default: leave one out and the
+platform's own value applies, so an untouched config behaves exactly as before
+these knobs existed. Do not set one just to restate a default.
+
+`lora_rank` picks the adapter's rank; alpha is always derived as 2x and is not
+a knob. Rank 128 is not accepted — it trains, but serving cannot load it.
+
+Model (`Qwen/Qwen3.5-4B`) and GPU topology are platform-owned — do not invent
+knobs for them. A row that renders past `max_context_tokens` tokens fails the
+run's preflight; trim long rows up front.
 
 ## Cost and consent
 

--- a/packages/castform/src/castform/cli/scaffold/skills/train-sft/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/train-sft/SKILL.md
@@ -79,7 +79,7 @@ turns contribute to the loss.
 | `global_batch_size` | 4–64, multiple of 4 | unset — 4 |
 | `eval_interval` (steps) | 1–10000; only with an eval set | unset — derived from `save_interval` |
 
-Every arg below `seed` is optional and unset by default: leave one out and the
+Every arg whose default reads `unset` is optional: leave it out and the
 platform's own value applies, so an untouched config behaves exactly as before
 these knobs existed. Do not set one just to restate a default.
 

--- a/packages/castform/src/castform/platform/client.py
+++ b/packages/castform/src/castform/platform/client.py
@@ -466,17 +466,41 @@ class TrainerClient:
         resolved = config if config is not None else SftTrainingConfig()
         if not isinstance(resolved, SftTrainingConfig):
             raise TypeError(f"config must be an SftTrainingConfig, got {type(config).__name__}")
-        response = self._http_client.post(
-            "/v1/train/runs/sft",
-            json={
-                "name": name,
-                "dataset": {
-                    "format": assets.dataset_format,
-                    "path": assets.dataset_path,
-                },
-                "args": resolved.as_args(),
-            },
-        )
+        dataset: dict[str, Any] = {
+            "format": assets.dataset_format,
+            "path": assets.dataset_path,
+        }
+        body: dict[str, Any] = {
+            "name": name,
+            "dataset": dataset,
+            "args": resolved.as_args(),
+        }
+
+        # The MARKER is what turns eval on, and it rides the uploaded assets
+        # rather than the config — a caller cannot request eval against a
+        # prefix that has no eval.jsonl. Train identity travels WITH the marker
+        # and only then: the platform needs it to derive the pass cap and
+        # re-derive the prefix, while a request without eval stays exactly the
+        # v1 body.
+        if assets.eval_digest is not None and assets.eval_row_count is not None:
+            if assets.row_count is None:
+                raise ValueError(
+                    "assets carry an eval set but no train row_count; re-upload with "
+                    "upload_sft_assets so the launch can be range-checked"
+                )
+            dataset["digest"] = assets.content_digest
+            dataset["rows"] = assets.row_count
+            body["eval"] = {
+                "rows": assets.eval_row_count,
+                "digest": assets.eval_digest,
+            }
+        elif resolved.eval_interval is not None:
+            raise ValueError(
+                "eval_interval was set but the uploaded assets carry no eval set; "
+                "pass eval_dataset=... to upload_sft_assets or drop eval_interval"
+            )
+
+        response = self._http_client.post("/v1/train/runs/sft", json=body)
         self._handle_response_errors(response)
         return response.json()["runId"]
 

--- a/packages/castform/src/castform/platform/client.py
+++ b/packages/castform/src/castform/platform/client.py
@@ -476,12 +476,10 @@ class TrainerClient:
             "args": resolved.as_args(),
         }
 
-        # The MARKER is what turns eval on, and it rides the uploaded assets
-        # rather than the config — a caller cannot request eval against a
-        # prefix that has no eval.jsonl. Train identity travels WITH the marker
-        # and only then: the platform needs it to derive the pass cap and
-        # re-derive the prefix, while a request without eval stays exactly the
-        # v1 body.
+        # The MARKER turns eval on and rides the uploaded assets, not the
+        # config: no eval.jsonl in the prefix, no eval. Train identity is sent
+        # only alongside the marker, since the platform needs it to derive the
+        # pass cap and re-derive the prefix.
         if assets.eval_digest is not None and assets.eval_row_count is not None:
             if assets.row_count is None:
                 raise ValueError(

--- a/packages/castform/src/castform/platform/sft.py
+++ b/packages/castform/src/castform/platform/sft.py
@@ -22,6 +22,16 @@ from .environment_assets import _validate_blob_path
 
 __all__ = ["SftTrainingConfig", "UploadedSftAssets", "upload_sft_assets"]
 
+_LR_DECAY_STYLES = frozenset({"constant", "cosine"})
+
+# Rank 128 trains but fused QKV expands it past serving MAX_LORA_RANK caps, so
+# it stays platform-only; these mirror the server's public set.
+_PUBLIC_LORA_RANKS = frozenset({32, 64})
+
+# Megatron needs global_batch_size divisible by the data-parallel width, which
+# is 4 on the fixed SFT topology. Mirrors the server; the server is authority.
+_DATA_PARALLEL_SIZE = 4
+
 
 @dataclass(frozen=True)
 class UploadedSftAssets:
@@ -53,6 +63,17 @@ class SftTrainingConfig:
     max_context_tokens: int = 8192
     save_interval: int = 20
     seed: int = 42
+    # v1.1 knobs. ``None`` means "not sent": the field is omitted from
+    # ``as_args()`` entirely, so the platform stamps nothing and the trainer
+    # keeps the model config's value. An untouched config therefore still
+    # produces exactly the v1 five-key payload.
+    lr_decay_style: str | None = None
+    min_lr: float | None = None
+    warmup_ratio: float | None = None
+    adam_beta2: float | None = None
+    grad_clip: float | None = None
+    lora_rank: int | None = None
+    global_batch_size: int | None = None
 
     def __post_init__(self) -> None:
         self._require_int("num_epochs", self.num_epochs, 1, 100)
@@ -65,6 +86,26 @@ class SftTrainingConfig:
         self._require_int("save_interval", self.save_interval, 1, 10_000)
         self._require_int("seed", self.seed, 0, 2_147_483_647)
 
+        if self.lr_decay_style is not None and self.lr_decay_style not in _LR_DECAY_STYLES:
+            raise ValueError(f"lr_decay_style must be one of {', '.join(sorted(_LR_DECAY_STYLES))}")
+        self._require_optional_number("min_lr", self.min_lr, 0.0, None)
+        if self.min_lr is not None and self.min_lr >= rate:
+            raise ValueError("min_lr must be less than learning_rate")
+        self._require_optional_number("warmup_ratio", self.warmup_ratio, 0.0, 0.5)
+        self._require_optional_number("adam_beta2", self.adam_beta2, 0.9, 0.999)
+        self._require_optional_number("grad_clip", self.grad_clip, None, 10.0, exclusive_minimum=0.0)
+        if self.lora_rank is not None and self.lora_rank not in _PUBLIC_LORA_RANKS:
+            raise ValueError(
+                f"lora_rank must be one of {', '.join(str(r) for r in sorted(_PUBLIC_LORA_RANKS))}"
+            )
+        if self.global_batch_size is not None:
+            self._require_int("global_batch_size", self.global_batch_size, _DATA_PARALLEL_SIZE, 64)
+            if self.global_batch_size % _DATA_PARALLEL_SIZE:
+                raise ValueError(
+                    f"global_batch_size must be a multiple of {_DATA_PARALLEL_SIZE} "
+                    "(the data-parallel width of the fixed SFT topology)"
+                )
+
     @staticmethod
     def _require_int(name: str, value: object, minimum: int, maximum: int) -> None:
         if isinstance(value, bool) or not isinstance(value, int):
@@ -72,16 +113,57 @@ class SftTrainingConfig:
         if not minimum <= value <= maximum:
             raise ValueError(f"{name} must be between {minimum} and {maximum}")
 
-    def as_args(self) -> dict[str, int | float]:
-        """The resolved public ``args`` object for the SFT launch request."""
+    @staticmethod
+    def _require_optional_number(
+        name: str,
+        value: object,
+        minimum: float | None,
+        maximum: float | None,
+        *,
+        exclusive_minimum: float | None = None,
+    ) -> None:
+        """Range-check a v1.1 knob, leaving ``None`` (not sent) untouched."""
 
-        return {
+        if value is None:
+            return
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise ValueError(f"{name} must be a number")
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must be finite")
+        if minimum is not None and value < minimum:
+            raise ValueError(f"{name} must be at least {minimum}")
+        if exclusive_minimum is not None and value <= exclusive_minimum:
+            raise ValueError(f"{name} must be greater than {exclusive_minimum}")
+        if maximum is not None and value > maximum:
+            raise ValueError(f"{name} must be at most {maximum}")
+
+    def as_args(self) -> dict[str, int | float | str]:
+        """The resolved public ``args`` object for the SFT launch request.
+
+        Unset v1.1 knobs are omitted entirely rather than serialized as null,
+        so an untouched config still produces the exact v1 five-key payload.
+        """
+
+        args: dict[str, int | float | str] = {
             "num_epochs": self.num_epochs,
             "learning_rate": self.learning_rate,
             "max_context_tokens": self.max_context_tokens,
             "save_interval": self.save_interval,
             "seed": self.seed,
         }
+        for name in (
+            "lr_decay_style",
+            "min_lr",
+            "warmup_ratio",
+            "adam_beta2",
+            "grad_clip",
+            "lora_rank",
+            "global_batch_size",
+        ):
+            value = getattr(self, name)
+            if value is not None:
+                args[name] = value
+        return args
 
 
 def upload_sft_assets(

--- a/packages/castform/src/castform/platform/sft.py
+++ b/packages/castform/src/castform/platform/sft.py
@@ -81,10 +81,9 @@ class SftTrainingConfig:
     max_context_tokens: int = 8192
     save_interval: int = 20
     seed: int = 42
-    # v1.1 knobs. ``None`` means "not sent": the field is omitted from
-    # ``as_args()`` entirely, so the platform stamps nothing and the trainer
-    # keeps the model config's value. An untouched config therefore still
-    # produces exactly the v1 five-key payload.
+    # Optional knobs. ``None`` means "not sent": the field is omitted from
+    # ``as_args()``, so the platform stamps nothing and the trainer keeps the
+    # model config's value.
     lr_decay_style: str | None = None
     min_lr: float | None = None
     warmup_ratio: float | None = None
@@ -115,7 +114,9 @@ class SftTrainingConfig:
             raise ValueError("min_lr must be less than learning_rate")
         self._require_optional_number("warmup_ratio", self.warmup_ratio, 0.0, 0.5)
         self._require_optional_number("adam_beta2", self.adam_beta2, 0.9, 0.999)
-        self._require_optional_number("grad_clip", self.grad_clip, None, 10.0, exclusive_minimum=0.0)
+        self._require_optional_number(
+            "grad_clip", self.grad_clip, None, 10.0, exclusive_minimum=0.0
+        )
         if self.lora_rank is not None and self.lora_rank not in _PUBLIC_LORA_RANKS:
             raise ValueError(
                 f"lora_rank must be one of {', '.join(str(r) for r in sorted(_PUBLIC_LORA_RANKS))}"
@@ -144,7 +145,7 @@ class SftTrainingConfig:
         *,
         exclusive_minimum: float | None = None,
     ) -> None:
-        """Range-check a v1.1 knob, leaving ``None`` (not sent) untouched."""
+        """Range-check an optional knob, leaving ``None`` (not sent) untouched."""
 
         if value is None:
             return
@@ -162,8 +163,8 @@ class SftTrainingConfig:
     def as_args(self) -> dict[str, int | float | str]:
         """The resolved public ``args`` object for the SFT launch request.
 
-        Unset v1.1 knobs are omitted entirely rather than serialized as null,
-        so an untouched config still produces the exact v1 five-key payload.
+        Unset knobs are omitted rather than serialized as null: the platform
+        reads presence, so a null would read as a deliberate override.
         """
 
         args: dict[str, int | float | str] = {
@@ -234,7 +235,7 @@ def upload_sft_assets(
     The blob layout is content-addressed like RL datasets:
     ``datasets/<run_name>/<digest16>/train.jsonl`` where ``digest16`` is the
     first 16 hex chars of :func:`sft_assets_digest` — the train digest alone
-    when there is no eval set, so v1 prefixes are unchanged. An eval set is
+    when there is no eval set, so train-only prefixes are unchanged. An eval set is
     written to ``eval.jsonl`` under the same prefix. Auth, retry, and
     path-safety ride the same :class:`StorageClient` mechanism as RL uploads.
 
@@ -277,7 +278,8 @@ def upload_sft_assets(
     if eval_dataset is not None:
         if len(eval_dataset.rows) > MAX_EVAL_ROWS:
             raise ValueError(
-                f"eval_dataset has {len(eval_dataset.rows)} rows, above the {MAX_EVAL_ROWS}-row limit"
+                f"eval_dataset has {len(eval_dataset.rows)} rows, "
+                f"above the {MAX_EVAL_ROWS}-row limit"
             )
         eval_payload = eval_dataset.to_jsonl_bytes()
         eval_digest = hashlib.sha256(eval_payload).hexdigest()

--- a/packages/castform/src/castform/platform/sft.py
+++ b/packages/castform/src/castform/platform/sft.py
@@ -20,7 +20,13 @@ from castform import config
 from .client import StorageClient
 from .environment_assets import _validate_blob_path
 
-__all__ = ["SftTrainingConfig", "UploadedSftAssets", "upload_sft_assets"]
+__all__ = [
+    "MAX_EVAL_ROWS",
+    "SftTrainingConfig",
+    "UploadedSftAssets",
+    "sft_assets_digest",
+    "upload_sft_assets",
+]
 
 _LR_DECAY_STYLES = frozenset({"constant", "cosine"})
 
@@ -32,6 +38,11 @@ _PUBLIC_LORA_RANKS = frozenset({32, 64})
 # is 4 on the fixed SFT topology. Mirrors the server; the server is authority.
 _DATA_PARALLEL_SIZE = 4
 
+# Eval rows the platform accepts. Mirrored here so an oversized set fails
+# before the upload rather than at launch; the server is the authority and
+# re-counts the real bytes.
+MAX_EVAL_ROWS = 2048
+
 
 @dataclass(frozen=True)
 class UploadedSftAssets:
@@ -41,11 +52,18 @@ class UploadedSftAssets:
     ``dataset_format`` is the literal public format identifier; and
     ``content_digest`` is the full SHA-256 hex digest of the canonical JSONL
     bytes. Pass the whole object to ``TrainerClient.launch_sft_run``.
+
+    The eval fields are set only when ``upload_sft_assets`` received an
+    ``eval_dataset``; their presence is what makes the launch send the eval
+    marker, so an ``eval.jsonl`` that merely exists at the prefix stays inert.
     """
 
     dataset_path: str
     dataset_format: str
     content_digest: str
+    row_count: int | None = None
+    eval_digest: str | None = None
+    eval_row_count: int | None = None
 
 
 @dataclass(frozen=True)
@@ -74,6 +92,10 @@ class SftTrainingConfig:
     grad_clip: float | None = None
     lora_rank: int | None = None
     global_batch_size: int | None = None
+    # Only meaningful with an eval set: the launch rejects an interval sent
+    # without the eval marker rather than silently ignoring it. Unset means the
+    # platform derives the cadence from save_interval.
+    eval_interval: int | None = None
 
     def __post_init__(self) -> None:
         self._require_int("num_epochs", self.num_epochs, 1, 100)
@@ -159,6 +181,7 @@ class SftTrainingConfig:
             "grad_clip",
             "lora_rank",
             "global_batch_size",
+            "eval_interval",
         ):
             value = getattr(self, name)
             if value is not None:
@@ -166,32 +189,73 @@ class SftTrainingConfig:
         return args
 
 
+def sft_assets_digest(train_digest: str, eval_digest: str | None = None) -> str:
+    """The identity digest for a launch's full asset set.
+
+    With no eval set this is the train digest, which keeps every previously
+    uploaded prefix byte-stable. With one it is a domain-separated hash over
+    fixed-width raw component digests::
+
+        sha256(b"castform-sft-assets-v1\\0" + b"train\\0" + raw32(train)
+               + b"eval\\0" + raw32(eval))
+
+    Tags and fixed-width components make the framing unambiguous; hashing the
+    raw payloads concatenated would not be, so a prefix would stop pinning
+    which bytes were which. Because the eval digest feeds the prefix, adding
+    or changing an eval set produces a NEW prefix — an overwrite at the old
+    one cannot swap eval sets under a launched run.
+
+    The platform re-derives this and rejects a prefix that disagrees, so this
+    construction must stay byte-identical to
+    ``platform-service/src/lib/sft-eval-assets.ts``.
+    """
+    if eval_digest is None:
+        return train_digest
+    hasher = hashlib.sha256()
+    hasher.update(b"castform-sft-assets-v1\0")
+    hasher.update(b"train\0")
+    hasher.update(bytes.fromhex(train_digest))
+    hasher.update(b"eval\0")
+    hasher.update(bytes.fromhex(eval_digest))
+    return hasher.hexdigest()
+
+
 def upload_sft_assets(
     *,
     dataset: SftDataset,
     run_name: str,
+    eval_dataset: SftDataset | None = None,
     api_key: str | None = None,
     base_url: str | None = None,
     storage_client: StorageClient | None = None,
 ) -> UploadedSftAssets:
-    """Upload a validated SFT dataset's canonical bytes as ``train.jsonl``.
+    """Upload a validated SFT dataset, and optionally an eval set beside it.
 
     The blob layout is content-addressed like RL datasets:
     ``datasets/<run_name>/<digest16>/train.jsonl`` where ``digest16`` is the
-    first 16 hex chars of the canonical bytes' SHA-256. Auth, retry, and
+    first 16 hex chars of :func:`sft_assets_digest` — the train digest alone
+    when there is no eval set, so v1 prefixes are unchanged. An eval set is
+    written to ``eval.jsonl`` under the same prefix. Auth, retry, and
     path-safety ride the same :class:`StorageClient` mechanism as RL uploads.
 
     Args:
         dataset: A fully constructed :class:`benchmax.sft.SftDataset`. Invalid
             data cannot reach here — construction already failed loudly.
         run_name: Asset namespace; must satisfy the platform blob-path charset.
+        eval_dataset: Optional held-out set to score during training.
         api_key: Platform API key; omitted means the per-request credential
             seam resolves the bearer.
         base_url: Platform base URL. Defaults to ``config.platform_url()``.
         storage_client: BYOC for connection reuse or test fakes.
 
     Returns:
-        UploadedSftAssets carrying the prefix, literal format, and digest.
+        UploadedSftAssets carrying the prefix, literal format, both digests,
+        and both row counts.
+
+    Raises:
+        ValueError: If the eval set exceeds :data:`MAX_EVAL_ROWS`. A local
+            mirror of the platform's bound — a convenience, never the
+            enforcement point.
     """
 
     if not isinstance(dataset, SftDataset):
@@ -199,9 +263,27 @@ def upload_sft_assets(
             f"dataset must be a benchmax.sft.SftDataset, got {type(dataset).__name__}; "
             "construct one with SftDataset.from_jsonl(...) or SftDataset.from_rows(...)"
         )
+    if eval_dataset is not None and not isinstance(eval_dataset, SftDataset):
+        raise TypeError(
+            f"eval_dataset must be a benchmax.sft.SftDataset, got {type(eval_dataset).__name__}"
+        )
+
     payload = dataset.to_jsonl_bytes()
     digest = hashlib.sha256(payload).hexdigest()
-    prefix = f"datasets/{run_name}/{digest[:16]}"
+
+    eval_payload: bytes | None = None
+    eval_digest: str | None = None
+    eval_row_count: int | None = None
+    if eval_dataset is not None:
+        if len(eval_dataset.rows) > MAX_EVAL_ROWS:
+            raise ValueError(
+                f"eval_dataset has {len(eval_dataset.rows)} rows, above the {MAX_EVAL_ROWS}-row limit"
+            )
+        eval_payload = eval_dataset.to_jsonl_bytes()
+        eval_digest = hashlib.sha256(eval_payload).hexdigest()
+        eval_row_count = len(eval_dataset.rows)
+
+    prefix = f"datasets/{run_name}/{sft_assets_digest(digest, eval_digest)[:16]}"
     _validate_blob_path(prefix, source="run_name")
 
     if storage_client is None:
@@ -210,8 +292,13 @@ def upload_sft_assets(
             base_url=base_url or config.platform_url(),
         )
     storage_client.upload_file(f"{prefix}/train.jsonl", payload, "application/jsonl")
+    if eval_payload is not None:
+        storage_client.upload_file(f"{prefix}/eval.jsonl", eval_payload, "application/jsonl")
     return UploadedSftAssets(
         dataset_path=prefix,
         dataset_format=SFT_DATASET_FORMAT,
         content_digest=digest,
+        row_count=len(dataset.rows),
+        eval_digest=eval_digest,
+        eval_row_count=eval_row_count,
     )

--- a/packages/castform/tests/unit/platform/test_sft.py
+++ b/packages/castform/tests/unit/platform/test_sft.py
@@ -159,9 +159,7 @@ class TestSftTrainingConfig:
         )
 
     def test_unset_fields_omitted_from_as_args(self) -> None:
-        # Unset v1.1 knobs must vanish from the payload, not serialize as
-        # null: the platform reads presence, and a null would look like a
-        # deliberate choice overriding the model config.
+        # Unset knobs must vanish from the payload, not serialize as null.
         args = SftTrainingConfig(adam_beta2=0.95).as_args()
         assert args["adam_beta2"] == 0.95
         for absent in (
@@ -336,7 +334,14 @@ class TestEvalAssets:
 
     def test_eval_set_lands_beside_train_under_a_combined_prefix(self) -> None:
         train = SftDataset.from_rows(
-            [{"messages": [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]}]
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": "q"},
+                        {"role": "assistant", "content": "a"},
+                    ]
+                }
+            ]
         )
         evalset = self._eval_dataset()
         storage = FakeStorageClient()
@@ -365,10 +370,19 @@ class TestEvalAssets:
         # The prefix pins the FULL data identity, so an overwrite at the
         # train-only prefix cannot attach an eval set to a launched run.
         train = SftDataset.from_rows(
-            [{"messages": [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]}]
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": "q"},
+                        {"role": "assistant", "content": "a"},
+                    ]
+                }
+            ]
         )
         train_only = upload_sft_assets(
-            dataset=train, run_name="s", storage_client=FakeStorageClient()  # type: ignore[arg-type]
+            dataset=train,
+            run_name="s",
+            storage_client=FakeStorageClient(),  # type: ignore[arg-type]
         )
         with_eval = upload_sft_assets(
             dataset=train,
@@ -379,10 +393,17 @@ class TestEvalAssets:
         assert train_only.dataset_path != with_eval.dataset_path
 
     def test_train_only_prefix_is_unchanged(self) -> None:
-        # v1 prefixes must stay byte-stable: sft_assets_digest with no eval
-        # set is exactly the train digest.
+        # Train-only prefixes must stay byte-stable: with no eval set,
+        # sft_assets_digest is exactly the train digest.
         train = SftDataset.from_rows(
-            [{"messages": [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]}]
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": "q"},
+                        {"role": "assistant", "content": "a"},
+                    ]
+                }
+            ]
         )
         digest = hashlib.sha256(train.to_jsonl_bytes()).hexdigest()
         assert sft_assets_digest(digest) == digest
@@ -395,7 +416,14 @@ class TestEvalAssets:
     def test_oversized_eval_set_fails_before_upload(self) -> None:
         storage = FakeStorageClient()
         train = SftDataset.from_rows(
-            [{"messages": [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]}]
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": "q"},
+                        {"role": "assistant", "content": "a"},
+                    ]
+                }
+            ]
         )
         with pytest.raises(ValueError, match="above the 2048-row limit"):
             upload_sft_assets(

--- a/packages/castform/tests/unit/platform/test_sft.py
+++ b/packages/castform/tests/unit/platform/test_sft.py
@@ -15,6 +15,7 @@ from castform.platform import (
     UploadedSftAssets,
     upload_sft_assets,
 )
+from castform.platform.sft import MAX_EVAL_ROWS, sft_assets_digest
 
 
 def _dataset() -> SftDataset:
@@ -59,8 +60,12 @@ class TestUploadSftAssets:
             dataset_path=f"datasets/support-sft/{digest[:16]}",
             dataset_format="benchmax-sft-v1",
             content_digest=digest,
+            row_count=1,
         )
         assert uploaded.dataset_format == SFT_DATASET_FORMAT
+        # No eval set was uploaded, so nothing marks one.
+        assert uploaded.eval_digest is None
+        assert uploaded.eval_row_count is None
 
     def test_equivalent_datasets_share_a_prefix(self) -> None:
         storage = FakeStorageClient()
@@ -311,3 +316,164 @@ class TestLaunchSftRun:
 
         with pytest.raises(JobLaunchError, match="not enabled"):
             self._client(handler).launch_sft_run(assets=self._assets(), name="n")
+
+
+class TestEvalAssets:
+    """Uploading an eval set, and the marker it makes the launch send."""
+
+    def _eval_dataset(self, count: int = 3) -> SftDataset:
+        return SftDataset.from_rows(
+            [
+                {
+                    "messages": [
+                        {"role": "user", "content": f"eq{i}"},
+                        {"role": "assistant", "content": f"ea{i}"},
+                    ]
+                }
+                for i in range(count)
+            ]
+        )
+
+    def test_eval_set_lands_beside_train_under_a_combined_prefix(self) -> None:
+        train = SftDataset.from_rows(
+            [{"messages": [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]}]
+        )
+        evalset = self._eval_dataset()
+        storage = FakeStorageClient()
+
+        uploaded = upload_sft_assets(
+            dataset=train,
+            eval_dataset=evalset,
+            run_name="support-sft",
+            storage_client=storage,  # type: ignore[arg-type]
+        )
+
+        train_digest = hashlib.sha256(train.to_jsonl_bytes()).hexdigest()
+        eval_digest = hashlib.sha256(evalset.to_jsonl_bytes()).hexdigest()
+        prefix = f"datasets/support-sft/{sft_assets_digest(train_digest, eval_digest)[:16]}"
+
+        assert [path for path, _, _ in storage.uploads] == [
+            f"{prefix}/train.jsonl",
+            f"{prefix}/eval.jsonl",
+        ]
+        assert uploaded.dataset_path == prefix
+        assert uploaded.eval_digest == eval_digest
+        assert uploaded.eval_row_count == 3
+        assert uploaded.row_count == 1
+
+    def test_adding_an_eval_set_moves_the_prefix(self) -> None:
+        # The prefix pins the FULL data identity, so an overwrite at the
+        # train-only prefix cannot attach an eval set to a launched run.
+        train = SftDataset.from_rows(
+            [{"messages": [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]}]
+        )
+        train_only = upload_sft_assets(
+            dataset=train, run_name="s", storage_client=FakeStorageClient()  # type: ignore[arg-type]
+        )
+        with_eval = upload_sft_assets(
+            dataset=train,
+            eval_dataset=self._eval_dataset(),
+            run_name="s",
+            storage_client=FakeStorageClient(),  # type: ignore[arg-type]
+        )
+        assert train_only.dataset_path != with_eval.dataset_path
+
+    def test_train_only_prefix_is_unchanged(self) -> None:
+        # v1 prefixes must stay byte-stable: sft_assets_digest with no eval
+        # set is exactly the train digest.
+        train = SftDataset.from_rows(
+            [{"messages": [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]}]
+        )
+        digest = hashlib.sha256(train.to_jsonl_bytes()).hexdigest()
+        assert sft_assets_digest(digest) == digest
+
+    def test_combined_digest_is_framing_unambiguous(self) -> None:
+        a, b = "a" * 64, "b" * 64
+        assert sft_assets_digest(a, b) != sft_assets_digest(b, a)
+        assert sft_assets_digest(a, b) != a
+
+    def test_oversized_eval_set_fails_before_upload(self) -> None:
+        storage = FakeStorageClient()
+        train = SftDataset.from_rows(
+            [{"messages": [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]}]
+        )
+        with pytest.raises(ValueError, match="above the 2048-row limit"):
+            upload_sft_assets(
+                dataset=train,
+                eval_dataset=self._eval_dataset(MAX_EVAL_ROWS + 1),
+                run_name="s",
+                storage_client=storage,  # type: ignore[arg-type]
+            )
+        assert storage.uploads == []
+
+
+class TestEvalLaunchWire:
+    """What the launch sends when the uploaded assets carry an eval set."""
+
+    def _client(self, handler) -> TrainerClient:
+        client = TrainerClient(api_key="test-key", base_url="https://example.invalid")
+        client._http_client = httpx.Client(
+            base_url="https://example.invalid",
+            headers={"Authorization": "Bearer test-key"},
+            transport=httpx.MockTransport(handler),
+        )
+        return client
+
+    def _eval_assets(self) -> UploadedSftAssets:
+        return UploadedSftAssets(
+            dataset_path="datasets/support-sft/0123456789abcdef",
+            dataset_format=SFT_DATASET_FORMAT,
+            content_digest="0" * 64,
+            row_count=400,
+            eval_digest="1" * 64,
+            eval_row_count=100,
+        )
+
+    def _capture(self, assets: UploadedSftAssets, config: SftTrainingConfig | None = None) -> dict:
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(202, json={"runId": "run-1", "trainingMethod": "sft"})
+
+        self._client(handler).launch_sft_run(assets=assets, name="support-sft", config=config)
+        return captured["body"]
+
+    def test_marker_and_train_identity_travel_together(self) -> None:
+        body = self._capture(self._eval_assets())
+        assert body["eval"] == {"rows": 100, "digest": "1" * 64}
+        # The platform derives the pass cap and re-derives the prefix from
+        # these, so they are mandatory exactly when the marker is present.
+        assert body["dataset"]["digest"] == "0" * 64
+        assert body["dataset"]["rows"] == 400
+
+    def test_eval_interval_rides_args_when_sent(self) -> None:
+        body = self._capture(self._eval_assets(), SftTrainingConfig(eval_interval=50))
+        assert body["args"]["eval_interval"] == 50
+
+    def test_unset_eval_interval_is_omitted_so_the_platform_derives_it(self) -> None:
+        body = self._capture(self._eval_assets())
+        assert "eval_interval" not in body["args"]
+
+    def test_eval_interval_without_an_eval_set_is_refused_locally(self) -> None:
+        # Fails before the request rather than earning a 400: the caller's
+        # mistake is knowable here.
+        assets = UploadedSftAssets(
+            dataset_path="datasets/support-sft/0123456789abcdef",
+            dataset_format=SFT_DATASET_FORMAT,
+            content_digest="0" * 64,
+            row_count=400,
+        )
+        with pytest.raises(ValueError, match="no eval set"):
+            self._capture(assets, SftTrainingConfig(eval_interval=50))
+
+    def test_no_eval_set_keeps_the_v1_body(self) -> None:
+        assets = UploadedSftAssets(
+            dataset_path="datasets/support-sft/0123456789abcdef",
+            dataset_format=SFT_DATASET_FORMAT,
+            content_digest="0" * 64,
+            row_count=400,
+        )
+        body = self._capture(assets)
+        assert set(body) == {"name", "dataset", "args"}
+        assert set(body["dataset"]) == {"format", "path"}

--- a/packages/castform/tests/unit/platform/test_sft.py
+++ b/packages/castform/tests/unit/platform/test_sft.py
@@ -153,6 +153,80 @@ class TestSftTrainingConfig:
             seed=2_147_483_647,
         )
 
+    def test_unset_fields_omitted_from_as_args(self) -> None:
+        # Unset v1.1 knobs must vanish from the payload, not serialize as
+        # null: the platform reads presence, and a null would look like a
+        # deliberate choice overriding the model config.
+        args = SftTrainingConfig(adam_beta2=0.95).as_args()
+        assert args["adam_beta2"] == 0.95
+        for absent in (
+            "lr_decay_style",
+            "min_lr",
+            "warmup_ratio",
+            "grad_clip",
+            "lora_rank",
+            "global_batch_size",
+        ):
+            assert absent not in args
+
+    def test_global_batch_size_presence_tracked(self) -> None:
+        assert "global_batch_size" not in SftTrainingConfig().as_args()
+        for gbs in (4, 8, 12, 64):
+            assert SftTrainingConfig(global_batch_size=gbs).as_args()["global_batch_size"] == gbs
+
+    def test_v28_shape_serializes_completely(self) -> None:
+        assert SftTrainingConfig(
+            learning_rate=6e-5,
+            lr_decay_style="cosine",
+            min_lr=2e-5,
+            warmup_ratio=0.05,
+            adam_beta2=0.95,
+            grad_clip=0.5,
+            lora_rank=64,
+        ).as_args() == {
+            "num_epochs": 1,
+            "learning_rate": 6e-5,
+            "max_context_tokens": 8192,
+            "save_interval": 20,
+            "seed": 42,
+            "lr_decay_style": "cosine",
+            "min_lr": 2e-5,
+            "warmup_ratio": 0.05,
+            "adam_beta2": 0.95,
+            "grad_clip": 0.5,
+            "lora_rank": 64,
+        }
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"lr_decay_style": "linear"},
+            {"min_lr": -1e-6},
+            # A floor at or above the peak makes the schedule meaningless.
+            {"learning_rate": 1e-5, "min_lr": 1e-5},
+            {"warmup_ratio": 0.51},
+            {"warmup_ratio": -0.01},
+            {"adam_beta2": 0.89},
+            {"adam_beta2": 1.0},
+            {"grad_clip": 0},
+            {"grad_clip": 10.1},
+            # 128 trains but cannot be served; alpha is never a caller input.
+            {"lora_rank": 128},
+            {"lora_rank": 16},
+            {"global_batch_size": 10},
+            {"global_batch_size": 5},
+            {"global_batch_size": 0},
+            {"global_batch_size": 68},
+        ],
+    )
+    def test_v11_out_of_range_values_rejected(self, kwargs: dict[str, Any]) -> None:
+        with pytest.raises(ValueError):
+            SftTrainingConfig(**kwargs)
+
+    def test_client_mirror_matches_server_lora_set(self) -> None:
+        for rank in (32, 64):
+            assert SftTrainingConfig(lora_rank=rank).as_args()["lora_rank"] == rank
+
 
 class TestLaunchSftRun:
     def _client(self, handler) -> TrainerClient:


### PR DESCRIPTION
Widens the public SFT surface to the v1.1 contract: the optimizer and LoRA
knobs a real fine-tune needs, a decoupled batch size, and a held-out eval set.

## What this adds

**`SftTrainingConfig` knobs** (`platform/sft.py`) — all optional, all
defaulted to today's behaviour, so an untouched v1 config serialises to the
v1 payload byte for byte:

| knob | purpose |
|---|---|
| `lr_decay_style`, `min_lr`, `warmup_ratio` | LR schedule |
| `adam_beta2`, `grad_clip` | optimizer stability |
| `lora_rank` | adapter capacity |
| `global_batch_size` | decoupled from the data-parallel width |
| `eval_interval` | eval cadence; unset derives a default |

**Eval assets** (`platform/client.py`, `platform/sft.py`) —
`upload_sft_assets(eval_dataset=…)` uploads a held-out set alongside the
train set and returns its digest and row count. Those fields are what make
the launch send the eval marker: without them a run silently trains with no
eval at all.

**Skill doc** (`train-sft/SKILL.md`) — replaces the now-false claim that SFT
runs have "no rollouts, evals, or reward curves" with a held-out-eval section
covering the row bound and why it is a compute bound rather than a billed
one, the cadence default, and the fact that the eval set is part of the data
identity. Also adds `global_batch_size`, which the knob table was missing.

## Review notes

- `eval_interval` left unset is meaningful, not merely absent: the server
  derives the cadence. The staging smoke deliberately left it unset to prove
  that path.
- The eval set participates in dataset identity, so changing it on a resume
  is a deliberate mismatch rather than a silent reinterpretation.
- Eval is a **compute** bound, never billed. That commitment is asserted
  end to end downstream — a staging run showed the emitter and the billing
  ledger agreeing at 1704 tokens with zero eval tokens in either.

## Tests

`tests/unit/platform/test_sft.py` (+240): per-knob serialisation, the v1
byte-identity case, and the eval-asset fields.

Merge order: slimefork first, then this, then castform — the castform
gitlink re-points at this branch's post-merge SHA.