### PR TITLE
Make RagEnv reward source-gated

### DIFF
--- a/packages/benchmax/src/benchmax/rag/env.py
+++ b/packages/benchmax/src/benchmax/rag/env.py
@@ -28,7 +28,7 @@ import math
 import re
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 from benchmax.rag.search import SearchClient
 
@@ -143,6 +143,14 @@ SEARCH_EFFICIENCY_DECAY_RATE = 0.2
 # bonus; shorter (still-correct) answers earn more. Dense signal on every correct
 # rollout, no second LLM call.
 ANSWER_LENGTH_CAP = 600
+
+
+class RagSourceScores(TypedDict):
+    """Source-level scores used by the default RAG reward."""
+
+    retrieval_hit: float
+    citation_recall: float
+    citation_grounding: float
 
 
 # ----------------------------------------------------------------------------
@@ -311,6 +319,38 @@ def score_citation_grounding(
         return 0.0
     retrieved_ids = extract_source_ids(tool_text, canonicalize=canonicalize)
     return len(cited_ids & retrieved_ids) / len(cited_ids)
+
+
+def score_rag_sources(
+    answer_text: str,
+    tool_text: str,
+    reference_chunks: list[dict[str, Any]],
+    *,
+    canonicalize: Callable[[str], str] = canonicalize_source_id,
+) -> RagSourceScores:
+    """Source scores composed by the default :class:`RagEnv` reward.
+
+    Keeps ``score_citations`` conventional — citation recall/precision against
+    gold refs — while exposing the stricter source-gated RAG shape by name.
+    """
+    citation_recall, _citation_gold_precision = score_citations(
+        answer_text,
+        reference_chunks,
+        canonicalize=canonicalize,
+    )
+    return {
+        "retrieval_hit": score_retrieval_sources(
+            tool_text,
+            reference_chunks,
+            canonicalize=canonicalize,
+        ),
+        "citation_recall": citation_recall,
+        "citation_grounding": score_citation_grounding(
+            answer_text,
+            tool_text,
+            canonicalize=canonicalize,
+        ),
+    }
 
 
 def score_search_efficiency(
@@ -600,7 +640,8 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         )
 
         tool_text = self._tool_text(rollout.messages)
-        retrieval_hit = self._score_retrieval(tool_text, reference_chunks)
+        source_scores = self._score_rag_sources(answer, tool_text, reference_chunks)
+        retrieval_hit = source_scores["retrieval_hit"]
         if retrieval_hit <= 0:
             rewards = dict(self._ZERO_REWARDS)
             rewards["retrieval_hit"] = self._w_retrieval_hit * retrieval_hit
@@ -618,17 +659,19 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         )
         correctness = clip01(result.score)
 
-        citation_recall, _citation_gold_precision = self._score_citations(
-            answer, reference_chunks
-        )
-        citation_grounding = self._score_citation_grounding(answer, tool_text)
         length_score = clip01(1.0 - len(answer) / ANSWER_LENGTH_CAP)
         rewards: dict[str, float] = {
             "answer_correctness": self._w_correctness * correctness,
             "retrieval_hit": self._w_retrieval_hit * retrieval_hit,
-            "citation_recall": self._w_citation_recall * citation_recall * correctness,
+            "citation_recall": (
+                self._w_citation_recall
+                * source_scores["citation_recall"]
+                * correctness
+            ),
             "citation_grounding": (
-                self._w_citation_grounding * citation_grounding * correctness
+                self._w_citation_grounding
+                * source_scores["citation_grounding"]
+                * correctness
             ),
             "answer_length": self._w_length * length_score * correctness,
         }
@@ -757,6 +800,20 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         """Answer-citation precision against retrieved tool sources."""
         return score_citation_grounding(
             answer_text, tool_text, canonicalize=self._canonicalize_id
+        )
+
+    def _score_rag_sources(
+        self,
+        answer_text: str,
+        tool_text: str,
+        reference_chunks: list[dict[str, Any]],
+    ) -> RagSourceScores:
+        """Default source-gated RAG scores, honoring ``_canonicalize_id``."""
+        return score_rag_sources(
+            answer_text,
+            tool_text,
+            reference_chunks,
+            canonicalize=self._canonicalize_id,
         )
 
     def _extract_reference_ids(self, reference_chunks: list[dict[str, Any]]) -> set[str]:

