### PR TITLE
SDK: accept the frozen long-context ladder

### DIFF
--- a/packages/castform/src/castform/cli/scaffold/skills/train-sft/SKILL.md
+++ b/packages/castform/src/castform/cli/scaffold/skills/train-sft/SKILL.md
@@ -67,7 +67,7 @@ turns contribute to the loss.
 |---|---|---|
 | `num_epochs` | 1–100 | 1 |
 | `learning_rate` | (0, 0.1] | 1e-5 |
-| `max_context_tokens` | 256–8192 (hard cap) | 8192 |
+| `max_context_tokens` | 256–8192, or 32768 / 65536 / 131072 (long context — must be enabled on the platform) | 8192 |
 | `save_interval` (steps) | 1–10000 | 20 |
 | `seed` | 0–2147483647 | 42 |
 | `lr_decay_style` | `"constant"` or `"cosine"` | unset — keeps the platform default |
@@ -76,7 +76,7 @@ turns contribute to the loss.
 | `adam_beta2` | 0.9–0.999 | unset |
 | `grad_clip` | (0, 10] | unset |
 | `lora_rank` | 32 or 64 | unset — keeps the platform's fixed policy |
-| `global_batch_size` | 4–64, multiple of 4 | unset — 4 |
+| `global_batch_size` | 4–64, multiple of 4 at `max_context_tokens` ≤ 8192; 1–64 at a long-context rung (the platform picks the topology, so it decides divisibility) | unset — 4 |
 | `eval_interval` (steps) | 1–10000; only with an eval set | unset — derived from `save_interval` |
 
 Every arg whose default reads `unset` is optional: leave it out and the

--- a/packages/castform/src/castform/platform/sft.py
+++ b/packages/castform/src/castform/platform/sft.py
@@ -38,6 +38,18 @@ _PUBLIC_LORA_RANKS = frozenset({32, 64})
 # is 4 on the fixed SFT topology. Mirrors the server; the server is authority.
 _DATA_PARALLEL_SIZE = 4
 
+# Context sizing. At or below the v1 ceiling any value is accepted; above it,
+# only the frozen ladder rungs exist. Mirrors the server's shape.
+#
+# The server-side flag that gates long context is deliberately NOT modelled
+# here. A flag-off platform rejects anything above 8192 whatever the SDK
+# version, so mirroring the flag would only let this client go stale against a
+# value it cannot observe. This range says which values are WELL-FORMED, not
+# which are currently enabled.
+V1_MAX_CONTEXT_TOKENS = 8192
+MIN_CONTEXT_TOKENS = 256
+LONG_CONTEXT_LADDER = (32768, 65536, 131072)
+
 # Eval rows the platform accepts. Mirrored here so an oversized set fails
 # before the upload rather than at launch; the server is the authority and
 # re-counts the real bytes.
@@ -103,7 +115,7 @@ class SftTrainingConfig:
             raise ValueError("learning_rate must be a number")
         if not math.isfinite(rate) or rate <= 0 or rate > 0.1:
             raise ValueError("learning_rate must be finite, greater than 0, and at most 0.1")
-        self._require_int("max_context_tokens", self.max_context_tokens, 256, 8192)
+        self._require_context_tokens(self.max_context_tokens)
         self._require_int("save_interval", self.save_interval, 1, 10_000)
         self._require_int("seed", self.seed, 0, 2_147_483_647)
 
@@ -122,8 +134,26 @@ class SftTrainingConfig:
                 f"lora_rank must be one of {', '.join(str(r) for r in sorted(_PUBLIC_LORA_RANKS))}"
             )
         if self.global_batch_size is not None:
