### PR TITLE
release: benchmax and castform 0.2.4

### DIFF
--- a/packages/benchmax/pyproject.toml
+++ b/packages/benchmax/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchmax"
-version = "0.2.3"
+version = "0.2.4"
 description = "Platform-independent runtime for grouped LLM environments"
 readme = "README.md"
 authors = [{ name = "benchmax Authors" }]

--- a/packages/castform/pyproject.toml
+++ b/packages/castform/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "castform"
-version = "0.2.3"
+version = "0.2.4"
 description = "SDK and CLI for the Castform training platform"
 readme = "README.md"
 authors = [{ name = "castie@castform.com" }]
 requires-python = "==3.12.*"
 dependencies = [
-    "benchmax==0.2.3",
+    "benchmax==0.2.4",
     "httpx[http2]>=0.27.0",
     "tqdm>=4.66.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -171,7 +171,7 @@ wheels = [
 
 [[package]]
 name = "benchmax"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/benchmax" }
 dependencies = [
     { name = "cloudpickle" },
@@ -565,7 +565,7 @@ wheels = [
 
 [[package]]
 name = "castform"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/castform" }
 dependencies = [
     { name = "benchmax" },


### PR DESCRIPTION
Unblocks the SFT v1.1 SDK release.

## The problem

`castform` 0.2.3 pins `benchmax==0.2.3`, and that benchmax **predates the `benchmax.sft` module**:

```
packages/benchmax/pyproject.toml @ 0.2.3   last set 2026-08-05 (e5c9c8a)
packages/benchmax/src/benchmax/sft/        first landed 2026-08-07 (6741096)
```

So a fresh-venv install of the published `castform` pulls a benchmax with no `benchmax.sft`, and the typed SFT transport fails to import.

## The change

Both packages to 0.2.4 with the pin following — same shape as the 0.2.3 release (`e5c9c8a`): two pyproject versions, the dependency pin, `uv.lock`.

## Testing

**1561 passed / 17 skipped** across `packages/castform/tests` and `packages/benchmax/tests`. `benchmax.sft` imports from the workspace; `SftTrainingConfig` exposes all 13 v1.1 fields.

## Not included — a second blocker

`SftTrainingConfig` caps `max_context_tokens` at **8192 client-side** (`platform/sft.py:106`, documented in the train-sft skill). That range extends to the frozen context ladder when the public context→CP mapping is frozen — a separate decision. Raising it here would let the SDK accept values the server still rejects, so it is deliberately left alone.

Worth flagging: the release blocker was previously understood as *only* the pin.