--- a/packages/benchmax/src/benchmax/rag/env.py
+++ b/packages/benchmax/src/benchmax/rag/env.py
@@ -1,15 +1,16 @@
 """RagEnv — retrieval-augmented generation environment for RL training.
 
-The default reward is the AUDITED 4-component shape (one LLM judge call, the rest
+The default reward is the AUDITED 5-component shape (one LLM judge call, the rest
 deterministic):
-1. **answer_correctness** — LLM judge scores factual accuracy (the GATE)
-2. **retrieval_hit** — fraction of gold sources cited in the final ``<answer>``
-   block (UNGATED: citing gold is rewarded even on a wrong answer, so the model
-   keeps learning to search). An answer-side proxy for retrieval — raw tool
-   traffic is never inspected.
-3. **citation_precision** — fraction of cited sources that are gold (gated on
-   correctness)
-4. **answer_length** — deterministic brevity term (gated on correctness; replaces
+1. **retrieval_hit** — fraction of gold sources surfaced in search tool output
+   (UNGATED dense search signal)
+2. **answer_correctness** — LLM judge factual score, gated to zero unless
+   ``retrieval_hit`` is positive
+3. **citation_recall** — fraction of gold sources cited in the final
+   ``<answer>`` block (gated on correctness)
+4. **citation_grounding** — fraction of cited sources that appeared in retrieved
+   tool output (gated on correctness)
+5. **answer_length** — deterministic brevity term (gated on correctness; replaces
    the LLM conciseness judge)
 
 Optional components are available as opt-in helpers (:data:`CONCISENESS_RUBRIC`,
@@ -29,6 +30,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from benchmax.rag.search import SearchClient
+
 from benchmax.envs import (
     BaseEnv,
     BaseRollout,
@@ -42,7 +45,6 @@ from benchmax.envs import (
     Tool,
     canonical_example_id,
 )
-from benchmax.rag.search import SearchClient
 from benchmax.rewards import (
     Judge,
     Rubric,
@@ -224,6 +226,13 @@ def parse_citations(
     text: str, *, canonicalize: Callable[[str], str] = canonicalize_source_id
 ) -> set[str]:
     """Parse ``[Source: <id>]`` citations from the model's answer."""
+    return extract_source_ids(text, canonicalize=canonicalize)
+
+
+def extract_source_ids(
+    text: str, *, canonicalize: Callable[[str], str] = canonicalize_source_id
+) -> set[str]:
+    """Parse ``[Source: <id>]`` labels from answer text or tool output."""
     ids: set[str] = set()
     for match in _CITATION_RE.finditer(text or ""):
         cid = canonicalize(match.group(1).strip())