-            self._require_int("global_batch_size", self.global_batch_size, _DATA_PARALLEL_SIZE, 64)
-            if self.global_batch_size % _DATA_PARALLEL_SIZE:
+            # The divisibility rule depends on the data-parallel width, and DP
+            # depends on the context-parallel size the SERVER resolves from the
+            # context bucket. In the v1 range CP is always 1, so DP is always 4
+            # and the rule is knowable here. Above the v1 ceiling it is not:
+            # the platform picks CP per rung, DP narrows to 2 or 1, and batch
+            # sizes this client would reject become legal.
+            #
+            # Rather than mirror the context->CP table — which would let this
+            # client go stale against a server-owned mapping, exactly the
+            # split-brain that has already cost this project two paid launches
+            # — only the range is enforced above the ceiling and the server
+            # decides divisibility.
+            in_v1_range = (
+                isinstance(self.max_context_tokens, int)
+                and not isinstance(self.max_context_tokens, bool)
+                and self.max_context_tokens <= V1_MAX_CONTEXT_TOKENS
+            )
+            minimum = _DATA_PARALLEL_SIZE if in_v1_range else 1
+            self._require_int("global_batch_size", self.global_batch_size, minimum, 64)
+            if in_v1_range and self.global_batch_size % _DATA_PARALLEL_SIZE:
                 raise ValueError(
                     f"global_batch_size must be a multiple of {_DATA_PARALLEL_SIZE} "
                     "(the data-parallel width of the fixed SFT topology)"
@@ -135,6 +165,33 @@ class SftTrainingConfig:
             raise ValueError(f"{name} must be an integer")
         if not minimum <= value <= maximum:
             raise ValueError(f"{name} must be between {minimum} and {maximum}")
+
+    @staticmethod
+    def _require_context_tokens(value: object) -> None:
+        """Free range up to the v1 ceiling, frozen ladder rungs above it.
+
+        Two shapes rather than one range because that is what the server
+        enforces: below the ceiling every value has been runnable since v1,
+        while above it only the rungs with measured calibration evidence exist
+        — an arbitrary 40000 is refused there, not clamped.
+
+        Whether a rung is currently ENABLED is a server-side flag this client
+        deliberately does not model, so a well-formed value here can still be
+        refused at launch. That is the intended split: the SDK rejects what can
+        never work, the platform decides what works today.
+        """
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError("max_context_tokens must be an integer")
+        if MIN_CONTEXT_TOKENS <= value <= V1_MAX_CONTEXT_TOKENS:
+            return
+        if value in LONG_CONTEXT_LADDER:
+            return
+        raise ValueError(
+            f"max_context_tokens must be between {MIN_CONTEXT_TOKENS} and "
+            f"{V1_MAX_CONTEXT_TOKENS}, or one of "
+            f"{', '.join(str(v) for v in LONG_CONTEXT_LADDER)} "
+            f"(long context must be enabled on the platform for those)"
+        )
 
     @staticmethod
     def _require_optional_number(

--- a/packages/castform/tests/unit/platform/test_sft.py
+++ b/packages/castform/tests/unit/platform/test_sft.py
@@ -15,7 +15,11 @@ from castform.platform import (
     UploadedSftAssets,
     upload_sft_assets,
 )
-from castform.platform.sft import MAX_EVAL_ROWS, sft_assets_digest
+from castform.platform.sft import (
+    LONG_CONTEXT_LADDER,
+    MAX_EVAL_ROWS,
+    sft_assets_digest,
+)
 
 
 def _dataset() -> SftDataset:
@@ -137,6 +141,7 @@ class TestSftTrainingConfig:
             {"learning_rate": True},
             {"max_context_tokens": 255},
             {"max_context_tokens": 8193},
+            {"max_context_tokens": 16384},
             {"max_context_tokens": False},
             {"save_interval": 0},
             {"save_interval": 10_001},
@@ -505,3 +510,72 @@ class TestEvalLaunchWire:
         body = self._capture(assets)
         assert set(body) == {"name", "dataset", "args"}
         assert set(body["dataset"]) == {"format", "path"}
+
+
+class TestLongContextLadder:
+    """The client-side range after the 2026-08-11 context->CP freeze.
+
+    Two shapes, mirroring the server: a free range up to the v1 ceiling, and
+    discrete rungs above it. The gating FLAG is deliberately not modelled — a
+    value can be well-formed here and still be refused at launch.
+    """
+
+    def test_v1_range_still_free(self) -> None:
+        for value in (256, 4096, 8192):
+            assert SftTrainingConfig(max_context_tokens=value).max_context_tokens == value
+
+    def test_every_frozen_rung_is_accepted(self) -> None:
+        for value in LONG_CONTEXT_LADDER:
+            assert SftTrainingConfig(max_context_tokens=value).max_context_tokens == value
+
+    def test_off_ladder_values_above_the_ceiling_are_refused(self) -> None:
+        # Not clamped: above the ceiling only calibrated rungs exist, so an
+        # arbitrary value is a mistake rather than a request to round down.
+        for value in (8193, 16384, 40000, 131073):
+            with pytest.raises(ValueError, match="max_context_tokens"):
+                SftTrainingConfig(max_context_tokens=value)
+
+    def test_below_the_floor_is_still_refused(self) -> None:
+        with pytest.raises(ValueError, match="max_context_tokens"):
+            SftTrainingConfig(max_context_tokens=255)
+
+    def test_a_long_context_config_serialises_the_value(self) -> None:
+        args = SftTrainingConfig(max_context_tokens=131072, global_batch_size=10).as_args()
+        assert args["max_context_tokens"] == 131072
+        assert args["global_batch_size"] == 10
+
+    def test_v1_config_as_args_is_unchanged(self) -> None:
+        # The release gate: an untouched v1 config must serialise exactly as
+        # before, or every existing caller's payload shifts under them.
+        assert SftTrainingConfig().as_args() == {
+            "num_epochs": 1,
+            "learning_rate": 1e-5,
+            "max_context_tokens": 8192,
+            "save_interval": 20,
+            "seed": 42,
+        }
+
+
+class TestBatchSizeAcrossContextBuckets:
+    """gbs divisibility is knowable client-side only in the v1 range."""
+
+    def test_v1_range_still_enforces_multiple_of_four(self) -> None:
+        # CP is always 1 below the ceiling, so DP is always 4 and the rule is
+        # certain. Keeping it preserves v1's fail-fast ergonomics.
+        with pytest.raises(ValueError, match="multiple of 4"):
+            SftTrainingConfig(max_context_tokens=8192, global_batch_size=10)
+
+    def test_long_rungs_defer_divisibility_to_the_server(self) -> None:
+        # Above the ceiling the platform picks CP per rung and DP narrows, so
+        # batch sizes this client would have rejected become legal. Mirroring
+        # the context->CP table here would let the SDK go stale against a
+        # server-owned mapping.
+        for context in LONG_CONTEXT_LADDER:
+            cfg = SftTrainingConfig(max_context_tokens=context, global_batch_size=10)
+            assert cfg.as_args()["global_batch_size"] == 10
+
+    def test_range_still_bounded_on_long_rungs(self) -> None:
+        # Relaxing divisibility is not relaxing the range.
+        for bad in (0, 65, -4):
+            with pytest.raises(ValueError, match="global_batch_size"):
+                SftTrainingConfig(max_context_tokens=131072, global_batch_size=bad)


### PR DESCRIPTION
0.2.4 (#95) fixed the *import*. This fixes what the SDK will actually **accept** — two client-side caps still refused every long-context launch locally, and the second was not previously identified as a blocker.

## `max_context_tokens`

Was a flat `256..8192`. Now the v1 range stays free and the frozen rungs (32768 / 65536 / 131072) are accepted.

Off-ladder values above the ceiling are **refused, not clamped** — above 8192 only rungs with measured calibration evidence exist, so `40000` is a mistake rather than a request to round down.

## `global_batch_size` — the one that wasn't on anyone's list

Was multiple-of-4 unconditionally. That mirrors a data-parallel width of 4, which is true only at CP1. The platform resolves CP per rung and DP narrows to 2 or 1, so batch sizes this client rejected are legal.

Concretely: **`gbs=10`, the reference workload's own shape, was refused by the SDK at every long rung.** The rule now applies only in the v1 range, where CP is always 1 and DP is knowably 4; above it only the range is enforced.

## What is deliberately NOT mirrored

The context→CP table and `SFT_LONG_CONTEXT_ENABLED`. Duplicating either would let this client go stale against server-owned state it cannot observe — the same split-brain that already cost two paid GPU launches in this project.

The split: **the SDK rejects what can never work; the platform decides what works today.** A well-formed value here can still be refused at launch, and that is correct.

## Testing

**1571 passed / 17 skipped**, ruff clean. An untouched v1 config's `as_args()` is unchanged, pinned by `test_v1_config_as_args_is_unchanged`.

Scaffold skill doc updated for both rows.