@@ -271,6 +280,39 @@ def score_citations(
     return recall, precision
 
 
+def score_retrieval_sources(
+    tool_text: str,
+    reference_chunks: list[dict[str, Any]],
+    *,
+    canonicalize: Callable[[str], str] = canonicalize_source_id,
+) -> float:
+    """Recall of gold source ids present in retrieved tool output.
+
+    This is the default ``retrieval_hit`` signal. It rewards finding the right
+    source even before the answer is correct, but it is based on actual tool
+    output rather than citations written from memory.
+    """
+    ref_ids = extract_reference_ids(reference_chunks, canonicalize=canonicalize)
+    if not ref_ids:
+        return 0.0
+    retrieved_ids = extract_source_ids(tool_text, canonicalize=canonicalize)
+    return len(retrieved_ids & ref_ids) / len(ref_ids)
+
+
+def score_citation_grounding(
+    answer_text: str,
+    tool_text: str,
+    *,
+    canonicalize: Callable[[str], str] = canonicalize_source_id,
+) -> float:
+    """Precision of answer citations against sources actually retrieved."""
+    cited_ids = parse_citations(answer_text, canonicalize=canonicalize)
+    if not cited_ids:
+        return 0.0
+    retrieved_ids = extract_source_ids(tool_text, canonicalize=canonicalize)
+    return len(cited_ids & retrieved_ids) / len(cited_ids)
+
+
 def score_search_efficiency(
     *,
     calls: int,
@@ -300,12 +342,13 @@ def score_search_efficiency(
 
 
 class RagEnv(BaseEnv):
-    """Backend-agnostic RAG environment with a four-component reward.
+    """Backend-agnostic RAG environment with a source-gated reward.
 
-    ``answer_correctness`` (one LLM judge call) is the GATE: every component
-    EXCEPT ``retrieval_hit`` is × correctness, so brevity/precision can't be
-    earned on a wrong answer. ``retrieval_hit`` is UNGATED — citing a gold
-    source is rewarded even when the answer is wrong. ``answer_length`` is a
+    ``retrieval_hit`` is the ungated search signal: it measures whether tool
+    output contained gold sources. ``answer_correctness`` is the gate: the LLM
+    judge score is zeroed unless ``retrieval_hit`` is positive, so the model
+    cannot answer from memory and still earn correctness. Citation and brevity
+    rewards are then multiplied by correctness. ``answer_length`` is a
     deterministic brevity term (no second judge call).
 
     Requires an LLM judge for correctness scoring.
@@ -320,9 +363,10 @@ class RagEnv(BaseEnv):
         judge_timeout: Timeout for judge API calls.
         w_correctness: Weight for the correctness component (the gate).
         w_retrieval_hit: Weight for the UNGATED retrieval_hit component (recall
-            of gold sources among the final-answer citations — a proxy for
-            retrieval; tool traffic is not inspected).
-        w_citation_precision: Weight for citation precision (gated).
+            of gold sources in search tool output).
+        w_citation_recall: Weight for cited-gold recall (gated).
+        w_citation_grounding: Weight for citations grounded in retrieved output
+            (gated).
         w_length: Weight for the deterministic brevity component (gated).
         max_search_calls: Hard search call budget (advertised in the prompt).
     """
@@ -333,7 +377,8 @@ class RagEnv(BaseEnv):
     _ZERO_REWARDS = {
         "answer_correctness": 0.0,
         "retrieval_hit": 0.0,
-        "citation_precision": 0.0,
+        "citation_recall": 0.0,
+        "citation_grounding": 0.0,
         "answer_length": 0.0,
     }
     SYSTEM_PROMPT_TEMPLATE = """\
@@ -391,7 +436,8 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         judge_timeout: float = 30.0,
         w_correctness: float = 1.0,
         w_retrieval_hit: float = 0.3,
-        w_citation_precision: float = 0.3,
+        w_citation_recall: float = 0.3,
+        w_citation_grounding: float = 0.2,
         w_length: float = 0.2,
         max_search_calls: int = 10,
         max_turns: int | None = None,
@@ -424,7 +470,8 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         )
         self._w_correctness = w_correctness
         self._w_retrieval_hit = w_retrieval_hit
-        self._w_citation_precision = w_citation_precision
+        self._w_citation_recall = w_citation_recall
+        self._w_citation_grounding = w_citation_grounding
         self._w_length = w_length
         self._max_search_calls = max_search_calls
 
@@ -528,12 +575,12 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         self,
         rollout: BaseRollout,
     ) -> dict[str, float]:
-        """The audited 4-component reward.
+        """The audited source-gated RAG reward.
 
-        ``answer_correctness`` (from the judge rubric) is the GATE: every
-        component EXCEPT ``retrieval_hit`` is × correctness, so brevity/precision
-        can't be earned on a wrong answer. ``retrieval_hit`` is UNGATED — citing
-        a gold source is rewarded even when the answer is wrong.
+        ``retrieval_hit`` measures gold sources in tool output and stays
+        ungated. ``answer_correctness`` is zeroed unless retrieval found at
+        least one gold source. Citation and brevity rewards are gated by that
+        source-grounded correctness.
         """
         # No committed answer is a valid terminal attempt with zero reward.
         answer = _extract_answer_block(extract_completion_text(rollout.messages))
@@ -552,6 +599,14 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
             answer[:200],
         )
 
+        tool_text = self._tool_text(rollout.messages)
+        retrieval_hit = self._score_retrieval(tool_text, reference_chunks)
+        if retrieval_hit <= 0:
+            rewards = dict(self._ZERO_REWARDS)
+            rewards["retrieval_hit"] = self._w_retrieval_hit * retrieval_hit
+            logger.info("[RagEnv] rewards=%s", rewards)
+            return rewards
+
         # A judge/verifier failure is infrastructure failure, not evidence that
         # the model earned a zero. Let it propagate to the rollout executor.
         result = await evaluate_single_rubric(
@@ -563,12 +618,18 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         )
         correctness = clip01(result.score)
 
-        recall, precision = self._score_citations(answer, reference_chunks)
+        citation_recall, _citation_gold_precision = self._score_citations(
+            answer, reference_chunks
+        )
+        citation_grounding = self._score_citation_grounding(answer, tool_text)
         length_score = clip01(1.0 - len(answer) / ANSWER_LENGTH_CAP)
         rewards: dict[str, float] = {
             "answer_correctness": self._w_correctness * correctness,
-            "retrieval_hit": self._w_retrieval_hit * recall,
-            "citation_precision": self._w_citation_precision * precision * correctness,
+            "retrieval_hit": self._w_retrieval_hit * retrieval_hit,
+            "citation_recall": self._w_citation_recall * citation_recall * correctness,
+            "citation_grounding": (
+                self._w_citation_grounding * citation_grounding * correctness
+            ),
             "answer_length": self._w_length * length_score * correctness,
         }
         logger.info("[RagEnv] rewards=%s", rewards)
@@ -678,6 +739,26 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
         helper, honoring a subclass's ``_canonicalize_id`` override."""
         return score_citations(answer_text, reference_chunks, canonicalize=self._canonicalize_id)
 
+    def _score_retrieval(
+        self,
+        tool_text: str,
+        reference_chunks: list[dict[str, Any]],
+    ) -> float:
+        """Gold-source recall in tool output, honoring ``_canonicalize_id``."""
+        return score_retrieval_sources(
+            tool_text, reference_chunks, canonicalize=self._canonicalize_id
+        )
+
+    def _score_citation_grounding(
+        self,
+        answer_text: str,
+        tool_text: str,
+    ) -> float:
+        """Answer-citation precision against retrieved tool sources."""
+        return score_citation_grounding(
+            answer_text, tool_text, canonicalize=self._canonicalize_id
+        )
+
     def _extract_reference_ids(self, reference_chunks: list[dict[str, Any]]) -> set[str]:
         """Document-level source IDs from reference chunks (uses ``_canonicalize_id``,
         which subclasses may override for corpus-specific extraction)."""
@@ -686,6 +767,10 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
     def _parse_citations(self, text: str) -> set[str]:
         """Parse ``[Source: <id>]`` citations, honoring ``_canonicalize_id``."""
         return parse_citations(text, canonicalize=self._canonicalize_id)
+
+    def _parse_source_ids(self, text: str) -> set[str]:
+        """Parse ``[Source: <id>]`` labels, honoring ``_canonicalize_id``."""
+        return extract_source_ids(text, canonicalize=self._canonicalize_id)
 
     def _canonicalize_id(self, source_id: str) -> str:
         """Normalize a source ID (default: the loose id-hash OR title-path
@@ -697,3 +782,9 @@ tags. Cite your sources inline using [Source: <source_id>] next to each claim.
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _tool_text(messages: Messages) -> str:
+        return "\n".join(
+            str(m.get("content") or "") for m in messages if m.get("role") == "tool"
+        )

--- a/packages/benchmax/tests/unit/rag/test_rag_env.py
+++ b/packages/benchmax/tests/unit/rag/test_rag_env.py
@@ -8,9 +8,10 @@ from unittest.mock import AsyncMock, patch
 
 import cloudpickle
 import pytest
-from benchmax.envs import BaseRollout, StaticBearerAuth
 from benchmax.rag.env import RagEnv, _extract_answer_block
 from benchmax.rag.search import SearchClient
+
+from benchmax.envs import BaseRollout, StaticBearerAuth
 from benchmax.rewards import Judge, RubricEvaluation
 
 JUDGE_ARGS = {
@@ -113,14 +114,15 @@ class TestInit:
         env = _make_env()
         assert env._w_correctness == pytest.approx(1.0)
         assert env._w_retrieval_hit == pytest.approx(0.3)
-        assert env._w_citation_precision == pytest.approx(0.3)
+        assert env._w_citation_recall == pytest.approx(0.3)
+        assert env._w_citation_grounding == pytest.approx(0.2)
         assert env._w_length == pytest.approx(0.2)
 
     def test_removed_weight_kwargs_fail_loudly(self):
         # The pre-audit weights are GONE, not aliased. **kwargs would swallow
         # them silently (caller's weights become no-ops), so __init__ rejects
         # them explicitly.
-        for kwarg in ("w_conciseness", "w_citation_recall", "w_search_efficiency"):
+        for kwarg in ("w_conciseness", "w_citation_precision", "w_search_efficiency"):
             with pytest.raises(TypeError, match="unexpected keyword argument"):
                 _make_env(**{kwarg: 0.5})
 
@@ -221,6 +223,18 @@ def _msgs(content):
     return [{"role": "assistant", "content": content}]
 
 
+def _rag_msgs(answer: str, *tool_sources: str):
+    """Build the minimum rollout messages needed for source-gated rewards."""
+    tool_lines = [
+        f"{i}. -- [source: {source}]\n   Content: retrieved text"
+        for i, source in enumerate(tool_sources, 1)
+    ]
+    return [
+        {"role": "tool", "tool_call_id": "call-search", "content": "\n".join(tool_lines)},
+        {"role": "assistant", "content": answer},
+    ]
+
+
 async def _compute_reward(env, rollout_id, messages, example_args):
     return await type(env).compute_reward(
         env,
@@ -245,7 +259,7 @@ class TestComputeReward:
             _compute_reward(
                 env,
                 "r1",
-                _msgs("The answer is <answer>42 [Source: doc_a]</answer>"),
+                _rag_msgs("The answer is <answer>42 [Source: doc_a]</answer>", "doc_a"),
                 {
                     "question": "What?",
                     "ground_truth": "42",
@@ -253,12 +267,13 @@ class TestComputeReward:
                 },
             )
         )
-        # Exactly the audited 4-component shape — no conciseness/recall/
-        # search_efficiency keys in the default reward.
+        # Exactly the audited source-gated shape — no conciseness,
+        # citation_precision, or search_efficiency keys in the default reward.
         assert set(result) == {
             "answer_correctness",
             "retrieval_hit",
-            "citation_precision",
+            "citation_recall",
+            "citation_grounding",
             "answer_length",
         }
 
@@ -273,8 +288,12 @@ class TestComputeReward:
             _compute_reward(
                 env,
                 "r1",
-                _msgs("<answer>partial</answer>"),
-                {"question": "Q?", "ground_truth": "full answer"},
+                _rag_msgs("<answer>partial</answer>", "doc_a"),
+                {
+                    "question": "Q?",
+                    "ground_truth": "full answer",
+                    "reference_chunks": [{"content": "...", "metadata": {"file": "doc_a"}}],
+                },
             )
         )
         assert result["answer_correctness"] == pytest.approx(1.0)  # 0.5 * 2.0
@@ -291,8 +310,12 @@ class TestComputeReward:
             _compute_reward(
                 env,
                 "r1",
-                _msgs("<answer>wrong</answer>"),
-                {"question": "Q?", "ground_truth": "right"},
+                _rag_msgs("<answer>wrong</answer>", "doc_a"),
+                {
+                    "question": "Q?",
+                    "ground_truth": "right",
+                    "reference_chunks": [{"content": "...", "metadata": {"file": "doc_a"}}],
+                },
             )
         )
         assert result["answer_length"] == 0.0
@@ -311,8 +334,12 @@ class TestComputeReward:
             _compute_reward(
                 env,
                 "r1",
-                _msgs(f"<answer>{short}</answer>"),
-                {"question": "Q?", "ground_truth": "42"},
+                _rag_msgs(f"<answer>{short}</answer>", "doc_a"),
+                {
+                    "question": "Q?",
+                    "ground_truth": "42",
+                    "reference_chunks": [{"content": "...", "metadata": {"file": "doc_a"}}],
+                },
             )
         )
         assert result["answer_length"] == pytest.approx(1.0 - len(short) / 600)
@@ -323,8 +350,12 @@ class TestComputeReward:
             _compute_reward(
                 env,
                 "r1",
-                _msgs(f"<answer>{long}</answer>"),
-                {"question": "Q?", "ground_truth": "42"},
+                _rag_msgs(f"<answer>{long}</answer>", "doc_a"),
+                {
+                    "question": "Q?",
+                    "ground_truth": "42",
+                    "reference_chunks": [{"content": "...", "metadata": {"file": "doc_a"}}],
+                },
             )
         )
         assert result["answer_length"] == 0.0
@@ -351,14 +382,45 @@ class TestComputeReward:
         "benchmax.rag.env.evaluate_single_rubric",
         new_callable=AsyncMock,
     )
-    def test_citation_exact_match(self, mock_eval):
-        mock_eval.return_value = RubricEvaluation(1.0, "", "")
-        env = _make_env(w_retrieval_hit=1.0, w_citation_precision=1.0)
+    def test_answer_citation_without_tool_source_short_circuits_before_judge(self, mock_eval):
+        # The stricter default refuses answer-from-memory: citing the gold source
+        # is not enough unless the source appeared in search tool output.
+        env = _make_env()
         result = asyncio.run(
             _compute_reward(
                 env,
                 "r1",
-                _msgs("<answer>Found it [Source: statute_a] [Source: statute_b]</answer>"),
+                _msgs("<answer>42 [Source: doc_a]</answer>"),
+                {
+                    "question": "Q?",
+                    "ground_truth": "42",
+                    "reference_chunks": [{"content": "...", "metadata": {"file": "doc_a"}}],
+                },
+            )
+        )
+        assert all(v == 0.0 for v in result.values())
+        mock_eval.assert_not_awaited()
+
+    @patch(
+        "benchmax.rag.env.evaluate_single_rubric",
+        new_callable=AsyncMock,
+    )
+    def test_retrieval_and_citations_exact_match(self, mock_eval):
+        mock_eval.return_value = RubricEvaluation(1.0, "", "")
+        env = _make_env(
+            w_retrieval_hit=1.0,
+            w_citation_recall=1.0,
+            w_citation_grounding=1.0,
+        )
+        result = asyncio.run(
+            _compute_reward(
+                env,
+                "r1",
+                _rag_msgs(
+                    "<answer>Found it [Source: statute_a] [Source: statute_b]</answer>",
+                    "statute_a",
+                    "statute_b",
+                ),
                 {
                     "question": "Q?",
                     "ground_truth": "answer",
@@ -370,7 +432,8 @@ class TestComputeReward:
             )
         )
         assert result["retrieval_hit"] == pytest.approx(1.0)
-        assert result["citation_precision"] == pytest.approx(1.0)
+        assert result["citation_recall"] == pytest.approx(1.0)
+        assert result["citation_grounding"] == pytest.approx(1.0)
 
     @patch(
         "benchmax.rag.env.evaluate_single_rubric",
@@ -380,12 +443,19 @@ class TestComputeReward:
         # The default canonicalizer is LOOSE (id-hash OR title-path): a cited
         # 'docs/Statute_A.md' matches a bare 'statute_a' gold file id.
         mock_eval.return_value = RubricEvaluation(1.0, "", "")
-        env = _make_env(w_retrieval_hit=1.0, w_citation_precision=1.0)
+        env = _make_env(
+            w_retrieval_hit=1.0,
+            w_citation_recall=1.0,
+            w_citation_grounding=1.0,
+        )
         result = asyncio.run(
             _compute_reward(
                 env,
                 "r1",
-                _msgs("<answer>Found it [Source: docs/Statute_A.md]</answer>"),
+                _rag_msgs(
+                    "<answer>Found it [Source: docs/Statute_A.md]</answer>",
+                    "docs/Statute_A.md",
+                ),
                 {
                     "question": "Q?",
                     "ground_truth": "answer",
@@ -396,20 +466,25 @@ class TestComputeReward:
             )
         )
         assert result["retrieval_hit"] == pytest.approx(1.0)
-        assert result["citation_precision"] == pytest.approx(1.0)
+        assert result["citation_recall"] == pytest.approx(1.0)
+        assert result["citation_grounding"] == pytest.approx(1.0)
 
     @patch(
         "benchmax.rag.env.evaluate_single_rubric",
         new_callable=AsyncMock,
     )
-    def test_citation_partial_recall(self, mock_eval):
+    def test_partial_retrieval_and_citation_recall(self, mock_eval):
         mock_eval.return_value = RubricEvaluation(1.0, "", "")
-        env = _make_env(w_retrieval_hit=1.0, w_citation_precision=1.0)
+        env = _make_env(
+            w_retrieval_hit=1.0,
+            w_citation_recall=1.0,
+            w_citation_grounding=1.0,
+        )
         result = asyncio.run(
             _compute_reward(
                 env,
                 "r1",
-                _msgs("<answer>Found it [Source: statute_a]</answer>"),
+                _rag_msgs("<answer>Found it [Source: statute_a]</answer>", "statute_a"),
                 {
                     "question": "Q?",
                     "ground_truth": "answer",
@@ -421,20 +496,47 @@ class TestComputeReward:
             )
         )
         assert result["retrieval_hit"] == pytest.approx(0.5)
-        assert result["citation_precision"] == pytest.approx(1.0)
+        assert result["citation_recall"] == pytest.approx(0.5)
+        assert result["citation_grounding"] == pytest.approx(1.0)
+
+    @patch(
+        "benchmax.rag.env.evaluate_single_rubric",
+        new_callable=AsyncMock,
+    )
+    def test_citation_grounding_penalizes_unretrieved_citations(self, mock_eval):
+        mock_eval.return_value = RubricEvaluation(1.0, "", "")
+        env = _make_env(w_citation_recall=1.0, w_citation_grounding=1.0)
+        result = asyncio.run(
+            _compute_reward(
+                env,
+                "r1",
+                _rag_msgs(
+                    "<answer>Found it [Source: doc_a] [Source: doc_b]</answer>",
+                    "doc_a",
+                ),
+                {
+                    "question": "Q?",
+                    "ground_truth": "answer",
+                    "reference_chunks": [{"content": "...", "metadata": {"file": "doc_a"}}],
+                },
+            )
+        )
+        assert result["citation_recall"] == pytest.approx(1.0)
+        assert result["citation_grounding"] == pytest.approx(0.5)
 
     @patch(
         "benchmax.rag.env.evaluate_single_rubric",
         new_callable=AsyncMock,
     )
     def test_gated_rewards_scaled_by_partial_correctness(self, mock_eval):
-        # correctness=0.5. The GATED components (precision, length) scale by
+        # correctness=0.5. The GATED components (citation, length) scale by
         # correctness; retrieval_hit does NOT (it's ungated by design).
         mock_eval.return_value = RubricEvaluation(0.5, "", "")
         env = _make_env(
             w_correctness=1.0,
             w_retrieval_hit=1.0,
-            w_citation_precision=1.0,
+            w_citation_recall=1.0,
+            w_citation_grounding=1.0,
             w_length=1.0,
         )
         answer = "partial [Source: doc_a]"
@@ -442,7 +544,7 @@ class TestComputeReward:
             _compute_reward(
                 env,
                 "r1",
-                _msgs(f"<answer>{answer}</answer>"),
+                _rag_msgs(f"<answer>{answer}</answer>", "doc_a"),
                 {
                     "question": "Q?",
                     "ground_truth": "full",
@@ -450,9 +552,10 @@ class TestComputeReward:
                 },
             )
         )
-        assert result["answer_correctness"] == pytest.approx(0.5)  # not gated
+        assert result["answer_correctness"] == pytest.approx(0.5)  # source gate satisfied
         assert result["retrieval_hit"] == pytest.approx(1.0)  # UNGATED: full recall
-        assert result["citation_precision"] == pytest.approx(0.5)  # 1.0 * 1.0 * 0.5
+        assert result["citation_recall"] == pytest.approx(0.5)  # 1.0 * 1.0 * 0.5
+        assert result["citation_grounding"] == pytest.approx(0.5)
         assert result["answer_length"] == pytest.approx((1.0 - len(answer) / 600) * 0.5)
 
     @patch(
@@ -460,15 +563,19 @@ class TestComputeReward:
         new_callable=AsyncMock,
     )
     def test_retrieval_hit_survives_wrong_answer(self, mock_eval):
-        # The core audit fix: correctness=0 → the GATED precision is zeroed, but
-        # the UNGATED retrieval_hit still credits citing the gold source.
+        # The core audit fix: correctness=0 → the GATED components are zeroed,
+        # but the UNGATED retrieval_hit still credits retrieving the gold source.
         mock_eval.return_value = RubricEvaluation(0.0, "", "")
-        env = _make_env(w_retrieval_hit=1.0, w_citation_precision=1.0)
+        env = _make_env(
+            w_retrieval_hit=1.0,
+            w_citation_recall=1.0,
+            w_citation_grounding=1.0,
+        )
         result = asyncio.run(
             _compute_reward(
                 env,
                 "r1",
-                _msgs("<answer>wrong [Source: doc_a]</answer>"),
+                _rag_msgs("<answer>wrong [Source: doc_a]</answer>", "doc_a"),
                 {
                     "question": "Q?",
                     "ground_truth": "right",
@@ -478,7 +585,9 @@ class TestComputeReward:
         )
         assert result["answer_correctness"] == 0.0
         assert result["retrieval_hit"] == pytest.approx(1.0)  # UNGATED
-        assert result["citation_precision"] == 0.0  # gated → 0
+        assert result["citation_recall"] == 0.0  # gated -> 0
+        assert result["citation_grounding"] == 0.0  # gated -> 0
+        assert result["answer_length"] == 0.0
 
     @patch(
         "benchmax.rag.env.evaluate_single_rubric",
@@ -492,7 +601,7 @@ class TestComputeReward:
                 _compute_reward(
                     env,
                     "r1",
-                    _msgs("<answer>42 [Source: doc_a]</answer>"),
+                    _rag_msgs("<answer>42 [Source: doc_a]</answer>", "doc_a"),
                     {
                         "question": "Q?",
                         "ground_truth": "42",
@@ -563,6 +672,25 @@ class TestCitationScoring:
         )
         assert recall == pytest.approx(1.0)
         assert precision == pytest.approx(1.0)
+
+    def test_score_retrieval_uses_tool_sources(self):
+        env = _make_env()
+        score = env._score_retrieval(
+            "1. -- [source: doc_a]\n2. -- [source: doc_b]",
+            [
+                {"content": "...", "metadata": {"file": "doc_a"}},
+                {"content": "...", "metadata": {"file": "doc_c"}},
+            ],
+        )
+        assert score == pytest.approx(0.5)
+
+    def test_score_citation_grounding_uses_tool_sources(self):
+        env = _make_env()
+        score = env._score_citation_grounding(
+            "answer [Source: doc_a] [Source: doc_b]",
+            "1. -- [source: doc_a]",
+        )
+        assert score == pytest.approx(0.5)
 
 
 class TestExtractAnswerBlock:
@@ -668,9 +796,12 @@ from benchmax.rag.env import (  # noqa: E402
     canonicalize_source_id_loose,
     extract_answer_block,
     extract_reference_ids,
+    extract_source_ids,
     judge_answer_quality,
     parse_citations,
+    score_citation_grounding,
     score_citations,
+    score_retrieval_sources,
     score_search_efficiency,
 )
 
@@ -704,8 +835,22 @@ class TestFreeRewardHelpers:
 
     def test_parse_and_reference_id_helpers(self):
         assert parse_citations("x [Source: p ] y") == {"p"}
+        assert extract_source_ids("tool output [source: p ]") == {"p"}
         assert extract_reference_ids([{"metadata": {"file_path": " q "}}]) == {"q"}
         assert canonicalize_source_id("  z  ") == "z"
+
+    def test_score_retrieval_sources(self):
+        chunks = [
+            {"metadata": {"file": "a"}},
+            {"metadata": {"file": "b"}},
+        ]
+        assert score_retrieval_sources("hit [Source: a]", chunks) == pytest.approx(0.5)
+
+    def test_score_citation_grounding(self):
+        assert score_citation_grounding(
+            "answer [Source: a] [Source: b]",
+            "tool [Source: a]",
+        ) == pytest.approx(0.5)
 
     def test_canonicalize_source_id_loose(self):
         # id-hash OR title-path: lowercase, strip dir prefix + extension.

--- a/packages/benchmax/tests/unit/rag/test_rag_env.py
+++ b/packages/benchmax/tests/unit/rag/test_rag_env.py
@@ -692,6 +692,19 @@ class TestCitationScoring:
         )
         assert score == pytest.approx(0.5)
 
+    def test_score_rag_sources_uses_env_canonicalizer(self):
+        env = _make_env()
+        scores = env._score_rag_sources(
+            "answer [Source: docs/Geography.md] [Source: extra]",
+            "1. -- [source: geography]",
+            [{"content": "...", "metadata": {"file": "Geography.md"}}],
+        )
+        assert scores == {
+            "retrieval_hit": pytest.approx(1.0),
+            "citation_recall": pytest.approx(1.0),
+            "citation_grounding": pytest.approx(0.5),
+        }
+
 
 class TestExtractAnswerBlock:
     def test_normal_closed_block(self):
@@ -801,6 +814,7 @@ from benchmax.rag.env import (  # noqa: E402
     parse_citations,
     score_citation_grounding,
     score_citations,
+    score_rag_sources,
     score_retrieval_sources,
     score_search_efficiency,
 )
@@ -851,6 +865,21 @@ class TestFreeRewardHelpers:
             "answer [Source: a] [Source: b]",
             "tool [Source: a]",
         ) == pytest.approx(0.5)
+
+    def test_score_rag_sources(self):
+        chunks = [
+            {"metadata": {"file": "a"}},
+            {"metadata": {"file": "b"}},
+        ]
+        assert score_rag_sources(
+            "answer [Source: a] [Source: c]",
+            "tool [Source: a]",
+            chunks,
+        ) == {
+            "retrieval_hit": pytest.approx(0.5),
+            "citation_recall": pytest.approx(0.5),
+            "citation_grounding": pytest.approx(0.5),
+        }
 
     def test_canonicalize_source_id_loose(self):
         # id-hash OR title-path: lowercase, strip dir prefix + extension.


### PR DESCRIPTION
## Summary

- Change the default `RagEnv` reward from answer-citation-proxy retrieval to source-gated retrieval based on search tool output.
- Add `citation_recall` and `citation_grounding` as default gated reward components, replacing the old default `citation_precision` component.
- Add `score_rag_sources()` as the high-level helper for the source-level reward pieces: `retrieval_hit`, `citation_recall`, and `citation_grounding`.
- Add helper coverage and reward tests for no-tool-source short-circuiting, partial retrieval, grounded citations, and wrong-answer retrieval credit.

## Why

The stricter reward matches the audited RAG training setup: the model should earn retrieval credit only for sources that actually appeared in tool output, and it should not earn correctness from memory without retrieving a gold source first. Keeping `score_citations()` conventional avoids surprising callers while giving custom envs a clearer helper for the stricter default behavior.

## Validation

- `uv run ruff check packages/benchmax/src/benchmax/rag/env.py packages/benchmax/tests/unit/rag/test_rag_env.py`
- `uv run pytest packages/benchmax/tests/unit/rag/test_rag_env.py`
- `git diff --check`
